### PR TITLE
Enabling generic attribute for column density results

### DIFF
--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -398,6 +398,7 @@ class Galaxy(BaseGalaxy):
         self,
         kappa,
         kernel,
+        tau_v_attr="tau_v",
         mask=None,
         threshold=1,
         force_loop=0,
@@ -423,6 +424,9 @@ class Galaxy(BaseGalaxy):
                 order such that a k element array can be indexed for the value
                 of impact parameter q via kernel[int(k*q)]. Note, this can be
                 an arbitrary kernel.
+            tau_v_attr (str)
+                The attribute to store the tau_v values in the stars object.
+                Defaults to "tau_v".
             mask (bool)
                 A mask to be applied to the stars. Surface densities will only
                 be computed and returned for stars with True in the mask.
@@ -475,10 +479,15 @@ class Galaxy(BaseGalaxy):
         # Finalise the calculation
         tau_v = kappa * los_dustsds
 
+        # Apply the mask if provided
+        if mask is not None:
+            tau_vs = np.zeros(self.stars.nparticles)
+            tau_vs[mask] = tau_v
+        else:
+            tau_vs = tau_v
+
         # Store the result in self.stars
-        if self.stars.tau_v is None:
-            self.stars.tau_v = np.zeros(self.stars.nparticles)
-        self.stars.tau_v[mask] = tau_v
+        setattr(self.stars, tau_v_attr, tau_vs)
 
         toc("Calculating stellar LOS tau_v", start)
 
@@ -488,6 +497,7 @@ class Galaxy(BaseGalaxy):
         self,
         kappa,
         kernel,
+        tau_v_attr="tau_v",
         mask=None,
         threshold=1,
         force_loop=0,
@@ -513,6 +523,9 @@ class Galaxy(BaseGalaxy):
                 order such that a k element array can be indexed for the value
                 of impact parameter q via kernel[int(k*q)]. Note, this can be
                 an arbitrary kernel.
+            tau_v_attr (str)
+                The attribute to store the tau_v values in the black_holes
+                object. Defaults to "tau_v".
             mask (bool)
                 A mask to be applied to the black holes. Surface densities will
                 only be computed and returned for black holes with True in the
@@ -566,10 +579,15 @@ class Galaxy(BaseGalaxy):
         # Finalise the calculation
         tau_v = kappa * los_dustsds
 
+        # Apply the mask if provided
+        if mask is not None:
+            tau_vs = np.zeros(self.black_holes.nbh)
+            tau_vs[mask] = tau_v
+        else:
+            tau_vs = tau_v
+
         # Store the result in self.black_holes
-        if self.black_holes.tau_v is None:
-            self.black_holes.tau_v = np.zeros(self.black_holes.nbh)
-        self.black_holes.tau_v[mask] = tau_v
+        setattr(self.black_holes, "tau_v", tau_vs)
 
         toc("Calculating black hole LOS tau_v", start)
 
@@ -580,6 +598,7 @@ class Galaxy(BaseGalaxy):
         self,
         kappa,
         kernel,
+        tau_v_attr="tau_v",
         mask=None,
         threshold=1,
         force_loop=0,
@@ -605,6 +624,9 @@ class Galaxy(BaseGalaxy):
                 order such that a k element array can be indexed for the value
                 of impact parameter q via kernel[int(k*q)]. Note, this can be
                 an arbitrary kernel.
+            tau_v_attr (str)
+                The attribute to store the tau_v values in the stars object.
+                Defaults to "tau_v".
             mask (bool)
                 A mask to be applied to the stars. Surface densities will only
                 be computed and returned for stars with True in the mask.
@@ -657,10 +679,15 @@ class Galaxy(BaseGalaxy):
         # Finalise the calculation
         tau_v = kappa * los_dustsds
 
+        # Apply the mask if provided
+        if mask is not None:
+            tau_vs = np.zeros(self.stars.nparticles)
+            tau_vs[mask] = tau_v
+        else:
+            tau_vs = tau_v
+
         # Store the result in self.stars
-        if self.stars.tau_v is None:
-            self.stars.tau_v = np.zeros(self.stars.nparticles)
-        self.stars.tau_v[mask] = tau_v
+        setattr(self.stars, tau_v_attr, tau_vs)
 
         toc("Calculating LOS tau_v", start)
 

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -691,6 +691,7 @@ class Particles:
         other_parts,
         density_attr,
         kernel,
+        column_density_attr=None,
         mask=None,
         threshold=1,
         force_loop=0,
@@ -714,6 +715,10 @@ class Particles:
                 order such that a k element array can be indexed for the value
                 of impact parameter q via kernel[int(k*q)]. Note, this can be
                 an arbitrary kernel.
+            column_density_attr (str)
+                The attribute to store the column density in on the Particles
+                instance. If None, the column density will not be stored. By
+                default this is None.
             mask (array-like, bool)
                 A mask to be applied to the stars. Surface densities will only
                 be computed and returned for stars with True in the mask.
@@ -750,7 +755,7 @@ class Particles:
             mask = np.ones(self.nparticles, dtype=bool)
 
         # Compute the column density
-        return compute_column_density(
+        col_den = compute_column_density(
             *self._prepare_los_args(
                 other_parts,
                 density_attr,
@@ -762,6 +767,12 @@ class Particles:
                 nthreads,
             )
         )
+
+        # Set the column density attribute (if requested)
+        if column_density_attr is not None:
+            setattr(self, column_density_attr, col_den)
+
+        return col_den
 
     @accepts(phi=rad, theta=rad)
     def rotate_particles(


### PR DESCRIPTION
DWISOTT, column density calculations now have the option of storing their results into a generic variable on the particle component.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enabled custom configuration for storing computed values, allowing users to define the attribute names for results.
	- Enhanced the handling logic for conditionally updating computed data, providing more flexible and robust result management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->