### PR TITLE
Added Grid.collapse method to handle dimensionality reduction

### DIFF
--- a/docs/source/grids/grids.rst
+++ b/docs/source/grids/grids.rst
@@ -84,7 +84,7 @@ Common variants
 
 Higher-dimensionality grids
 ---------------------------
-Most SPS grids are two-dimensional, with the dimensions being `log10(age)` and `metallicity`. However synthesizer can utlilise grids with higher dimensionality e.g. including varying alpha-abundance, or photoionisation parameters (e.g. `U`).
+Most SPS grids are two-dimensional, with the dimensions being `log10(age)` and `metallicity`. However synthesizer can utilise grids with higher dimensionality e.g. including varying alpha-abundance, or photoionisation parameters (e.g. `U`).
 
 By default, certain models (e.g., parametric stars) aren't set up to handle higher dimensionality, though this may change in a future version. 
 For now, we provide the functionality to handle these grids by "collapsing" over the additional axes. 

--- a/docs/source/grids/grids.rst
+++ b/docs/source/grids/grids.rst
@@ -84,7 +84,11 @@ Common variants
 
 Higher-dimensionality grids
 ---------------------------
-Most SPS grids are two-dimensional, with the dimensions being `log10(age)` and `metallicty`. However synthesizer can utlilise grids with higher dimensionality e.g. including varying alpha-abundance, or photoionisation parameters (e.g. `U`).
+Most SPS grids are two-dimensional, with the dimensions being `log10(age)` and `metallicity`. However synthesizer can utlilise grids with higher dimensionality e.g. including varying alpha-abundance, or photoionisation parameters (e.g. `U`).
+
+By default, certain models (e.g., parametric stars) aren't set up to handle higher dimensionality, though this may change in a future version. 
+For now, we provide the functionality to handle these grids by "collapsing" over the additional axes. 
+More details on this are provided in the `grids_example <grids_example>` notebook.
 
 Grid list
 =========

