### PR TITLE
BUGFIX: Template scaling fixed for singular black holes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,7 +2,20 @@
 
 import numpy as np
 import pytest
-from unyt import Hz, Mpc, Msun, Myr, angstrom, cm, erg, km, kpc, s, unyt_array, yr
+from unyt import (
+    Hz,
+    Mpc,
+    Msun,
+    Myr,
+    angstrom,
+    cm,
+    erg,
+    km,
+    kpc,
+    s,
+    unyt_array,
+    yr,
+)
 
 from synthesizer.emission_models import (
     BimodalPacmanEmission,

--- a/docs/source/sed/sed_example.ipynb
+++ b/docs/source/sed/sed_example.ipynb
@@ -34,7 +34,9 @@
     "grid_dir = \"../../../tests/test_grid/\"\n",
     "grid_name = \"test_grid\"\n",
     "# Let's load a grid and truncate it to a wavelength range\n",
-    "grid = Grid(grid_name, grid_dir=grid_dir, lam_lims=[400*Angstrom, 1E5*Angstrom])"
+    "grid = Grid(\n",
+    "    grid_name, grid_dir=grid_dir, lam_lims=[400 * Angstrom, 1e5 * Angstrom]\n",
+    ")"
    ]
   },
   {
@@ -774,25 +776,7 @@
    ]
   }
  ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "astro_venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.3"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 5
 }

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1984,9 +1984,8 @@ def plot_spectra_as_rainbow(
 
     # Normalise spectrum
     max_val = np.max(spectra)
-    if max_val == 0:
-        return fig, ax  # or handle gracefully
-    spectra /= max_val
+    if max_val > 0:
+        spectra /= max_val
 
     # If logged rescale to between 0 and 1 using min_log_lnu
     if logged:

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -383,6 +383,20 @@ class Sed:
             else:
                 lnu *= scaling
 
+        # Ok, if we have an array but the shapes don't match then we need to
+        # create a new array where each element of the scaling array is
+        # multipled by the whole lnu array producing a new lnu array of
+        # shape (scaling.shape + lnu.shape)
+        elif isinstance(scaling, np.ndarray):
+            new_lnu = scaling[..., np.newaxis] * lnu
+
+            # Masks are not supported in this case
+            if mask is not None:
+                raise exceptions.InconsistentMultiplication(
+                    "Masking is not supported for scaling arrays"
+                    " with different shapes"
+                )
+
         # Otherwise, we've been handed a bad scaling factor
         else:
             out_str = f"Incompatible scaling factor with type {type(scaling)} "

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1343,7 +1343,13 @@ class Sed:
             new_lam = rebin_1d(self.lam, resample_factor, func=np.mean)
 
         # Evaluate the function at the desired wavelengths
-        new_spectra = spectres(new_lam, self._lam, self._lnu, fill=0)
+        new_spectra = spectres(
+            new_lam,
+            self._lam,
+            self._lnu,
+            fill=0,
+            verbose=False,
+        )
 
         # Instantiate the new Sed
         sed = Sed(new_lam, new_spectra * self.lnu.units)

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -350,14 +350,6 @@ class Sed:
             else:
                 lnu *= scaling
 
-        # Handle an single element array scaling factor
-        elif scaling.size == 1:
-            scaling = scaling.item()
-            if mask is not None:
-                lnu[mask] *= scaling
-            else:
-                lnu *= scaling
-
         # Handle a multi-element array scaling factor as long as it matches
         # the shape of the lnu array up to the dimensions of the scaling array
         elif isinstance(scaling, np.ndarray) and len(scaling.shape) < len(
@@ -379,7 +371,7 @@ class Sed:
         # just multiply them together
         elif isinstance(scaling, np.ndarray) and scaling.shape == self.shape:
             if mask is not None:
-                lnu[mask] *= scaling[..., mask]
+                lnu[mask] *= scaling[mask]
             else:
                 lnu *= scaling
 
@@ -388,7 +380,7 @@ class Sed:
         # multipled by the whole lnu array producing a new lnu array of
         # shape (scaling.shape + lnu.shape)
         elif isinstance(scaling, np.ndarray):
-            new_lnu = scaling[..., np.newaxis] * lnu
+            lnu = scaling[..., np.newaxis] * lnu
 
             # Masks are not supported in this case
             if mask is not None:
@@ -413,7 +405,7 @@ class Sed:
         else:
             new_lnu = lnu * units
 
-        # If we scaled then we can return the scaled Sed
+        # Return a new Sed object if we aren't scaling inplace
         if not inplace:
             return Sed(self.lam, lnu=new_lnu)
 

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1650,13 +1650,11 @@ class Template:
 
         # Attach the template now we've done the interpolation (if needed)
         self._sed = sed
-        self.lnu = sed.lnu
         self.lam = sed.lam
 
         # Normalise, just in case
-        self.normalisation = sed._bolometric_luminosity
-        self._sed._lnu /= self.normalisation
-        self._lnu /= self.normalisation
+        self.normalisation = sed.bolometric_luminosity
+        self._sed._lnu /= self.normalisation.to(self._sed.lnu.units * Hz).value
 
     @accepts(bolometric_luminosity=erg / s)
     def get_spectra(self, bolometric_luminosity):

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -30,7 +30,7 @@ from synthesizer.components.blackhole import BlackholesComponent
 from synthesizer.particle.particles import Particles
 from synthesizer.synth_warnings import deprecated
 from synthesizer.units import Quantity, accepts
-from synthesizer.utils import value_to_array
+from synthesizer.utils import scalar_to_array
 
 
 class BlackHoles(Particles, BlackholesComponent):
@@ -176,13 +176,15 @@ class BlackHoles(Particles, BlackholesComponent):
         """
 
         # Handle singular values being passed (arrays are just returned)
-        masses = value_to_array(masses)
-        accretion_rates = value_to_array(accretion_rates)
-        epsilons = value_to_array(epsilons)
-        inclinations = value_to_array(inclinations)
-        spins = value_to_array(spins)
-        metallicities = value_to_array(metallicities)
-        smoothing_lengths = value_to_array(smoothing_lengths)
+        print("masses: ", masses)
+        masses = scalar_to_array(masses)
+        print("after masses: ", masses)
+        accretion_rates = scalar_to_array(accretion_rates)
+        epsilons = scalar_to_array(epsilons)
+        inclinations = scalar_to_array(inclinations)
+        spins = scalar_to_array(spins)
+        metallicities = scalar_to_array(metallicities)
+        smoothing_lengths = scalar_to_array(smoothing_lengths)
 
         # Instantiate parents
         Particles.__init__(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -262,6 +262,7 @@ class BlackHoles(Particles, BlackholesComponent):
         # Ensure all arrays are the expected length
         for key in self.attrs:
             attr = getattr(self, key)
+            print(key, attr)
             if isinstance(attr, np.ndarray):
                 if attr.shape[0] != self.nparticles:
                     raise exceptions.InconsistentArguments(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -262,7 +262,6 @@ class BlackHoles(Particles, BlackholesComponent):
         # Ensure all arrays are the expected length
         for key in self.attrs:
             attr = getattr(self, key)
-            print(key, attr)
             if isinstance(attr, np.ndarray):
                 if attr.shape[0] != self.nparticles:
                     raise exceptions.InconsistentArguments(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -176,9 +176,7 @@ class BlackHoles(Particles, BlackholesComponent):
         """
 
         # Handle singular values being passed (arrays are just returned)
-        print("masses: ", masses)
         masses = scalar_to_array(masses)
-        print("after masses: ", masses)
         accretion_rates = scalar_to_array(accretion_rates)
         epsilons = scalar_to_array(epsilons)
         inclinations = scalar_to_array(inclinations)

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -110,6 +110,10 @@ def scalar_to_array(value):
         InconsistentArguments
             If the value is not a scalar or array-like object.
     """
+    # If the value is None just return it straight away
+    if value is None:
+        return None
+
     # Do we have units? If so strip them away for now for simplicity
     if isinstance(value, (unyt_quantity, unyt_array)):
         units = value.units
@@ -117,11 +121,12 @@ def scalar_to_array(value):
     else:
         units = None
 
-    # Just return it if we have been handed an array already or None
-    if value is None or not np.isscalar(value):
+    # Just return it if we have been handed a ndim > 0 array already or None
+    if not np.isscalar(value) and value.shape != ():
         arr = value
 
-    elif np.isscalar(value):
+    # If we have a scalar or a 0D array then wrap it in a 1D array
+    elif np.isscalar(value) or value.shape == ():
         arr = np.array(
             [
                 value,

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -110,20 +110,33 @@ def scalar_to_array(value):
         InconsistentArguments
             If the value is not a scalar or array-like object.
     """
+    # Do we have units? If so strip them away for now for simplicity
+    if isinstance(value, (unyt_quantity, unyt_array)):
+        units = value.units
+        value = value.value
+    else:
+        units = None
+
     # Just return it if we have been handed an array already or None
     if value is None or not np.isscalar(value):
         arr = value
 
     elif np.isscalar(value):
-        arr = np.array([value])
+        arr = np.array(
+            [
+                value,
+            ]
+        )
 
-    elif isinstance(value, unyt_quantity):
-        arr = np.array([value.value]) * value.units
     else:
         raise exceptions.InconsistentArguments(
             "Value to convert to an array wasn't a float or a unyt_quantity:"
             f"type(value) = {type(value)}"
         )
+
+    # Reattach the units if they were stripped
+    if units is not None:
+        arr = unyt_array(arr, units)
 
     return arr
 

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -92,46 +92,33 @@ def rebin_1d(arr, resample_factor, func=np.sum):
     return func(brr, axis=1)
 
 
-def value_to_array(value):
+def scalar_to_array(value):
     """
-    A helper functions for converting a single value to an array holding
-    a single value.
+    Convert a passed scalar to an array.
 
     Args:
-        value (float/unyt_quantity)
-            The value to wrapped into an array.
+        value (Any)
+            The value to wrapped into an array. If already an array-like
+            object then it is returned as is.
 
     Returns:
         array-like/unyt_array
-            An array containing the single value
+            The scalar value wrapped in an array or the array-like object
+            passed in.
 
     Raises:
         InconsistentArguments
-            If the argument is not a float or unyt_quantity.
+            If the value is not a scalar or array-like object.
     """
-
     # Just return it if we have been handed an array already or None
-    # NOTE: unyt_arrays and quantities are by definition arrays and thus
-    # return True for the isinstance below.
-    if (isinstance(value, np.ndarray) and value.size > 1) or value is None:
-        return value
+    if value is None or not np.isscalar(value):
+        arr = value
 
-    if isinstance(value, float):
-        arr = np.array(
-            [
-                value,
-            ]
-        )
+    elif np.isscalar(value):
+        arr = np.array([value])
 
-    elif isinstance(value, (unyt_quantity, unyt_array)):
-        arr = (
-            np.array(
-                [
-                    value.value,
-                ]
-            )
-            * value.units
-        )
+    elif isinstance(value, unyt_quantity):
+        arr = np.array([value.value]) * value.units
     else:
         raise exceptions.InconsistentArguments(
             "Value to convert to an array wasn't a float or a unyt_quantity:"

--- a/tests/test_particle_bh.py
+++ b/tests/test_particle_bh.py
@@ -1,0 +1,64 @@
+"""Test suite for particle based black holes."""
+
+import numpy as np
+from unyt import s, unyt_array
+
+from synthesizer.utils import scalar_to_array
+
+
+class TestBlackHolesInit:
+    def test_scalar_to_array(self):
+        """Test that scalar_to_array works in various situations."""
+        # Scalar with no units
+        arr = scalar_to_array(1)
+        assert isinstance(
+            arr, np.ndarray
+        ), f"Scalar with no units failed: 1->{arr}"
+
+        # Scalar with units
+        arr = scalar_to_array(1 * s)
+        assert isinstance(
+            arr, unyt_array
+        ), f"Scalar with units failed: 1 * s->{arr}"
+        assert arr.units == s, f"Scalar with units failed: 1 * s->{arr}"
+
+        # Check that an array without units is returned as is
+        arr = scalar_to_array(np.arange(10))
+        assert isinstance(
+            arr, np.ndarray
+        ), f"Array without units failed: {np.arange(10)}->{arr}"
+
+        # Check that an array with units is returned as is
+        arr = scalar_to_array(np.arange(10) * s)
+        assert isinstance(
+            arr, unyt_array
+        ), f"Array with units failed: {np.arange(10) * s}->{arr}"
+        assert (
+            arr.units == s
+        ), f"Array with units failed: {np.arange(10) * s}->{arr}"
+
+        # Check that a ndim = 2 array without units is returned as is
+        arr = scalar_to_array(np.arange(10).reshape(2, 5))
+        assert isinstance(arr, np.ndarray), (
+            "2D array without units failed: "
+            f"{np.arange(10).reshape(2, 5)}->{arr}"
+        )
+
+        # Check that a ndim = 2 array with units is returned as is
+        arr = scalar_to_array(np.arange(10).reshape(2, 5) * s)
+        assert isinstance(arr, unyt_array), (
+            "2D array with units failed:"
+            f" {np.arange(10).reshape(2, 5) * s}->{arr}"
+        )
+
+        # Check that a 1 element aray without units is returned as is
+        arr = scalar_to_array(np.array([1]))
+        assert isinstance(
+            arr, np.ndarray
+        ), f"1 element array without units failed: {np.array([1])}->{arr}"
+        assert arr.shape == (
+            1,
+        ), f"1 element array without units failed: {np.array([1])}->{arr}"
+        assert (
+            arr.ndim == 1
+        ), f"1 element array without units failed: {np.array([1])}->{arr}"

--- a/tests/test_particle_bh.py
+++ b/tests/test_particle_bh.py
@@ -21,9 +21,10 @@ class TestBlackHolesInit:
             arr, unyt_array
         ), f"Scalar with units failed: 1 * s->{arr}"
         assert arr.units == s, f"Scalar with units failed: 1 * s->{arr}"
-        assert arr.shape == (
-            1,
-        ), f"Scalar with units shape is wrong: 1 * s->{arr}"
+        assert arr.shape == (1,), (
+            f"Scalar with units shape is wrong: {arr.shape} "
+            f"(value: {arr}, type: {type(arr)})"
+        )
 
         # Check that an array without units is returned as is
         arr = scalar_to_array(np.arange(10))

--- a/tests/test_particle_bh.py
+++ b/tests/test_particle_bh.py
@@ -21,6 +21,9 @@ class TestBlackHolesInit:
             arr, unyt_array
         ), f"Scalar with units failed: 1 * s->{arr}"
         assert arr.units == s, f"Scalar with units failed: 1 * s->{arr}"
+        assert arr.shape == (
+            1,
+        ), f"Scalar with units shape is wrong: 1 * s->{arr}"
 
         # Check that an array without units is returned as is
         arr = scalar_to_array(np.arange(10))

--- a/tests/test_premade_emodels.py
+++ b/tests/test_premade_emodels.py
@@ -262,11 +262,11 @@ class TestCharlotFallEmission:
     def test_missing_optical_depth(self, test_grid, random_part_stars):
         """Test the initialization of the CharlotFall2000 object."""
         with pytest.raises(TypeError):
-            model = CharlotFall2000(
+            _ = CharlotFall2000(
                 test_grid,
             )
         with pytest.raises(TypeError):
-            model = CharlotFall2000(
+            _ = CharlotFall2000(
                 test_grid,
                 tau_v_ism=0.33,
             )

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,0 +1,1 @@
+"""Tests of the Template generator."""

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,1 +1,210 @@
 """Tests of the Template generator."""
+
+import numpy as np
+import pytest
+from unyt import unyt_array, unyt_quantity
+
+from synthesizer.emissions import Sed
+from synthesizer.grid import Template
+
+
+class TestTemplateInit:
+    """Test suite for initialising a Template object."""
+
+    def test_template_init(self):
+        """Test Template initialization."""
+        # Create sample data
+        lam = unyt_array(np.linspace(1000, 10000, 100), "angstrom")
+        lnu = unyt_array(np.ones_like(lam.value), "erg/s/Hz")
+
+        # Initialize a Template object
+        template = Template(lam, lnu)
+
+        # Check that the wavelength and luminosity arrays are stored correctly
+        assert np.allclose(
+            template.lam.value, lam.value
+        ), f"Wavelengths differ {template.lam.value} != {lam.value}"
+        assert (
+            template.lam.units == lam.units
+        ), f"Units differ {template.lam.units} != {lam.units}"
+
+        # Check that normalization happened
+        assert isinstance(
+            template.normalisation, unyt_quantity
+        ), f"Normalisation is not a unyt_quantity {template.normalisation}"
+        assert (
+            template.normalisation > 0
+        ), f"Normalisation is not positive {template.normalisation}"
+
+    def test_template_normalization(self):
+        """Test that the template luminosity is normalized correctly."""
+        # Create sample data
+        lam = unyt_array(np.linspace(1000, 10000, 100), "angstrom")
+        lnu = unyt_array(np.ones_like(lam.value), "erg/s/Hz")
+
+        # Initialize a Template object
+        template = Template(lam, lnu)
+
+        # Check that the internal SED has been normalized
+        assert np.isclose(
+            template._sed._bolometric_luminosity, 1.0
+        ), f"Template is not normalized {template._sed._bolometric_luminosity}"
+
+    def test_template_unify_with_grid(self, test_grid):
+        """Test unifying the template with a grid."""
+        # Create sample data
+        lam = unyt_array(np.linspace(1000, 10000, 100), "angstrom")
+        lnu = unyt_array(np.ones_like(lam.value), "erg/s/Hz")
+
+        # Initialize a Template object with the mock grid
+        template = Template(lam, lnu, unify_with_grid=test_grid)
+
+        # Check that the template wavelength matches the grid wavelength
+        assert len(template.lam) == len(test_grid.lam)
+        assert np.allclose(template.lam.value, test_grid.lam.value)
+        assert template.lam.units == test_grid.lam.units
+
+    def test_template_scaling_missing_units_error(self):
+        """Test that an error is raised when the scaling has no units."""
+        # Create sample data
+        lam = unyt_array(np.linspace(1000, 10000, 100), "angstrom")
+        lnu = unyt_array(np.ones_like(lam.value), "erg/s/Hz")
+
+        # Initialize a Template object
+        template = Template(lam, lnu)
+
+        # Test with a bolometric luminosity that has no units
+        with pytest.raises(Exception) as excinfo:
+            # This should raise an exception because 1e45 has no units
+            template.get_spectra(1e45)
+
+        # Check that the error message mentions units
+        assert "units" in str(excinfo.value).lower()
+
+    def test_template_init_missing_units_error(self):
+        """Test that an error is raised when the input has no units."""
+        # Create sample data
+        lam = unyt_array(np.linspace(1000, 10000, 100), "angstrom")
+        lnu = unyt_array(np.ones_like(lam.value), "erg/s/Hz")
+
+        # Test with a bolometric luminosity that has no units
+        with pytest.raises(Exception) as excinfo:
+            # This should raise an exception because the input has no units
+            Template(lam, lnu.value)
+
+        # Check that the error message mentions units
+        assert "units" in str(excinfo.value).lower()
+
+
+class TestTemplateGeneration:
+    def test_template_get_spectra(self):
+        """Test the get_spectra method."""
+        # Create sample data
+        lam = unyt_array(np.linspace(1000, 10000, 100), "angstrom")
+        lnu = unyt_array(np.ones_like(lam.value), "erg/s/Hz")
+
+        # Initialize a Template object
+        template = Template(lam, lnu)
+
+        # Test with a specific bolometric luminosity
+        bol_lum = unyt_quantity(1.0e45, "erg/s")
+        scaled_sed = template.get_spectra(bol_lum)
+
+        # Check that the returned object is an Sed
+        assert isinstance(scaled_sed, Sed)
+
+        # Check that scaling was applied correctly
+        assert np.isclose(scaled_sed._bolometric_luminosity, bol_lum.value)
+
+    def test_bh_template_model(
+        self,
+        particle_black_hole,
+        template_emission_model_bh,
+    ):
+        """Test the template model with a black hole particle."""
+        sed = particle_black_hole.get_spectra(template_emission_model_bh)
+
+        # Check that the returned object is an Sed
+        assert isinstance(sed, Sed)
+
+        # Ensure the Sed has the correct shape (i.e. ndim = 2 and (nbh, nlam))
+        assert (
+            sed.shape[0] == particle_black_hole.nbh
+        ), f"Sed has the wrong shape {sed.shape}"
+        assert sed.shape[1] == len(
+            template_emission_model_bh.lam
+        ), f"Sed has the wrong shape {sed.shape}"
+
+        # Check that the bolometric luminosity is correct
+        assert np.all(
+            np.isclose(
+                sed.bolometric_luminosity,
+                particle_black_hole.bolometric_luminosity,
+            )
+        ), (
+            "Bolometric luminosity differs "
+            f"{sed.bolometric_luminosity} != "
+            f"{particle_black_hole.bolometric_luminosity}"
+        )
+
+    def test_single_array_bh_template_model(
+        self,
+        single_particle_black_hole,
+        template_emission_model_bh,
+    ):
+        """Test the template model with a single black hole."""
+        sed = single_particle_black_hole.get_spectra(
+            template_emission_model_bh
+        )
+
+        # Check that the returned object is an Sed
+        assert isinstance(sed, Sed)
+
+        # Ensure the Sed has the correct shape (i.e. ndim = 2 and (nbh, nlam))
+        assert (
+            sed.shape[0] == single_particle_black_hole.nbh
+        ), f"Sed has the wrong shape {sed.shape}"
+        assert sed.shape[1] == len(
+            template_emission_model_bh.lam
+        ), f"Sed has the wrong shape {sed.shape}"
+
+        # Check that the bolometric luminosity is correct
+        assert np.isclose(
+            sed.bolometric_luminosity,
+            single_particle_black_hole.bolometric_luminosity,
+        ), (
+            "Bolometric luminosity differs "
+            f"{sed.bolometric_luminosity} != "
+            f"{single_particle_black_hole.bolometric_luminosity}"
+        )
+
+    def test_single_scalar_bh_template_model(
+        self,
+        single_particle_black_hole_scalars,
+        template_emission_model_bh,
+    ):
+        """Test the template model with a single black hole."""
+        sed = single_particle_black_hole_scalars.get_spectra(
+            template_emission_model_bh
+        )
+
+        # Check that the returned object is an Sed
+        assert isinstance(sed, Sed)
+
+        # Ensure the Sed has the correct shape (i.e. ndim = 2 and (nbh, nlam))
+        assert (
+            sed.shape[0] == single_particle_black_hole_scalars.nbh
+        ), f"Sed has the wrong shape {sed.shape}"
+        assert sed.shape[1] == len(
+            template_emission_model_bh.lam
+        ), f"Sed has the wrong shape {sed.shape}"
+
+        # Check that the bolometric luminosity is correct
+        assert np.isclose(
+            sed.bolometric_luminosity,
+            single_particle_black_hole_scalars.bolometric_luminosity,
+        ), (
+            "Bolometric luminosity differs "
+            f"{sed.bolometric_luminosity} != "
+            f"{single_particle_black_hole_scalars.bolometric_luminosity}"
+        )


### PR DESCRIPTION
`Template` scaling was failing for black holes with only a single BH. This was only discovered in the FLARES-LRD pipeline. This PR fixes the problem and implements a suite of tests.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined spectral scaling to provide more consistent handling of input arrays and improved error messaging.
	- Enhanced simulation templates by refining normalization with robust unit conversion.
	- Upgraded routines for converting scalar parameters to arrays to ensure consistency across simulations.

- **New Features**
	- Introduced new pytest fixtures for testing black hole models and templates.
	- Added comprehensive test suites for the `Template` class and particle-based black holes.

- **Tests**
	- Expanded test coverage for black hole models and template generation to validate functionality and error handling.
	- Added a new test for the `scalar_to_array` function to ensure correct handling of various input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->