### PR TITLE
Add age lookup table to additional cosmo sim load_data methods

### DIFF
--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -27,8 +27,8 @@ import numpy as np
 from astropy.cosmology import Planck15
 from tqdm import tqdm
 from unyt import Msun, kpc, yr
-from utils import age_lookup_table, lookup_age
 
+from .utils import age_lookup_table, lookup_age
 from synthesizer.exceptions import UnmetDependency
 
 try:

--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -27,9 +27,9 @@ import numpy as np
 from astropy.cosmology import Planck15
 from tqdm import tqdm
 from unyt import Msun, kpc, yr
+from utils import age_lookup_table, lookup_age
 
 from synthesizer.exceptions import UnmetDependency
-from synthesizer.load_data.utils import age_lookup_table, lookup_age
 
 try:
     import illustris_python as il

--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -28,7 +28,7 @@ from astropy.cosmology import Planck15
 from tqdm import tqdm
 from unyt import Msun, kpc, yr
 
-from .utils import age_lookup_table, lookup_age
+from synthesizer.load_data.utils import age_lookup_table, lookup_age
 from synthesizer.exceptions import UnmetDependency
 
 try:

--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -9,7 +9,7 @@ import numpy as np
 from astropy.cosmology import FlatLambdaCDM
 from unyt import Msun, kpc, yr
 
-from .utils import age_lookup_table, lookup_age
+from synthesizer.load_data.utils import age_lookup_table, lookup_age
 from ..particle.galaxy import Galaxy
 
 

--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -8,6 +8,7 @@ import h5py
 import numpy as np
 from astropy.cosmology import FlatLambdaCDM
 from unyt import Msun, kpc, yr
+from utils import age_lookup_table, lookup_age
 
 from ..particle.galaxy import Galaxy
 
@@ -18,6 +19,8 @@ def load_Simba(
     caesar_name="fof_subhalo_tab_033.hdf5",
     caesar_directory=None,
     load_halo=False,
+    age_lookup=True,
+    age_lookup_delta_a=1e-4,
 ):
     """
     Load Simba galaxy data from a caesar file and snapshot
@@ -35,6 +38,10 @@ def load_Simba(
         load_halo (bool, false):
             optional argument, whether to load galaxy or halo objects.
             If False (default), will load individual galaxies.
+        age_lookup (bool):
+            Create a lookup table for ages
+        age_lookup_delta_a (float):
+            Scale factor resolution of the age lookup
 
     Returns:
         galaxies (object):
@@ -66,6 +73,8 @@ def load_Simba(
 
         g_dustmass = hf["PartType0/Dust_Masses"][:]
 
+    redshift = (1.0 / scale_factor) - 1
+
     # convert units
     masses = (masses * 1e10) / h
     g_masses = (g_masses * 1e10) / h
@@ -80,7 +89,24 @@ def load_Simba(
     # convert formation times to ages
     cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
     universe_age = cosmo.age(1.0 / scale_factor - 1)
-    _ages = cosmo.age(1.0 / form_time - 1)
+
+    # Are we creating a lookup table for ages?
+    if age_lookup:
+        # Create the lookup grid
+        scale_factors, ages = age_lookup_table(
+            cosmo,
+            redshift=redshift,
+            delta_a=age_lookup_delta_a,
+            low_lim=1e-4,
+        )
+
+        # Look up the ages for the particles
+        _ages = lookup_age(form_time, scale_factors, ages)
+    else:
+        # Calculate ages of these explicitly using astropy
+        _ages = cosmo.age(1.0 / form_time - 1)
+
+    # Calculate ages at snapshot redshift
     ages = (universe_age - _ages).value * 1e9  # yr
 
     # check which kind of object we're loading
@@ -101,7 +127,7 @@ def load_Simba(
     for i, (b, e) in enumerate(zip(begin, end)):
         # create the individual galaxy objects
         galaxies[i] = Galaxy()
-
+        galaxies[i].redshift = redshift
         galaxies[i].load_stars(
             initial_masses=imasses[b:e] * Msun,
             ages=ages[b:e] * yr,

--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -8,8 +8,8 @@ import h5py
 import numpy as np
 from astropy.cosmology import FlatLambdaCDM
 from unyt import Msun, kpc, yr
-from utils import age_lookup_table, lookup_age
 
+from .utils import age_lookup_table, lookup_age
 from ..particle.galaxy import Galaxy
 
 


### PR DESCRIPTION
Adds age lookup grid initialisation to the TNG and Simba load_data methods.

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced particle data processing by introducing options for age calculation: users can now toggle between direct calculation and an efficient lookup table method with adjustable resolution.
	- Improved simulation outputs with newly computed redshift values for galaxy data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->