### PR TITLE
Adding turbulence as a parameter that is set by synthesizer

### DIFF
--- a/src/synthesizer/photoionisation/cloudy23.py
+++ b/src/synthesizer/photoionisation/cloudy23.py
@@ -157,6 +157,8 @@ def create_cloudy_input(
         "z": 0.0,
         # include CMB heating
         "CMB": None,
+        # include turbulence
+        "turbulence": None,
         # include cosmic rays
         "cosmic_rays": None,
         # include metals
@@ -378,6 +380,10 @@ def create_cloudy_input(
 
     if params["CMB"] is not None:
         cinput.append(f'CMB {params["z"]}\n')
+
+    # define turbulence
+    if params["turbulence"] is not None:
+        cinput.append(f"turbulence {params['turbulence']}\n")
 
     # define hydrogen density
     if params["hydrogen_density"] is not None:


### PR DESCRIPTION
After finding out that turbulence makes a difference (at least for dense gas) I discovered that turbulence was never actually set in the `synthesizer` photoionisation pipeline. This adds it.

## Issue Type
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new "turbulence" option that lets users include turbulence parameters when generating cloudy atmosphere commands, enhancing the configuration capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->