### PR TITLE
Use gnu99 standard on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ compiler = new_compiler()
 # Determine the platform-specific default compiler and linker flags
 if sys.platform == "darwin":  # macOS
     default_compile_flags = [
-        "-std=c99",
+        "-std=gnu99",
         "-Wall",
         "-O3",
         "-ffast-math",
@@ -163,7 +163,7 @@ elif sys.platform == "win32":  # windows
     include_dirs = []
 else:  # Unix-like systems (Linux)
     default_compile_flags = [
-        "-std=c99",
+        "-std=gnu99",
         "-Wall",
         "-O3",
         "-ffast-math",


### PR DESCRIPTION
Compile with std=gnu99 on Linux. This deals with an error observed on cosma using gcc 14.1.0 where `posix_memalign` wasn't defined, simplest solution was to switch standard. 

Note that both c99 and gnu99 work on mac (darwin).

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
