### PR TITLE
BUGFIX: Fixes `lam_lims` combination with C extensions

### DIFF
--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1668,9 +1668,9 @@ class Grid:
 
         # Apply the mask to the spectra
         for spectra_type in self.available_spectra:
-            self.spectra[spectra_type] = self.spectra[spectra_type][
-                ..., okinds
-            ]
+            self.spectra[spectra_type] = np.ascontiguousarray(
+                self.spectra[spectra_type][..., okinds]
+            )
 
     def animate_grid(
         self,


### PR DESCRIPTION
Recent changes mean we do not invoke `np.ascontiguousarray` every time data is passed to the C since this was a big overhead. However, this leads to nonsense values if the `Grid` is instantiated with `lam_lims` since the spectra were no longer contiguous after that masking has been performed. This masking is now wrapped in a call to `np.ascontiguousarray` such that the conversion is done once and only once.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal data handling process for spectral information to enhance memory efficiency without altering the overall functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->