### PR TITLE
Moving the masks into the C extensions to minimise memory

### DIFF
--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -365,13 +365,6 @@ class BlackholesComponent(Component):
                     grid.grid_name
                 ] = grid_weights
 
-        # If we had a wavelength mask we need to make sure we return a spectra
-        # compatible with the original wavelength array.
-        if lam_mask is not None:
-            out_spec = np.zeros(len(grid.lam))
-            out_spec[lam_mask] = spec
-            spec = out_spec
-
         return spec
 
     def generate_line(

--- a/src/synthesizer/extensions/integrated_line.c
+++ b/src/synthesizer/extensions/integrated_line.c
@@ -192,7 +192,7 @@ PyObject *compute_integrated_line(PyObject *self, PyObject *args) {
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, /*np_velocities*/ NULL, npart, ndim);
+      part_tuple, np_part_mass, /*np_velocities*/ NULL, NULL, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -42,6 +42,11 @@ static double *get_spectra_serial(struct grid *grid_props,
   /* Loop over wavelengths */
   for (int ilam = 0; ilam < grid_props->nlam; ilam++) {
 
+    /* Skip if this wavelength is masked. */
+    if (grid_props->lam_mask != NULL && !grid_props->lam_mask[ilam]) {
+      continue;
+    }
+
     /* Loop over grid cells. */
     for (int grid_ind = 0; grid_ind < grid_props->size; grid_ind++) {
 
@@ -110,6 +115,11 @@ static double *get_spectra_omp(struct grid *grid_props, double *grid_weights,
 
     /* Loop over wavelengths. */
     for (int ilam = 0; ilam < end - start; ilam++) {
+
+      /* Skip if this wavelength is masked. */
+      if (grid_props->lam_mask != NULL && !grid_props->lam_mask[start + ilam]) {
+        continue;
+      }
 
       /* Temporary value to hold the the spectra for this wavelength. */
       double this_element = 0.0;

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -203,23 +203,26 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
   PyObject *grid_tuple, *part_tuple;
   PyArrayObject *np_grid_spectra, *np_grid_weights;
   PyArrayObject *np_part_mass, *np_ndims;
+  PyArrayObject *np_mask, *np_lam_mask;
   char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOOiiisiO", &np_grid_spectra, &grid_tuple,
+  if (!PyArg_ParseTuple(args, "OOOOOiiisiOOO", &np_grid_spectra, &grid_tuple,
                         &part_tuple, &np_part_mass, &np_ndims, &ndim, &npart,
-                        &nlam, &method, &nthreads, &np_grid_weights))
+                        &nlam, &method, &nthreads, &np_grid_weights, &np_mask,
+                        &np_lam_mask))
     return NULL;
 
   /* Extract the grid struct. */
-  struct grid *grid_props = get_spectra_grid_struct(
-      grid_tuple, np_ndims, np_grid_spectra, /*np_lam*/ NULL, ndim, nlam);
+  struct grid *grid_props =
+      get_spectra_grid_struct(grid_tuple, np_ndims, np_grid_spectra,
+                              /*np_lam*/ NULL, np_lam_mask, ndim, nlam);
   if (grid_props == NULL) {
     return NULL;
   }
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, /*np_velocities*/ NULL, npart, ndim);
+      part_tuple, np_part_mass, /*np_velocities*/ NULL, np_mask, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }

--- a/src/synthesizer/extensions/particle_line.c
+++ b/src/synthesizer/extensions/particle_line.c
@@ -480,7 +480,7 @@ PyObject *compute_particle_line(PyObject *self, PyObject *args) {
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, /*np_velocities*/ NULL, npart, ndim);
+      part_tuple, np_part_mass, /*np_velocities*/ NULL, NULL, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -1124,14 +1124,14 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
 
   /* Extract the grid struct. */
   struct grid *grid_props = get_spectra_grid_struct(
-      grid_tuple, np_ndims, np_grid_spectra, /*np_lam*/ NULL, ndim, nlam);
+      grid_tuple, np_ndims, np_grid_spectra, /*np_lam*/ NULL, NULL, ndim, nlam);
   if (grid_props == NULL) {
     return NULL;
   }
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, /*np_velocities*/ NULL, npart, ndim);
+      part_tuple, np_part_mass, /*np_velocities*/ NULL, NULL, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }
@@ -1224,14 +1224,14 @@ PyObject *compute_part_seds_with_vel_shift(PyObject *self, PyObject *args) {
 
   /* Extract the grid struct. */
   struct grid *grid_props = get_spectra_grid_struct(
-      grid_tuple, np_ndims, np_grid_spectra, np_lam, ndim, nlam);
+      grid_tuple, np_ndims, np_grid_spectra, np_lam, NULL, ndim, nlam);
   if (grid_props == NULL) {
     return NULL;
   }
 
   /* Extract the particle struct. */