--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -245,6 +245,39 @@
   },
   {
    "cell_type": "markdown",
+   "id": "34e89bb1",
+   "metadata": {},
+   "source": [
+    "## Collapsing Grids\n",
+    "\n",
+    "While most of the models within synthesizer (e.g., `Stars`, `BlackHoles`) are set up to handle higher dimensionality grids (i.e., grids with more dimensions than `age` and `metallicity`), other workflows might require some method to reduce the dimensionality. \n",
+    "\n",
+    "This functionality is provided via the `collapse()` method, which collapses the grid over a specified axis.\n",
+    "There are three ways to actually collapse the grid, specified by the `method` keyword argument:\n",
+    "\n",
+    "- `marginalize` over the entire axis. If you don't know anything about this parameter, you can marginalize over the possible values. \n",
+    "- Pick the value `nearest` to a specified value. If you know the value of the parameter you want to use, you can collapse the grid by picking the value closest to your specified value.\n",
+    "- `interpolate` to a specified value. Similar to `nearest`, but with a linear interpolation to your specified value.\n",
+    "\n",
+    "\n",
+    "For example, if we have a grid with three dimensions (`age`, `metallicity`, and `U`), we can collapse over the `U` axis to create a new grid with only two dimensions (`age` and `metallicity`).\n",
+    "This can be done by marginalizing , \n",
+    "picking the value of `U` closest to a specified value, or \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0ce0fbe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid.metallicities"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "10bbb357",
    "metadata": {},
    "source": [

--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -250,20 +250,16 @@
    "source": [
     "## Collapsing Grids\n",
     "\n",
-    "While most of the models within synthesizer (e.g., `Stars`, `BlackHoles`) are set up to handle higher dimensionality grids (i.e., grids with more dimensions than `age` and `metallicity`), other workflows might require some method to reduce the dimensionality. \n",
+    "While most of the models within synthesizer are capable of handling higher dimensionality grids (i.e., grids with more dimensions than `age` and `metallicity`), other workflows might require some method to reduce the dimensionality. \n",
     "\n",
     "This functionality is provided via the `collapse()` method, which collapses the grid over a specified axis.\n",
     "There are three ways to actually collapse the grid, specified by the `method` keyword argument:\n",
     "\n",
-    "- `marginalize` over the entire axis. If you don't know anything about this parameter, you can marginalize over the possible values. \n",
-    "- Pick the value `nearest` to a specified value. If you know the value of the parameter you want to use, you can collapse the grid by picking the value closest to your specified value.\n",
-    "- `interpolate` to a specified value. Similar to `nearest`, but with a linear interpolation to your specified value.\n",
+    "- `marginalize` over the entire axis. This is useful if you don't know anything about this parameter, and just want to adopt the average over it. You can specify the function used to marginalize with the keyword argument `marginalize_function`; the default is `np.average`. \n",
+    "- Pick the value `nearest` to a specified value. If you know the value of the parameter you want to use, you can collapse the grid by picking the value closest to your specified value. For this, you need to specify the `value` keyword argument. \n",
+    "- `interpolate` to a specified value. Similar to `nearest`, but with a linear interpolation to your specified `value`. This is useful in workflows where you can't adopt a discrete value, but be warned that interpolating over a coarse grid can give unrealistic results. You can apply a transformation to the axis before interpolating, e.g. to interpolate in log-space rather than linear space, with the keyword argument `pre_interp_function`. \n",
     "\n",
-    "\n",
-    "For example, if we have a grid with three dimensions (`age`, `metallicity`, and `U`), we can collapse over the `U` axis to create a new grid with only two dimensions (`age` and `metallicity`).\n",
-    "This can be done by marginalizing , \n",
-    "picking the value of `U` closest to a specified value, or \n",
-    "\n"
+    "For example, here we collapse the grid over the metallicity axis:"
    ]
   },
   {
@@ -273,7 +269,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "grid.metallicities"
+    "print(\"The old grid had dimensions:\", grid.spectra[\"incident\"].shape)\n",
+    "print(\"and axes:\", \", \".join(grid.axes))\n",
+    "\n",
+    "# Collapse the grid to a single metallicity value\n",
+    "grid.collapse(\"metallicities\", value=0.03, method=\"nearest\")\n",
+    "\n",
+    "print(\"The collapsed grid has dimensions:\", grid.spectra[\"incident\"].shape)\n",
+    "print(\"and axes:\", \", \".join(grid.axes))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "611cef91",
+   "metadata": {},
+   "source": [
+    "Note that `collapse()` will overwrite the `Grid` _in place_. You can restore the grid to its original dimensionality by re-loading from the HDF5 file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bacbdd48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-load the original grid\n",
+    "grid = Grid(grid_name, grid_dir=grid_dir)"
    ]
   },
   {

--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -250,7 +250,7 @@
    "source": [
     "## Collapsing Grids\n",
     "\n",
-    "While most of the models within synthesizer are capable of handling higher dimensionality grids (i.e., grids with more dimensions than `age` and `metallicity`), other workflows might require some method to reduce the dimensionality. \n",
+    "While most of the models within synthesizer are capable of handling higher dimensionality grids (i.e. grids with more dimensions than `age` and `metallicity`), other workflows might require some method to reduce the dimensionality. \n",
     "\n",
     "This functionality is provided via the `collapse()` method, which collapses the grid over a specified axis.\n",
     "There are three ways to actually collapse the grid, specified by the `method` keyword argument:\n",

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1193,6 +1193,7 @@ class Grid:
                     spectra, axis=axis_index
                 )  # TODO Could allow weights as kwargs?
 
+                # Marginalize the line luminosities and continua
                 collapsed_line_lums[spectra_id] = {}
                 collapsed_line_conts[spectra_id] = {}
                 for line in self.available_lines:
@@ -1204,8 +1205,10 @@ class Grid:
                     )
 
             elif method == "interpolate":
+                # Adopt pre-interpolation function if provided
                 pre_interp_function = pre_interp_function or (lambda x: x)
 
+                # Interpolate the spectra
                 i0 = np.argmax(axis_values[axis_values <= value])
                 i1 = i0 + 1
                 value_0 = pre_interp_function(axis_values[i0])
@@ -1222,6 +1225,7 @@ class Grid:
                     axis=0,
                 )  # TODO Check if np.take uses too much memory?
 
+                # Interpolate the line luminosities and continua
                 collapsed_line_lums[spectra_id] = {}
                 collapsed_line_conts[spectra_id] = {}
                 for line in self.available_lines:
@@ -1243,12 +1247,14 @@ class Grid:
                     )
 
             elif method == "nearest":
