### PR TITLE
Fixing escape fractions in premade stellar models

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -5,6 +5,7 @@ from unyt import Hz, Mpc, Msun, Myr, erg, km, kpc, s, yr
 from synthesizer.emission_models import (
     BimodalPacmanEmission,
     IncidentEmission,
+    IntrinsicEmission,
     NebularEmission,
     PacmanEmission,
     ReprocessedEmission,
@@ -56,6 +57,12 @@ def reprocessed_emission_model(test_grid):
     """Return a ReprocessedEmission object."""
     # First need a grid to pass to the IncidentEmission object
     return ReprocessedEmission(grid=test_grid)
+
+
+@pytest.fixture
+def intrinsic_emission_model(test_grid):
+    """Return an IntrinsicEmission object."""
+    return IntrinsicEmission(grid=test_grid)
 
 
 @pytest.fixture

--- a/src/synthesizer/emission_models/stellar/models.py
+++ b/src/synthesizer/emission_models/stellar/models.py
@@ -84,6 +84,7 @@ class NebularLineEmission(StellarEmissionModel):
         grid,
         label="nebular_line",
         fesc_ly_alpha="fesc_ly_alpha",
+        fesc="fesc",
         **kwargs,
     ):
         """
@@ -268,6 +269,7 @@ class NebularEmission(StellarEmissionModel):
         grid,
         label="nebular",
         fesc_ly_alpha="fesc_ly_alpha",
+        fesc="fesc",
         nebular_line=None,
         nebular_continuum=None,
         **kwargs,
@@ -305,10 +307,20 @@ class NebularEmission(StellarEmissionModel):
                 **kwargs,
             )
 
+        # Combined nebular emission
+        combined_nebular = StellarEmissionModel(
+            label=label + "_combined",
+            combine=(nebular_line, nebular_continuum),
+            save=False,
+            **kwargs,
+        )
+
         StellarEmissionModel.__init__(
             self,
             label=label,
-            combine=(nebular_line, nebular_continuum),
+            apply_to=combined_nebular,
+            transformer=ProcessedFraction(),
+            fesc=fesc,
             **kwargs,
         )
 
@@ -354,6 +366,7 @@ class ReprocessedEmission(StellarEmissionModel):
             nebular = NebularEmission(
                 grid=grid,
                 fesc_ly_alpha=fesc_ly_alpha,
+                fesc=fesc,
                 **kwargs,
             )
 

--- a/src/synthesizer/emission_models/transformers/escape_fraction.py
+++ b/src/synthesizer/emission_models/transformers/escape_fraction.py
@@ -111,7 +111,7 @@ class ProcessedFraction(Transformer):
 
         # Ensure the escape fraction is between 0 and 1
         if not 0 <= fesc <= 1:
-            raise exceptions.InvalidProcessedFraction(
+            raise exceptions.InconsistentParameter(
                 f"Escape fraction must be between 0 and 1 (got {fesc})."
             )
 
@@ -201,7 +201,7 @@ class EscapedFraction(Transformer):
 
         # Ensure the escape fraction is between 0 and 1
         if not 0 <= fesc <= 1:
-            raise exceptions.InvalidProcessedFraction(
+            raise exceptions.InconsistentParameter(
                 f"Escape fraction must be between 0 and 1 (got {fesc})."
             )
 
@@ -292,7 +292,7 @@ class CoveringFraction(Transformer):
 
         # Ensure the escape fraction is between 0 and 1
         if not 0 <= fcov <= 1:
-            raise exceptions.InvalidProcessedFraction(
+            raise exceptions.InconsistentParameter(
                 f"Covering fraction must be between 0 and 1 (got {fcov})."
             )
 
@@ -383,7 +383,7 @@ class EscapingFraction(Transformer):
 
         # Ensure the escape fraction is between 0 and 1
         if not 0 <= fcov <= 1:
-            raise exceptions.InvalidProcessedFraction(
+            raise exceptions.InconsistentParameter(
                 f"Covering fraction must be between 0 and 1 (got {fcov})."
             )
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -10,10 +10,12 @@ def test_fesc_model_level(
     random_part_stars,
 ):
     """
