### PR TITLE
update repo names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Synthesizer
 
-<img src="https://raw.githubusercontent.com/flaresimulations/synthesizer/main/docs/source/img/synthesizer_logo.png" align="right" width="140px"/>
+<img src="https://raw.githubusercontent.com/synthesizer-project/synthesizer/main/docs/source/img/synthesizer_logo.png" align="right" width="140px"/>
 
-[![workflow](https://github.com/flaresimulations/synthesizer/actions/workflows/python-app.yml/badge.svg)](https://github.com/flaresimulations/synthesizer/actions)
-[![Documentation Status](https://github.com/flaresimulations/synthesizer/actions/workflows/static.yml/badge.svg)](https://flaresimulations.github.io/synthesizer/)
-[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/flaresimulations/synthesizer/blob/main/docs/CONTRIBUTING.md)
+[![workflow](https://github.com/synthesizer-project/synthesizer/actions/workflows/python-app.yml/badge.svg)](https://github.com/synthesizer-project/synthesizer/actions)
+[![Documentation Status](https://github.com/synthesizer-project/synthesizer/actions/workflows/static.yml/badge.svg)](https://synthesizer-project.github.io/synthesizer/)
+[![Contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/synthesizer-project/synthesizer/blob/main/docs/CONTRIBUTING.md)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![License: GPLv3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -17,7 +17,7 @@ This will also display the number of downloads but lets hide for now...
 
 Synthesizer is a Python package for generating synthetic astrophysical observables. It is modular, flexible, extensible and fast.
 
-Read the documentation [here](https://flaresimulations.github.io/synthesizer/).
+Read the documentation [here](https://synthesizer-project.github.io/synthesizer/).
 
 ## Getting Started
 
@@ -27,9 +27,9 @@ The latest stable release of Synthesizer can be installed directly using pip,
 pip install cosmos-synthesizer
 ```
 
-Please refer to the [installation documentation](https://flaresimulations.github.io/synthesizer/getting_started/installation.html) for further information. 
+Please refer to the [installation documentation](https://synthesizer-project.github.io/synthesizer/getting_started/installation.html) for further information. 
 
-Various configuration options can also be set at installation (see [here](https://flaresimulations.github.io/synthesizer/advanced/config_options.html)).
+Various configuration options can also be set at installation (see [here](https://synthesizer-project.github.io/synthesizer/advanced/config_options.html)).
 
 ## Getting Grids
 
@@ -77,4 +77,4 @@ A code paper is currently in preparation. For now please cite [Vijayan et al. 20
 
 ## Licence
 
-[GNU General Public License v3.0](https://github.com/flaresimulations/synthesizer/blob/main/LICENSE.md)
+[GNU General Public License v3.0](https://github.com/synthesizer-project/synthesizer/blob/main/LICENSE.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,7 +25,7 @@ source synth-dev-env/bin/activate
 You can then clone the repo and install it in editable mode with the extra development dependencies.
 
 ```bash
-git clone https://github.com/flaresimulations/synthesizer.git
+git clone https://github.com/synthesizer-project/synthesizer.git
 cd synthesizer
 pip install -e .[dev]
 ```
@@ -34,7 +34,7 @@ Note: if you are planning to build the docs locally you'll also need to include 
 
 ### Test data
 
-To run existing examples or docs and add new ones, you'll need test data, provided [here](https://flaresimulations.github.io/synthesizer/getting_started/downloading_grids.html#downloading-the-test-grid). This can be downloaded through the command line interface. Run the following at the root of the Synthesizer repo.
+To run existing examples or docs and add new ones, you'll need test data, provided [here](https://synthesizer-project.github.io/synthesizer/getting_started/downloading_grids.html#downloading-the-test-grid). This can be downloaded through the command line interface. Run the following at the root of the Synthesizer repo.
 
 ```bash
 synthesizer-download --test-grids --dust-grid -d tests/test_grid

--- a/docs/source/advanced/creating_grids.rst
+++ b/docs/source/advanced/creating_grids.rst
@@ -3,7 +3,7 @@ Creating Grids
 
 Advanced users can create their own `synthesizer grids <../grids/grids>`_. These can be intrinsic grids of stellar emission, generated from stellar population synthesis models, or grids post-processed through photoionisation codes such as `cloudy <https://trac.nublado.org>`_.
 
-The code for creating custom grids is contained in a separate repository, `synthesizer-grids <https://github.com/flaresimulations/synthesizer-grids>`_.
+The code for creating custom grids is contained in a separate repository, `grid-generation <https://github.com/synthesizer-project/grid-generation>`_.
 You will need a working installation of synthesizer for these scripts to work, as well as other dependencies for specific codes (e.g. CLOUDY, python-FSPS). 
 
 Grids should follow the naming convention where possible, see :ref:`grid-naming`.
@@ -16,7 +16,7 @@ Running your own SPS grids
 
 Here we will show how to create an incident grid using synthesizer. These incident grids are often used as inputs to photoionisation codes like Cloudy, but are also useful in their own right for understanding the intrinsic properties of stellar populations.
 
-Firstly, choose the grid you want to create, e.g. BC03, maraston05, or FSPS, and find the corresponding python script to install it within the `synthesizer-grids` repository.
+Firstly, choose the grid you want to create, e.g. BC03, maraston05, or FSPS, and find the corresponding python script to install it within the `grid-generation` repository.
 To create the grid, you need to specify where you want to place the raw data files from the model (`input_dir`), and where you would like the grid file to be created (`grid_dir`), e.g.
 
 .. code-block:: bash
@@ -52,7 +52,7 @@ To create input files with varying parameter values, we can do something like th
    python create_cloudy_input_grid.py -grid_dir /home/dir/data/synthesizer_data/grids -cloudy_dir /home/dir/data/synthesizer_data/cloudy -incident_grid maraston11_kroupa -cloudy_params c23.01-sps -cloudy_params_addition test_suite/ionisation_parameter -machine sciama -verbose True 
 
 
-Then, using the method of your choice, you can run the created input files through Cloudy. Within `synthesizer-grids` are example scripts showing how to run these using different HPC systems.
+Then, using the method of your choice, you can run the created input files through Cloudy. Within `grid-generation` are example scripts showing how to run these using different HPC systems.
 
 Once these have been run through Cloudy, we can use the outputs from Cloudy to create a new grid, containing the post-processed spectra and line emission:
 

--- a/docs/source/getting_started/getting_started.rst
+++ b/docs/source/getting_started/getting_started.rst
@@ -18,7 +18,7 @@ Getting Help
 
 For updates and general help with synthesizer we have a dedicated Slack page. Please email <christopher dot lovell at port dot ac dot uk> for a sign up link.
 
-If you wish to report an issue with synthesizer, please `raise an issue <https://github.com/flaresimulations/synthesizer/issues>`_ on github.
+If you wish to report an issue with synthesizer, please `raise an issue <https://github.com/synthesizer-project/synthesizer/issues>`_ on github.
 
 To be kept up to date on important updates, you can sign up to our mailing list using the form below.
 This list will only be used to notify users of major changes (including breaking changes) to the code, which will also be associated with point updates.

--- a/docs/source/getting_started/installation.rst
+++ b/docs/source/getting_started/installation.rst
@@ -35,7 +35,7 @@ To install the latest unstable version from source, clone the repository and ins
 
 .. code-block:: bash
 
-    git clone https://github.com/flaresimulations/synthesizer.git
+    git clone https://github.com/synthesizer-project/synthesizer.git
     cd synthesizer
     pip install .
 

--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -17,7 +17,7 @@ For example, one could have a grid that has been post-processed through a photoi
 Different grids can also be swapped in and out to assess the impact of different modelling choices; for example, one might wish to understand the impact of different SPS models on the integrated stellar emission.
 
 We provide a number of `pre-computed grids <../grids/grids.rst>`_ for stellar and AGN emission that will be sufficient for most use cases.
-Advanced users can also generate their own grids, using the ``synthesizer-grids`` package (see `here <../advanced/creating_grids.rst>`_).
+Advanced users can also generate their own grids, using the ``grid-generation`` package (see `here <../advanced/creating_grids.rst>`_).
 
 
 Particle vs Parametric

--- a/docs/source/grids/grids.rst
+++ b/docs/source/grids/grids.rst
@@ -65,7 +65,7 @@ A more complex IMF, for example with two power-laws (2.0, 2.35) separated at 1 M
 
     bpl-0.1,1.0,100-2.0,2.35
 
-If an IMF you need is missing, please let us know by raising a feature request through an `issue <https://github.com/flaresimulations/synthesizer/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=>`_.
+If an IMF you need is missing, please let us know by raising a feature request through an `issue <https://github.com/synthesizer-project/synthesizer/issues/new?assignees=&labels=&projects=&template=feature_request.md&title=>`_.
 
 
 Photoionisation modelling
@@ -236,7 +236,7 @@ Creating your own grids
 =======================
 
 For advanced users, synthesizer contains scripts for creating your own grids from popular SPS codes, and running these through CLOUDY.
-We provide scripts for doing this in the `synthesizer-grids` repository.
+We provide scripts for doing this in the `grid-generation` repository.
 Details are provided `here <../advanced/creating_grids>`_.
 You will need a working installation of synthesizer for these scripts to work, as well as other dependencies for specific codes (e.g. `CLOUDY`, `python-FSPS`).
 Please reach out to us if you have questions about the pre-computed grids or grid creation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -75,7 +75,7 @@ A code paper is currently in preparation. For now please cite `Vijayan et al. 20
 Contributing
 ------------
 
-Please see `here <https://github.com/flaresimulations/synthesizer/blob/main/docs/CONTRIBUTING.md>`_ for contribution guidelines.
+Please see `here <https://github.com/synthesizer-project/synthesizer/blob/main/docs/CONTRIBUTING.md>`_ for contribution guidelines.
 
 Primary Contributors
 ---------------------
@@ -85,5 +85,5 @@ Primary Contributors
 License
 -------
 
-Synthesizer is free software made available under the GNU General Public License v3.0. For details see the `LICENSE <https://github.com/flaresimulations/synthesizer/blob/main/LICENSE.md>`_.
+Synthesizer is free software made available under the GNU General Public License v3.0. For details see the `LICENSE <https://github.com/synthesizer-project/synthesizer/blob/main/LICENSE.md>`_.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,10 +131,10 @@ eagle = [
 
 # Project urls
 [project.urls]
-"Homepage" = "https://github.com/flaresimulations/synthesizer"
-"Bug Reports" = "https://github.com/flaresimulations/synthesizer/issues"
-"Source" = "https://github.com/flaresimulations/synthesizer"
-"Documentation" = "https://flaresimulations.github.io/synthesizer/"
+"Homepage" = "https://github.com/synthesizer-project/synthesizer"
+"Bug Reports" = "https://github.com/synthesizer-project/synthesizer/issues"
+"Source" = "https://github.com/synthesizer-project/synthesizer"
+"Documentation" = "https://synthesizer-project.github.io/synthesizer/"
 
 # Entry points
 [project.scripts]

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -6,7 +6,7 @@ object contains attributes and methods for interfacing with spectral and line
 grids.
 
 The grids themselves use a standardised HDF5 format which can be generated
-using the synthesizer-grids sister package.
+using the grid-generation sister package.
 
 Example usage:
 

--- a/src/synthesizer/imaging/spectral_cube.py
+++ b/src/synthesizer/imaging/spectral_cube.py
@@ -465,7 +465,7 @@ class SpectralCube:
         raise exceptions.UnimplementedFunctionality(
             "Not yet implemented! Feel free to implement and raise a "
             "pull request. Guidance for contributing can be found at "
-            "https://github.com/flaresimulations/synthesizer/blob/main/"
+            "https://github.com/synthesizer-project/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )
 
@@ -473,7 +473,7 @@ class SpectralCube:
         raise exceptions.UnimplementedFunctionality(
             "Not yet implemented! Feel free to implement and raise a "
             "pull request. Guidance for contributing can be found at "
-            "https://github.com/flaresimulations/synthesizer/blob/main/"
+            "https://github.com/synthesizer-project/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )
 
@@ -481,7 +481,7 @@ class SpectralCube:
         raise exceptions.UnimplementedFunctionality(
             "Not yet implemented! Feel free to implement and raise a "
             "pull request. Guidance for contributing can be found at "
-            "https://github.com/flaresimulations/synthesizer/blob/main/"
+            "https://github.com/synthesizer-project/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )
 
@@ -489,7 +489,7 @@ class SpectralCube:
         raise exceptions.UnimplementedFunctionality(
             "Not yet implemented! Feel free to implement and raise a "
             "pull request. Guidance for contributing can be found at "
-            "https://github.com/flaresimulations/synthesizer/blob/main/"
+            "https://github.com/synthesizer-project/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )
 

--- a/src/synthesizer/load_data/load_eagle.py
+++ b/src/synthesizer/load_data/load_eagle.py
@@ -5,10 +5,6 @@ hydrodynamical simulations suite.
 The EAGLE hdf5 data loading scripts have been taken from
 the `eagle_io` package (https://github.com/flaresimulations/eagle_IO/).
 This has been to make the call as self-contained as possible.
-
-The functions here used in
-https://github.com/flaresimulations/synthesizer-pipeline
-
 """
 
 import glob

--- a/src/synthesizer/parametric/sf_hist.py
+++ b/src/synthesizer/parametric/sf_hist.py
@@ -36,7 +36,7 @@ parametrisations = (
     "Exponential",
     "TruncatedExponential",
     "DecliningExponential",
-    "DelayedExponential" "LogNormal",
+    "DelayedExponentialLogNormal",
     "DoublePowerLaw",
     "DenseBasis",
 )
@@ -198,7 +198,7 @@ class Common:
         raise exceptions.UnimplementedFunctionality(
             "Not yet implemented! Feel free to implement and raise a "
             "pull request. Guidance for contributing can be found at "
-            "https://github.com/flaresimulations/synthesizer/blob/main/"
+            "https://github.com/synthesizer-project/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )
 
@@ -245,9 +245,9 @@ class Common:
         for parameter_name, parameter_value in self.parameters.items():
             pstr += f"{parameter_name}: {parameter_value}" + "\n"
         pstr += (
-            f'median age: {self.calculate_median_age().to("Myr"):.2f}' + "\n"
+            f"median age: {self.calculate_median_age().to('Myr'):.2f}" + "\n"
         )
-        pstr += f'mean age: {self.calculate_mean_age().to("Myr"):.2f}' + "\n"
+        pstr += f"mean age: {self.calculate_mean_age().to('Myr'):.2f}" + "\n"
         pstr += "-" * 10 + "\n"
 
         return pstr

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -948,7 +948,7 @@ class CoordinateGenerator:
         raise exceptions.UnimplementedFunctionality(
             "Not yet implemented! Feel free to implement and raise a "
             "pull request. Guidance for contributing can be found at "
-            "https://github.com/flaresimulations/synthesizer/blob/main/"
+            "https://github.com/synthesizer-project/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )
 
@@ -956,6 +956,6 @@ class CoordinateGenerator:
         raise exceptions.UnimplementedFunctionality(
             "Not yet implemented! Feel free to implement and raise a "
             "pull request. Guidance for contributing can be found at "
-            "https://github.com/flaresimulations/synthesizer/blob/main/"
+            "https://github.com/synthesizer-project/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )


### PR DESCRIPTION
DWISOTT. Updates synthesizer repo names after organisation change. Also fixes references to the renamed `grid-generation` package.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