+                # Extract the nearest value in the axis
                 collapsed_spectra[spectra_id] = np.take(
                     spectra,
                     np.argmin(np.abs(axis_values - value)),
                     axis=axis_index,
                 )  # TODO Check if np.take uses too much memory?
 
+                # Extract the line luminosities and continua
                 collapsed_line_lums[spectra_id] = {}
                 collapsed_line_conts[spectra_id] = {}
                 for line in self.available_lines:

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1116,7 +1116,6 @@ class Grid:
         value=None,
         marginalize_function=np.average,
         pre_interp_function=None,
-        inplace=True,
     ):
         """
         Collapse the grid along a specified axis.
@@ -1137,9 +1136,6 @@ class Grid:
                 A function to apply to the axis values before interpolation.
                 Can be used to interpolate in logarithmic space, for example.
                 Defaults to None, i.e., interpolation in linear space.
-            inplace (bool)
-                Whether to modify the grid in place (default) or return a
-                new grid.
 
         Returns:
             grid (Grid)
@@ -1257,52 +1253,28 @@ class Grid:
                 collapsed_line_conts[spectra_id] = {}
                 for line in self.available_lines:
                     collapsed_line_lums[spectra_id][line] = np.take(
-                        line_lums,
+                        line_lums[line],
                         np.argmin(np.abs(axis_values - value)),
                         axis=axis_index,
                     )
                     collapsed_line_conts[spectra_id][line] = np.take(
-                        line_conts,
+                        line_conts[line],
                         np.argmin(np.abs(axis_values - value)),
                         axis=axis_index,
                     )
 
-        if inplace:
-            # Update the grid metadata
-            self.axes.pop(axis_index)
-            self._axes_values.pop(axis)
-            self._axes_units.pop(axis)
-            self.naxes -= 1
+        # Update the grid metadata
+        self.axes.pop(axis_index)
+        self._axes_values.pop(axis)
+        self._axes_units.pop(axis)
+        self.naxes -= 1
 
-            # Update the spectra
-            self.spectra = collapsed_spectra
+        # Update the spectra
+        self.spectra = collapsed_spectra
 
-            # Update the line luminosities and continua
-            self.line_lums = collapsed_line_lums
-            self.line_conts = collapsed_line_conts
-
-            return self
-
-        else:
-            # Return a copy of the grid
-            from copy import deepcopy
-
-            collapsed_grid = deepcopy(self)
-
-            # Update the grid metadata
-            collapsed_grid.axes.pop(axis_index)
-            collapsed_grid._axes_values.pop(axis)
-            collapsed_grid._axes_units.pop(axis)
-            collapsed_grid.naxes -= 1
-
-            # Update the spectra
-            collapsed_grid.spectra = collapsed_spectra
-
-            # Update the line luminosities and continua
-            collapsed_grid.line_lums = collapsed_line_lums
-            collapsed_grid.line_conts = collapsed_line_conts
-
-            return collapsed_grid
+        # Update the line luminosities and continua
+        self.line_lums = collapsed_line_lums
+        self.line_conts = collapsed_line_conts
 
     def get_spectra(self, grid_point, spectra_id="incident"):
         """

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1138,8 +1138,8 @@ class Grid:
                 Defaults to None, i.e., interpolation in linear space.
 
         Returns:
-            grid (Grid)
-                A new Grid object with the collapsed axis.
+            None
+                Collapses the grid in-place over the specified axis.
         """
 
         # Check the axis is valid
@@ -1170,11 +1170,6 @@ class Grid:
                 raise exceptions.InconsistentParameter(
                     f"Value {value} is outside the bounds of the axis {axis}."
                 )
-
-            if np.min(np.abs(axis_values - value)) / value < 1e-3:
-                # Revert to "nearest" if the value is
-                # very close to an axis value
-                method = "nearest"
 
         # Collapse the grid
         collapsed_spectra = {}
@@ -1207,6 +1202,14 @@ class Grid:
             elif method == "interpolate":
                 # Adopt pre-interpolation function if provided
                 pre_interp_function = pre_interp_function or (lambda x: x)
+
+                # Validate axis monotonicity
+                dv = np.diff(axis_values)
+                if not np.all(dv > 0):
+                    raise exceptions.UnimplementedFunctionality(
+                        "Axis values must be strictly increasing for "
+                        "interpolation."
+                    )
 
                 # Interpolate the spectra
                 i0 = np.argmax(axis_values[axis_values <= value])

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1165,18 +1165,17 @@ class Grid:
                 f"Value {value} is outside the bounds of the axis {axis}."
             )
 
+        # Validate axis monotonicity
+        dv = np.diff(axis_values)
+        if not np.all(dv > 0):
+            raise exceptions.UnimplementedFunctionality(
+                "Axis values must be strictly increasing for interpolation."
+            )
+
+        # Adopt pre-interpolation function if provided
+        pre_interp_function = pre_interp_function or (lambda x: x)
+
         for spectra_id in self.available_spectra:
-            # Adopt pre-interpolation function if provided
-            pre_interp_function = pre_interp_function or (lambda x: x)
-
-            # Validate axis monotonicity
-            dv = np.diff(axis_values)
-            if not np.all(dv > 0):
-                raise exceptions.UnimplementedFunctionality(
-                    "Axis values must be strictly increasing for "
-                    "interpolation."
-                )
-
             # Interpolate the spectra
             i0 = np.argmax(axis_values[axis_values <= value])
             i1 = i0 + 1

--- a/src/synthesizer/load_data/load_eagle.py
+++ b/src/synthesizer/load_data/load_eagle.py
@@ -31,7 +31,7 @@ except ImportError:
         " `pip install .[eagle]`."
     )
 
-from unyt import Mpc, Msun, unyt_array, unyt_quantity, yr, km, s
+from unyt import Mpc, Msun, km, s, unyt_array, unyt_quantity, yr
 
 from synthesizer.load_data.utils import lookup_age
 


### PR DESCRIPTION
Added `collapse` method to `Grid` per discussions in issue #875. This method allows the user to reduce the dimensionality of a grid. Currently there are three methods (specified via the `method` keyword argument): `marginalize`, `interpolate`, or `nearest`. Open to splitting these into separate methods if its more intuitive. 

Added brief discussion of this feature in the docs and example in the `grids_example` notebook. Could be worth more thoroughly warning users about the perils of interpolating, but not sure. 

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() 
- [X] I have added docstrings to all methods
- [X] I have added sufficient comments to all lines
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no pep8 errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced grid manipulation that lets users collapse higher-dimensional grids using multiple methods, such as marginalization, interpolation, and nearest selection.

- **Documentation**
  - Expanded and clarified documentation with a new section in the demonstration notebook detailing how to use the grid collapsing feature.
  - Fixed a typographical error in the documentation regarding "metallicty" to "metallicity."
<!-- end of auto-generated comment: release notes by coderabbit.ai -->