-    Test the fesc override in the emission model.
+    Test setting fesc on the emission model.
 
-    This test ensures that the fesc override on get_spectra methods is working
-    correctly.
+    This test ensures that the fesc set during instantiation of a model
+    is set correctly. We only do this for the IntrinsicEmission model here
+    since it encompasses all the models that relate to fesc with some parent
+    models derived from it.
     """
     # Get the spectra with fesc=0
     model = IntrinsicEmission(test_grid, fesc=0)
@@ -39,10 +41,11 @@ def test_fesc_override(
     pacman_emission_model,
 ):
     """
-    Test the fesc override in the emission model.
+    Test the get_spectra fesc override in the emission model.
 
     This test ensures that the fesc override on get_spectra methods is working
-    correctly.
+    correctly. Unlike above, we test all the models here to ensure the
+    override is correctly passed through different levels of complexity.
     """
     # For this test we need a singular tau_V value (we're only doing integrated
     # spectra)

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,0 +1,75 @@
+"""A test suite for the transformers module."""
+
+import numpy as np
+
+from synthesizer.emission_models import IntrinsicEmission
+
+
+def test_fesc_model_level(
+    test_grid,
+    random_part_stars,
+):
+    """
+    Test the fesc override in the emission model.
+
+    This test ensures that the fesc override on get_spectra methods is working
+    correctly.
+    """
+    # Get the spectra with fesc=0
+    model = IntrinsicEmission(test_grid, fesc=0)
+    spec_fesc0 = random_part_stars.get_spectra(model)
+    random_part_stars.clear_all_emissions()
+
+    # Get the spectra with fesc=1
+    model = IntrinsicEmission(test_grid, fesc=1)
+    spec_fesc1 = random_part_stars.get_spectra(model)
+
+    # Ensure the two differ
+    assert not np.all(
+        spec_fesc0.lnu == spec_fesc1.lnu
+    ), "The spectra are the same with different fesc values"
+
+
+def test_fesc_override(
+    test_grid,
+    random_part_stars,
+    nebular_emission_model,
+    reprocessed_emission_model,
+    intrinsic_emission_model,
+    pacman_emission_model,
+):
+    """
+    Test the fesc override in the emission model.
+
+    This test ensures that the fesc override on get_spectra methods is working
+    correctly.
+    """
+    # For this test we need a singular tau_V value (we're only doing integrated
+    # spectra)
+    random_part_stars.tau_v = 0.1
+
+    # Loop over the models and test
+    for model in [
+        nebular_emission_model,
+        reprocessed_emission_model,
+        intrinsic_emission_model,
+        pacman_emission_model,
+    ]:
+        # Get the spectra with fesc=0
+        spec_fesc0 = random_part_stars.get_spectra(
+            model,
+            fesc=0,
+        )
+        random_part_stars.clear_all_emissions()
+
+        # Get the spectra with fesc=1
+        spec_fesc1 = random_part_stars.get_spectra(
+            model,
+            fesc=1,
+        )
+
+        # Ensure the two differ
+        assert not np.all(spec_fesc0.lnu == spec_fesc1.lnu), (
+            f"[{model.__class__.__name__}]: The spectra "
+            "are the same with different fesc values"
+        )


### PR DESCRIPTION
The escape fraction was never actually being applied to the `NebularEmission` when set via a parent model such as `IntrinsicEmission`. This PR not only solves this issue but also adds some tests to ensure this works, both when a model is created with an attached escape fraction and when the `get_spectra` override argument is used.

Closes #878 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Emission models now support a configurable escape fraction parameter, providing enhanced flexibility in generating nebular emissions.
  - Introduced a new pytest fixture for the `IntrinsicEmission` model to streamline testing.
- **Bug Fixes**
  - Refined parameter validation now offers consistent error handling for out-of-range emission fractions.
- **Tests**
  - Added validations confirm that varying the escape fraction produces distinct emission outputs, ensuring robust model behavior.
  - New test suite for the `transformers` module to verify the functionality of the escape fraction parameter across multiple models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->