-  struct particles *part_props =
-      get_part_struct(part_tuple, np_part_mass, np_velocities, npart, ndim);
+  struct particles *part_props = get_part_struct(
+      part_tuple, np_part_mass, np_velocities, NULL, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -58,9 +58,15 @@ static void shifted_spectra_loop_cic_serial(struct grid *grid,
   double **part_props = parts->props;
   double *velocity = parts->velocities;
   int npart = parts->npart;
+  npy_bool *mask = parts->mask;
 
   /* Loop over particles. */
   for (int p = 0; p < npart; p++) {
+
+    /* Skip masked particles. */
+    if (mask != NULL && !mask[p]) {
+      continue;
+    }
 
     /* Get this particle's mass. */
     const double mass = part_masses[p];
@@ -145,6 +151,14 @@ static void shifted_spectra_loop_cic_serial(struct grid *grid,
         int ilam_shifted = mapped_indices[ilam];
         double shifted_lambda = shifted_wavelengths[ilam];
 
+        /* Skip if this wavelength is masked. */
+        /* Note: we skip the shifted wavelength here because the mask is
+         * effectively saying "I want to ignore this wavelength in the
+         * output spectra". */
+        if (grid->lam_mask != NULL && !grid->lam_mask[ilam_shifted]) {
+          continue;
+        }
+
         /* Compute the fraction of the shifted wavelength between the two
          * closest wavelength elements. */
         double frac_shifted = 0.0;
@@ -192,9 +206,15 @@ static void spectra_loop_cic_serial(struct grid *grid, struct particles *parts,
   double *part_masses = parts->mass;
   double **part_props = parts->props;
   int npart = parts->npart;
+  npy_bool *mask = parts->mask;
 
   /* Loop over particles. */
   for (int p = 0; p < npart; p++) {
+
+    /* Skip masked particles. */
+    if (mask != NULL && !mask[p]) {
+      continue;
+    }
 
     /* Get this particle's mass. */
     const double mass = part_masses[p];
@@ -259,6 +279,11 @@ static void spectra_loop_cic_serial(struct grid *grid, struct particles *parts,
       /* Add this grid cell's contribution to the spectra */
       for (int ilam = 0; ilam < nlam; ilam++) {
 
+        /* Skip if this wavelength is masked. */
+        if (grid->lam_mask != NULL && !grid->lam_mask[ilam]) {
+          continue;
+        }
+
         /* Add the contribution to this wavelength. */
         spectra[p * nlam + ilam] += grid_spectra[spectra_ind + ilam] * weight;
       }
@@ -298,6 +323,7 @@ static void spectra_loop_cic_omp(struct grid *grid, struct particles *parts,
     double *part_masses = parts->mass;
     double **part_props = parts->props;
     int npart = parts->npart;
+    npy_bool *mask = parts->mask;
 
     /* Get the thread id. */
     int tid = omp_get_thread_num();
@@ -321,6 +347,11 @@ static void spectra_loop_cic_omp(struct grid *grid, struct particles *parts,
 
     /* Loop over particles. */
     for (int p = start; p < end; p++) {
+
+      /* Skip masked particles. */
+      if (mask != NULL && !mask[p]) {
+        continue;
+      }
 
       /* Get this particle's mass. */
       const double mass = part_masses[p];
@@ -384,6 +415,11 @@ static void spectra_loop_cic_omp(struct grid *grid, struct particles *parts,
         /* Add this grid cell's contribution to the spectra */
         for (int ilam = 0; ilam < nlam; ilam++) {
 
+          /* Skip if this wavelength is masked. */
+          if (grid->lam_mask != NULL && !grid->lam_mask[ilam]) {
+            continue;
+          }
+
           /* Add the contribution to this wavelength. */
           spectra[p * nlam + ilam] += grid_spectra[spectra_ind + ilam] * weight;
         }
@@ -430,6 +466,7 @@ static void shifted_spectra_loop_cic_omp(struct grid *grid,
     double **part_props = parts->props;
     double *velocity = parts->velocities;
     int npart = parts->npart;
+    npy_bool *mask = parts->mask;
 
     /* Get the thread id. */
     int tid = omp_get_thread_num();
@@ -453,6 +490,11 @@ static void shifted_spectra_loop_cic_omp(struct grid *grid,
 
     /* Loop over particles. */
     for (int p = start; p < end; p++) {
+
+      /* Skip masked particles. */
+      if (mask != NULL && !mask[p]) {
+        continue;
+      }
 
       /* Get this particle's mass. velocity and doppler shift. */
       const double mass = part_masses[p];
@@ -535,6 +577,14 @@ static void shifted_spectra_loop_cic_omp(struct grid *grid,
           /* Get the shifted wavelength and index. */
           int ilam_shifted = mapped_indices[ilam];
           double shifted_lambda = shifted_wavelengths[ilam];
+
+          /* Skip if this wavelength is masked. */
+          /* Note: we skip the shifted wavelength here because the mask is
+           * effectively saying "I want to ignore this wavelength in the
+           * output spectra". */
+          if (grid->lam_mask != NULL && !grid->lam_mask[ilam_shifted]) {
+            continue;
+          }
 
           /* Compute the fraction of the shifted wavelength between the two
            * closest wavelength elements. */
@@ -667,9 +717,15 @@ static void spectra_loop_ngp_serial(struct grid *grid, struct particles *parts,
   double *part_masses = parts->mass;
   double **part_props = parts->props;
   int npart = parts->npart;
+  npy_bool *mask = parts->mask;
 
   /* Loop over particles. */
   for (int p = 0; p < npart; p++) {
+
+    /* Skip masked particles. */
+    if (mask != NULL && !mask[p]) {
+      continue;
+    }
 
     /* Get this particle's mass. */
     const double weight = part_masses[p];
@@ -691,6 +747,11 @@ static void spectra_loop_ngp_serial(struct grid *grid, struct particles *parts,
 
     /* Add this grid cell's contribution to the spectra */
     for (int ilam = 0; ilam < nlam; ilam++) {
+
+      /* Skip if this wavelength is masked. */
+      if (grid->lam_mask != NULL && !grid->lam_mask[ilam]) {
+        continue;
+      }
 
       /* Add the contribution to this wavelength. */
       spectra[p * nlam + ilam] += grid_spectra[spectra_ind + ilam] * weight;
@@ -725,9 +786,15 @@ static void shifted_spectra_loop_ngp_serial(struct grid *grid,
   double **part_props = parts->props;
   double *velocity = parts->velocities;
   int npart = parts->npart;
+  npy_bool *mask = parts->mask;
 
   /* Loop over particles. */
   for (int p = 0; p < npart; p++) {
+
+    /* Skip masked particles. */
+    if (mask != NULL && !mask[p]) {
+      continue;
+    }
 
     /* Get this particle's mass, velocity and doppler shift. */
     const double weight = part_masses[p];
@@ -769,6 +836,14 @@ static void shifted_spectra_loop_ngp_serial(struct grid *grid,
       /* Get the shifted wavelength and index. */
       int ilam_shifted = mapped_indices[ilam];
       double shifted_lambda = shifted_wavelengths[ilam];
+
+      /* Skip if this wavelength is masked. */
+      /* Note: we skip the shifted wavelength here because the mask is
+       * effectively saying "I want to ignore this wavelength in the
+       * output spectra". */
+      if (grid->lam_mask != NULL && !grid->lam_mask[ilam_shifted]) {
+        continue;
+      }
 
       /* Compute the fraction of the shifted wavelength between the two
        * closest wavelength elements. */
@@ -824,6 +899,7 @@ static void spectra_loop_ngp_omp(struct grid *grid, struct particles *parts,
     double *part_masses = parts->mass;
     double **part_props = parts->props;
     int npart = parts->npart;
+    npy_bool *mask = parts->mask;
 
     /* Get the thread id. */
     int tid = omp_get_thread_num();
@@ -848,6 +924,11 @@ static void spectra_loop_ngp_omp(struct grid *grid, struct particles *parts,
     /* Loop over particles. */
     for (int p = start; p < end; p++) {
 
+      /* Skip masked particles. */
+      if (mask != NULL && !mask[p]) {
+        continue;
+      }
+
       /* Get this particle's mass. */
       const double weight = part_masses[p];
 
@@ -868,6 +949,11 @@ static void spectra_loop_ngp_omp(struct grid *grid, struct particles *parts,
 
       /* Add this grid cell's contribution to the spectra */
       for (int ilam = 0; ilam < nlam; ilam++) {
+
+        /* Skip if this wavelength is masked. */
+        if (grid->lam_mask != NULL && !grid->lam_mask[ilam]) {
+          continue;
+        }
 
         /* Add the contribution to this wavelength. */
         spectra[p * nlam + ilam] += grid_spectra[spectra_ind + ilam] * weight;
@@ -912,6 +998,7 @@ static void shifted_spectra_loop_ngp_omp(struct grid *grid,
     double **part_props = parts->props;
     double *velocity = parts->velocities;
     int npart = parts->npart;
+    npy_bool *mask = parts->mask;
 
     /* Get the thread id. */
     int tid = omp_get_thread_num();
@@ -935,6 +1022,11 @@ static void shifted_spectra_loop_ngp_omp(struct grid *grid,
 
     /* Loop over particles. */
     for (int p = start; p < end; p++) {
+
+      /* Skip masked particles. */
+      if (mask != NULL && !mask[p]) {
+        continue;
+      }
 
       /* Get this particle's mass, velocity and doppler shift contribution. */
       const double weight = part_masses[p];
@@ -976,6 +1068,14 @@ static void shifted_spectra_loop_ngp_omp(struct grid *grid,
         /* Get the shifted wavelength and index. */
         int ilam_shifted = mapped_indices[ilam];
         double shifted_lambda = shifted_wavelengths[ilam];
+
+        /* Skip if this wavelength is masked. */
+        /* Note: we skip the shifted wavelength here because the mask is
+         * effectively saying "I want to ignore this wavelength in the
+         * output spectra". */
+        if (grid->lam_mask != NULL && !grid->lam_mask[ilam_shifted]) {
+          continue;
+        }
 
         /* Compute the fraction of the shifted wavelength between the two
          * closest wavelength elements. */
@@ -1114,24 +1214,26 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
   PyObject *grid_tuple, *part_tuple;
   PyArrayObject *np_grid_spectra;
   PyArrayObject *np_part_mass, *np_ndims;
+  PyArrayObject *np_mask, *np_lam_mask;
   char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOOiiisi", &np_grid_spectra, &grid_tuple,
+  if (!PyArg_ParseTuple(args, "OOOOOiiisiOO", &np_grid_spectra, &grid_tuple,
                         &part_tuple, &np_part_mass, &np_ndims, &ndim, &npart,
-                        &nlam, &method, &nthreads)) {
+                        &nlam, &method, &nthreads, &np_mask, &np_lam_mask)) {
     return NULL;
   }
 
   /* Extract the grid struct. */
-  struct grid *grid_props = get_spectra_grid_struct(
-      grid_tuple, np_ndims, np_grid_spectra, /*np_lam*/ NULL, NULL, ndim, nlam);
+  struct grid *grid_props =
+      get_spectra_grid_struct(grid_tuple, np_ndims, np_grid_spectra,
+                              /*np_lam*/ NULL, np_lam_mask, ndim, nlam);
   if (grid_props == NULL) {
     return NULL;
   }
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, /*np_velocities*/ NULL, NULL, npart, ndim);
+      part_tuple, np_part_mass, /*np_velocities*/ NULL, np_mask, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }
@@ -1213,25 +1315,26 @@ PyObject *compute_part_seds_with_vel_shift(PyObject *self, PyObject *args) {
   PyArrayObject *np_grid_spectra, *np_lam;
   PyArrayObject *np_velocities;
   PyArrayObject *np_part_mass, *np_ndims;
+  PyArrayObject *np_mask, *np_lam_mask;
   char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOOOOiiisiO", &np_grid_spectra, &np_lam,
+  if (!PyArg_ParseTuple(args, "OOOOOOOiiisiOOO", &np_grid_spectra, &np_lam,
                         &grid_tuple, &part_tuple, &np_part_mass, &np_velocities,
                         &np_ndims, &ndim, &npart, &nlam, &method, &nthreads,
-                        &py_c)) {
+                        &py_c, &np_mask, &np_lam_mask)) {
     return NULL;
   }
 
   /* Extract the grid struct. */
   struct grid *grid_props = get_spectra_grid_struct(
-      grid_tuple, np_ndims, np_grid_spectra, np_lam, NULL, ndim, nlam);
+      grid_tuple, np_ndims, np_grid_spectra, np_lam, np_lam_mask, ndim, nlam);
   if (grid_props == NULL) {
     return NULL;
   }
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, np_velocities, NULL, npart, ndim);
+      part_tuple, np_part_mass, np_velocities, np_mask, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }

--- a/src/synthesizer/extensions/property_funcs.c
+++ b/src/synthesizer/extensions/property_funcs.c
@@ -70,22 +70,21 @@ int *extract_data_int(PyArrayObject *np_arr, char *name) {
 /**
  * @brief Extract boolean data from a numpy array.
  *
- * This will return the boolean data as represented by an array of integers.
- * 0 is False and 1 is True.
+ * This function returns a pointer to the underlying boolean data stored
+ * as npy_bool values (typically unsigned char).
  *
  * @param np_arr: The numpy array to extract.
- * @param name: The name of the numpy array. (For error messages)
+ * @param name: The name of the numpy array (for error messages).
+ * @return Pointer to the npy_bool data, or NULL on error.
  */
-int *extract_data_bool(PyArrayObject *np_arr, char *name) {
-
-  /* Extract a pointer to the spectra grids */
-  int *data = (int *)PyArray_DATA(np_arr);
+npy_bool *extract_data_bool(PyArrayObject *np_arr, char *name) {
+  npy_bool *data = (npy_bool *)PyArray_DATA(np_arr);
   if (data == NULL) {
     char error_msg[100];
     snprintf(error_msg, sizeof(error_msg), "Failed to extract %s.", name);
     PyErr_SetString(PyExc_ValueError, error_msg);
+    return NULL;
   }
-  /* Success. */
   return data;
 }
 

--- a/src/synthesizer/extensions/property_funcs.c
+++ b/src/synthesizer/extensions/property_funcs.c
@@ -68,6 +68,28 @@ int *extract_data_int(PyArrayObject *np_arr, char *name) {
 }
 
 /**
+ * @brief Extract boolean data from a numpy array.
+ *
+ * This will return the boolean data as represented by an array of integers.
+ * 0 is False and 1 is True.
+ *
+ * @param np_arr: The numpy array to extract.
+ * @param name: The name of the numpy array. (For error messages)
+ */
+int *extract_data_bool(PyArrayObject *np_arr, char *name) {
+
+  /* Extract a pointer to the spectra grids */
+  int *data = (int *)PyArray_DATA(np_arr);
+  if (data == NULL) {
+    char error_msg[100];
+    snprintf(error_msg, sizeof(error_msg), "Failed to extract %s.", name);
+    PyErr_SetString(PyExc_ValueError, error_msg);
+  }
+  /* Success. */
+  return data;
+}
+
+/**
  * @brief Extract the grid properties from a tuple of numpy arrays.
  *
  * @param grid_tuple: A tuple of numpy arrays containing the grid properties.
@@ -163,6 +185,8 @@ double **extract_part_props(PyObject *part_tuple, int ndim, int npart) {
  * @param grid_tuple: A tuple of numpy arrays containing the grid properties.
  * @param np_ndims: The number of grid cells along each axis.
  * @param np_grid_spectra: The grid spectra.
+ * @param np_lam: The wavelength array.
+ * @param np_lam_mask: The wavelength mask array.
  * @param ndim: The number of dimensions in the grid.
  * @param nlam: The number of wavelength elements.
  *
@@ -171,7 +195,8 @@ double **extract_part_props(PyObject *part_tuple, int ndim, int npart) {
 struct grid *get_spectra_grid_struct(PyObject *grid_tuple,
                                      PyArrayObject *np_ndims,
                                      PyArrayObject *np_grid_spectra,
-                                     PyArrayObject *np_lam, const int ndim,
+                                     PyArrayObject *np_lam,
+                                     PyArrayObject *np_lam_mask, const int ndim,
                                      const int nlam) {
 
   /* Initialise the grid struct. */
@@ -229,6 +254,17 @@ struct grid *get_spectra_grid_struct(PyObject *grid_tuple,
     if (grid->lam == NULL) {
       return NULL;
     }
+  }
+
+  /* Extract the wavelength mask array, if this is Py_None then we will
+   * treat it as NULL. */
+  if (np_lam_mask != Py_None) {
+    grid->lam_mask = extract_data_bool(np_lam_mask, "lam_mask");
+    if (grid->lam_mask == NULL) {
+      return NULL;
+    }
+  } else {
+    grid->lam_mask = NULL;
   }
 
   return grid;
@@ -318,13 +354,16 @@ struct grid *get_lines_grid_struct(PyObject *grid_tuple,
  * @param part_tuple: A tuple of numpy arrays containing the particle
  * properties.
  * @param np_part_mass: The particle masses.
+ * @param np_velocities: The particle velocities.
+ * @param np_mask: The particle mask.
  * @param npart: The number of particles.
  *
  * @return struct particles*: A pointer to the particles struct.
  */
 struct particles *get_part_struct(PyObject *part_tuple,
                                   PyArrayObject *np_part_mass,
-                                  PyArrayObject *np_velocities, const int npart,
+                                  PyArrayObject *np_velocities,
+                                  PyArrayObject *np_mask, const int npart,
                                   const int ndim) {
 
   /* Initialise the particles struct. */
@@ -362,6 +401,17 @@ struct particles *get_part_struct(PyObject *part_tuple,
     if (particles->props == NULL) {
       return NULL;
     }
+  }
+
+  /* Extract a pointer to the particle mask, if this is Py_None then we will
+   * treat it as NULL. */
+  if (np_mask != Py_None) {
+    particles->mask = extract_data_bool(np_mask, "mask");
+    if (particles->mask == NULL) {
+      return NULL;
+    }
+  } else {
+    particles->mask = NULL;
   }
 
   return particles;

--- a/src/synthesizer/extensions/property_funcs.c
+++ b/src/synthesizer/extensions/property_funcs.c
@@ -258,7 +258,7 @@ struct grid *get_spectra_grid_struct(PyObject *grid_tuple,
 
   /* Extract the wavelength mask array, if this is Py_None then we will
    * treat it as NULL. */
-  if (np_lam_mask != Py_None) {
+  if (np_lam_mask != NULL && np_lam_mask != Py_None) {
     grid->lam_mask = extract_data_bool(np_lam_mask, "lam_mask");
     if (grid->lam_mask == NULL) {
       return NULL;
@@ -405,7 +405,7 @@ struct particles *get_part_struct(PyObject *part_tuple,
 
   /* Extract a pointer to the particle mask, if this is Py_None then we will
    * treat it as NULL. */
-  if (np_mask != Py_None) {
+  if (np_mask != NULL && np_mask != Py_None) {
     particles->mask = extract_data_bool(np_mask, "mask");
     if (particles->mask == NULL) {
       return NULL;

--- a/src/synthesizer/extensions/property_funcs.h
+++ b/src/synthesizer/extensions/property_funcs.h
@@ -50,7 +50,7 @@ struct grid {
   double *lam;
 
   /* The mask array denoting which wavelength elements should be included. */
-  int *lam_mask;
+  npy_bool *lam_mask;
 };
 
 /* A struct to hold particle properties. */
@@ -69,13 +69,14 @@ struct particles {
   double *velocities;
 
   /* The mask array denoting which particles should be included. */
-  int *mask;
+  npy_bool *mask;
 };
 
 /* Prototypes */
 void *synth_malloc(size_t n, char *msg);
 double *extract_data_double(PyArrayObject *np_arr, char *name);
 int *extract_data_int(PyArrayObject *np_arr, char *name);
+npy_bool *extract_data_bool(PyArrayObject *np_arr, char *name);
 double **extract_grid_props(PyObject *grid_tuple, int ndim, int *dims);
 double **extract_part_props(PyObject *part_tuple, int ndim, int npart);
 struct grid *get_spectra_grid_struct(PyObject *grid_tuple,

--- a/src/synthesizer/extensions/property_funcs.h
+++ b/src/synthesizer/extensions/property_funcs.h
@@ -48,6 +48,9 @@ struct grid {
 
   /* Wavelength */
   double *lam;
+
+  /* The mask array denoting which wavelength elements should be included. */
+  int *lam_mask;
 };
 
 /* A struct to hold particle properties. */
@@ -64,6 +67,9 @@ struct particles {
 
   /* Velocities for redshift */
   double *velocities;
+
+  /* The mask array denoting which particles should be included. */
+  int *mask;
 };
 
 /* Prototypes */
@@ -75,7 +81,8 @@ double **extract_part_props(PyObject *part_tuple, int ndim, int npart);
 struct grid *get_spectra_grid_struct(PyObject *grid_tuple,
                                      PyArrayObject *np_ndims,
                                      PyArrayObject *np_grid_spectra,
-                                     PyArrayObject *np_lam, const int ndim,
+                                     PyArrayObject *np_lam,
+                                     PyArrayObject *np_lam_mask, const int ndim,
                                      const int nlam);
 struct grid *get_lines_grid_struct(PyObject *grid_tuple,
                                    PyArrayObject *np_ndims,
@@ -84,7 +91,8 @@ struct grid *get_lines_grid_struct(PyObject *grid_tuple,
                                    const int ndim, const int nlam);
 struct particles *get_part_struct(PyObject *part_tuple,
                                   PyArrayObject *np_part_mass,
-                                  PyArrayObject *np_velocities, const int npart,
+                                  PyArrayObject *np_velocities,
+                                  PyArrayObject *np_mask, const int npart,
                                   const int ndim);
 
 #endif // PROPERTY_FUNCS_H_

--- a/src/synthesizer/extensions/sfzh.c
+++ b/src/synthesizer/extensions/sfzh.c
@@ -56,14 +56,14 @@ PyObject *compute_sfzh(PyObject *self, PyObject *args) {
   /* Extract the grid struct. */
   struct grid *grid_props =
       get_spectra_grid_struct(grid_tuple, np_ndims, /*np_grid_spectra*/ NULL,
-                              /*np_lam*/ NULL, ndim, /*nlam*/ 1);
+                              /*np_lam*/ NULL, NULL, ndim, /*nlam*/ 1);
   if (grid_props == NULL) {
     return NULL;
   }
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, /*np_velocities*/ NULL, npart, ndim);
+      part_tuple, np_part_mass, /*np_velocities*/ NULL, NULL, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }

--- a/src/synthesizer/extensions/sfzh.c
+++ b/src/synthesizer/extensions/sfzh.c
@@ -46,11 +46,12 @@ PyObject *compute_sfzh(PyObject *self, PyObject *args) {
   int ndim, npart, nthreads;
   PyObject *grid_tuple, *part_tuple;
   PyArrayObject *np_part_mass, *np_ndims;
+  PyArrayObject *np_mask;
   char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOiisi", &grid_tuple, &part_tuple,
+  if (!PyArg_ParseTuple(args, "OOOOiisiO", &grid_tuple, &part_tuple,
                         &np_part_mass, &np_ndims, &ndim, &npart, &method,
-                        &nthreads))
+                        &nthreads, &np_mask))
     return NULL;
 
   /* Extract the grid struct. */
@@ -63,7 +64,7 @@ PyObject *compute_sfzh(PyObject *self, PyObject *args) {
 
   /* Extract the particle struct. */
   struct particles *part_props = get_part_struct(
-      part_tuple, np_part_mass, /*np_velocities*/ NULL, NULL, npart, ndim);
+      part_tuple, np_part_mass, /*np_velocities*/ NULL, np_mask, npart, ndim);
   if (part_props == NULL) {
     return NULL;
   }

--- a/src/synthesizer/extensions/weights.c
+++ b/src/synthesizer/extensions/weights.c
@@ -106,7 +106,7 @@ static void weight_loop_cic_serial(struct grid *grid, struct particles *parts,
   double *part_masses = parts->mass;
   double **part_props = parts->props;
   int npart = parts->npart;
-  int *mask = parts->mask;
+  npy_bool *mask = parts->mask;
 
   /* Set the sub cell constants we'll use below. */
   const int num_sub_cells = 1 << ndim; /* 2^ndim */
@@ -204,7 +204,7 @@ static void weight_loop_cic_omp(struct grid *grid, struct particles *parts,
   double *part_masses = parts->mass;
   double **part_props = parts->props;
   int npart = parts->npart;
-  int *mask = parts->mask;
+  npy_bool *mask = parts->mask;
 
   /* Set the sub cell constants we'll use below. */
   const int num_sub_cells = 1 << ndim; // 2^ndim
@@ -435,7 +435,7 @@ static void weight_loop_ngp_serial(struct grid *grid, struct particles *parts,
   double *part_masses = parts->mass;
   double **part_props = parts->props;
   int npart = parts->npart;
-  int *mask = parts->mask;
+  npy_bool *mask = parts->mask;
 
   /* Convert out. */
   double *out_arr = (double *)out;
@@ -493,7 +493,7 @@ static void weight_loop_ngp_omp(struct grid *grid, struct particles *parts,
   double *part_masses = parts->mass;
   double **part_props = parts->props;
   int npart = parts->npart;
-  int *mask = parts->mask;
+  npy_bool *mask = parts->mask;
 
 #pragma omp parallel num_threads(nthreads)
   {
@@ -513,7 +513,7 @@ static void weight_loop_ngp_omp(struct grid *grid, struct particles *parts,
 
     /* Get local pointers to the particle properties. */
     double *local_part_masses = part_masses + start;
-    int *local_mask = (mask == NULL) ? mask : mask + start;
+    npy_bool *local_mask = (mask == NULL) ? mask : mask + start;
 
     /* Allocate a local output array. */
     double *local_out_arr = calloc(out_size, sizeof(double));

--- a/src/synthesizer/parametric/blackholes.py
+++ b/src/synthesizer/parametric/blackholes.py
@@ -349,6 +349,8 @@ class BlackHole(BlackholesComponent):
             grid_assignment_method,
             nthreads,
             None,
+            None,
+            None,
         )
 
     def _prepare_line_args(

--- a/src/synthesizer/parametric/blackholes.py
+++ b/src/synthesizer/parametric/blackholes.py
@@ -249,13 +249,6 @@ class BlackHole(BlackholesComponent):
             # this is a generic disc grid so no line_region
             line_region = None
 
-        # If lam_mask is None then we want all wavelengths
-        if lam_mask is None:
-            lam_mask = np.ones(
-                grid.spectra[spectra_type].shape[-1],
-                dtype=bool,
-            )
-
         # Set up the inputs to the C function.
         grid_props = [
             np.ascontiguousarray(getattr(grid, axis), dtype=np.float64)
@@ -309,18 +302,12 @@ class BlackHole(BlackholesComponent):
         bol_lum = self.bolometric_luminosity.value
 
         # Make sure we get the wavelength index of the grid array
-        nlam = np.int32(np.sum(lam_mask))
+        nlam = grid.lam.size
 
         # Get the grid spctra
         grid_spectra = np.ascontiguousarray(
             grid.spectra[spectra_type],
             dtype=np.float64,
-        )
-
-        # Apply the wavelength mask
-        grid_spectra = np.ascontiguousarray(
-            grid_spectra[..., lam_mask],
-            np.float64,
         )
 
         # Get the grid dimensions after slicing what we need
@@ -350,7 +337,7 @@ class BlackHole(BlackholesComponent):
             nthreads,
             None,
             None,
-            None,
+            lam_mask,
         )
 
     def _prepare_line_args(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -509,6 +509,8 @@ class BlackHoles(Particles, BlackholesComponent):
                     grid.grid_name,
                     None,
                 ),
+                None,
+                None,
             )
         else:
             return (

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -342,17 +342,6 @@ class BlackHoles(Particles, BlackholesComponent):
             # this is a generic disc grid so no line_region
             line_region = None
 
-        # Handle the case where mask is None
-        if mask is None:
-            mask = np.ones(self.nbh, dtype=bool)
-
-        # If lam_mask is None then we want all wavelengths
-        if lam_mask is None:
-            lam_mask = np.ones(
-                grid.spectra[spectra_type].shape[-1],
-                dtype=bool,
-            )
-
         # Set up the inputs to the C function.
         grid_props = [
             np.ascontiguousarray(getattr(grid, axis), dtype=np.float64)
@@ -393,7 +382,7 @@ class BlackHoles(Particles, BlackholesComponent):
             props.append(prop)
 
         # Calculate npart from the mask
-        npart = np.sum(mask)
+        npart = self.nbh
 
         # Remove units from any unyt_arrays
         props = [
@@ -431,7 +420,7 @@ class BlackHoles(Particles, BlackholesComponent):
         else:
             # We aren't doing a shift so just pass a dummy array and units
             part_vels = np.ascontiguousarray(
-                np.zeros((np.sum(mask), 3)),
+                np.zeros((npart, 3)),
                 dtype=np.float64,
             )
             vel_units = km / s
@@ -441,7 +430,7 @@ class BlackHoles(Particles, BlackholesComponent):
         bol_lum = self.bolometric_luminosity.value
 
         # Make sure we get the wavelength index of the grid array
-        nlam = np.int32(np.sum(lam_mask))
+        nlam = grid.lam.size
 
         # Get the grid spctra
         grid_spectra = np.ascontiguousarray(
@@ -453,12 +442,6 @@ class BlackHoles(Particles, BlackholesComponent):
         grid_lam = np.ascontiguousarray(
             grid._lam,
             dtype=np.float64,
-        )
-
-        # Apply the wavelength mask
-        grid_spectra = np.ascontiguousarray(
-            grid_spectra[..., lam_mask],
-            np.float64,
         )
 
         # Get the grid dimensions after slicing what we need
@@ -492,6 +475,8 @@ class BlackHoles(Particles, BlackholesComponent):
                 grid_assignment_method,
                 nthreads,
                 c.to(vel_units).value,
+                mask,
+                lam_mask,
             )
         elif integrated:
             return (
@@ -524,6 +509,8 @@ class BlackHoles(Particles, BlackholesComponent):
                 nlam,
                 grid_assignment_method,
                 nthreads,
+                mask,
+                lam_mask,
             )
 
     def _prepare_line_args(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -716,12 +716,6 @@ class BlackHoles(Particles, BlackholesComponent):
         if self.nbh == 0:
             return np.zeros((self.nbh, len(grid.lam)))
 
-        # Handle the case where the masks are None
-        if mask is None:
-            mask = np.ones(self.nbh, dtype=bool)
-        if lam_mask is None:
-            lam_mask = np.ones(len(grid.lam), dtype=bool)
-
         # Handle malformed masks
         if mask.size != self.nbh:
             mask = np.ones(self.nbh, dtype=bool)
@@ -747,29 +741,15 @@ class BlackHoles(Particles, BlackholesComponent):
                 compute_part_seds_with_vel_shift,
             )
 
-            masked_spec = compute_part_seds_with_vel_shift(*args)
+            spec = compute_part_seds_with_vel_shift(*args)
         else:
             from synthesizer.extensions.particle_spectra import (
                 compute_particle_seds,
             )
 
-            masked_spec = compute_particle_seds(*args)
+            spec = compute_particle_seds(*args)
 
         start = tic()
-
-        # If there's no mask we're done
-        if mask is None and lam_mask is None:
-            return masked_spec
-        elif mask is None:
-            mask = np.ones(self.nbh, dtype=bool)
-        elif lam_mask is None:
-            lam_mask = np.ones(len(grid.lam), dtype=bool)
-
-        # If we have a mask we need to account for the zeroed spectra
-        spec = np.zeros((self.nbh, grid.lam.size))
-        spec[np.ix_(mask, lam_mask)] = masked_spec
-
-        toc("Masking spectra and adding contribution", start)
 
         return spec
 

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -717,7 +717,7 @@ class BlackHoles(Particles, BlackholesComponent):
             return np.zeros((self.nbh, len(grid.lam)))
 
         # Handle malformed masks
-        if mask.size != self.nbh:
+        if mask is not None and mask.size != self.nbh:
             mask = np.ones(self.nbh, dtype=bool)
 
         # Prepare the arguments for the C function.

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1990,6 +1990,7 @@ class Stars(Particles, StarsComponent):
             npart,
             grid_assignment_method,
             nthreads,
+            None,
         )
 
     def get_sfzh(
@@ -2129,6 +2130,7 @@ class Stars(Particles, StarsComponent):
             npart,
             grid_assignment_method,
             nthreads,
+            None,
         )
 
     def get_sfh(self, log10ages, grid_assignment_method="cic", nthreads=0):
@@ -2281,6 +2283,7 @@ class Stars(Particles, StarsComponent):
             npart,
             grid_assignment_method,
             nthreads,
+            None,
         )
 
     def get_metal_dist(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -620,11 +620,6 @@ class Stars(Particles, StarsComponent):
                 A tuple of all the arguments required by the C extension.
         """
         arg_start = tic()
-        # Make a dummy mask if none has been passed
-        if mask is None:
-            mask_start = tic()
-            mask = np.ones(self.nparticles, dtype=bool)
-            toc("Creating mask", mask_start)
 
         # Set up the inputs to the C function.
         grid_start = tic()
@@ -635,13 +630,11 @@ class Stars(Particles, StarsComponent):
         toc("Preparing grid properties", grid_start)
         part_start = tic()
         part_props = [
-            np.ascontiguousarray(self.log10ages[mask], dtype=np.float64),
-            np.ascontiguousarray(
-                self.log10metallicities[mask], dtype=np.float64
-            ),
+            np.ascontiguousarray(self.log10ages, dtype=np.float64),
+            np.ascontiguousarray(self.log10metallicities, dtype=np.float64),
         ]
         part_mass = np.ascontiguousarray(
-            self._initial_masses[mask],
+            self._initial_masses,
             dtype=np.float64,
         )
 
@@ -649,7 +642,7 @@ class Stars(Particles, StarsComponent):
         # has been requested)
         if self.velocities is not None and vel_shift:
             part_vels = np.ascontiguousarray(
-                self._velocities[mask],
+                self._velocities,
                 dtype=np.float64,
             )
             vel_units = self.velocities.units
@@ -663,7 +656,7 @@ class Stars(Particles, StarsComponent):
             vel_units = None
 
         # Make sure we set the number of particles to the size of the mask
-        npart = np.int32(np.sum(mask))
+        npart = self.nstars
 
         toc("Preparing particle properties", part_start)
 
@@ -752,6 +745,8 @@ class Stars(Particles, StarsComponent):
                     grid.grid_name,
                     None,
                 ),
+                mask,
+                None,
             )
         else:
             return (


### PR DESCRIPTION
This is another PR focus on performance and memory. It also another step towards simplifying the preparation methods in an attempt to limit the need for them.

Previously we've always created a mask if one wasn't passed, this is clearly bad from both a performance and memory standpoint. The reality is that its much cheaper to pass any mask into directly into the C extension (or pass None) and just skip elements which are masekd out. This also means that spectra will always explicitly always be the same shape.  

This PR implements this way of working with masks for spectra (omitting lines since a rewrite is immenent). 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
