### PR TITLE
Adding a handler to ensure the C extensions aren't handed garbage

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -88,7 +88,7 @@ class StarsComponent(Component):
             log10ages (array)
                 log10 stellar ages
         """
-        return np.log10(self._ages)
+        return np.log10(self._ages, dtype=np.float64)
 
     @property
     def log10metallicities(self):
@@ -99,7 +99,7 @@ class StarsComponent(Component):
             log10metallicities (array)
                 log10 stellar metallicities
         """
-        return np.log10(self.metallicities)
+        return np.log10(self.metallicities, dtype=np.float64)
 
     def __str__(self):
         """

--- a/src/synthesizer/emission_models/extractors/extractor.py
+++ b/src/synthesizer/emission_models/extractors/extractor.py
@@ -16,6 +16,7 @@ from synthesizer.extensions.particle_spectra import (
 )
 from synthesizer.extensions.timers import tic, toc
 from synthesizer.synth_warnings import warn
+from synthesizer.utils import get_attr_c_compatible_double
 
 
 class Extractor(ABC):
@@ -543,7 +544,7 @@ class DopplerShiftedParticleExtractor(Extractor):
             self._grid_axes,
             extracted,
             weight,
-            emitter._velocities,
+            get_attr_c_compatible_double(emitter, "_velocities"),
             self._grid_dims,
             self._grid_naxes,
             emitter.nparticles,
@@ -654,7 +655,7 @@ class IntegratedDopplerShiftedParticleExtractor(Extractor):
             self._grid_axes,
             extracted,
             weight,
-            emitter._velocities,
+            get_attr_c_compatible_double(emitter, "_velocities"),
             self._grid_dims,
             self._grid_naxes,
             emitter.nparticles,

--- a/src/synthesizer/emission_models/utils.py
+++ b/src/synthesizer/emission_models/utils.py
@@ -3,7 +3,12 @@
 import numpy as np
 
 from synthesizer import exceptions
-from synthesizer.utils import depluralize, pluralize
+from synthesizer.utils import (
+    depluralize,
+    ensure_array_c_compatible_double,
+    get_attr_c_compatible_double,
+    pluralize,
+)
 
 _NO_DEFAULT = object()
 
@@ -49,15 +54,19 @@ def get_param(param, model, emission, emitter, default=_NO_DEFAULT):
 
     # Check the model's fixed parameters first
     if model is not None and param in model.fixed_parameters:
-        value = model.fixed_parameters[param]
+        value = (
+            ensure_array_c_compatible_double(model.fixed_parameters[param])
+            if not isinstance(model.fixed_parameters[param], str)
+            else model.fixed_parameters[param]
+        )
 
     # Check the emission next
     elif emission is not None and hasattr(emission, param):
-        value = getattr(emission, param)
+        value = get_attr_c_compatible_double(emission, param)
 
     # Finally check the emitter
     elif emitter is not None and hasattr(emitter, param):
-        value = getattr(emitter, param)
+        value = get_attr_c_compatible_double(emitter, param)
 
     # Do we need to recursively look for the parameter? (We know we're only
     # looking on the emitter at this point)

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -208,7 +208,7 @@ class Particles:
         mets = self.metallicities
         mets[mets == 0.0] = self.metallicity_floor
 
-        return np.log10(mets)
+        return np.log10(mets, dtype=np.float64)
 
     def get_particle_photo_lnu(self, filters, verbose=True, nthreads=1):
         """

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -14,7 +14,7 @@ from unyt import Mpc, Msun, km, rad, s
 from synthesizer import exceptions
 from synthesizer.synth_warnings import deprecation
 from synthesizer.units import Quantity, accepts
-from synthesizer.utils import TableFormatter
+from synthesizer.utils import TableFormatter, ensure_array_c_compatible_double
 from synthesizer.utils.geometry import get_rotation_matrix
 
 
@@ -110,8 +110,8 @@ class Particles:
                 The name of the particle type.
         """
         # Set phase space coordinates
-        self.coordinates = coordinates
-        self.velocities = velocities
+        self.coordinates = ensure_array_c_compatible_double(coordinates)
+        self.velocities = ensure_array_c_compatible_double(velocities)
 
         # Define the dictionary to hold particle spectra
         self.particle_spectra = {}
@@ -126,10 +126,12 @@ class Particles:
         # Set unit information
 
         # Set the softening length
-        self.softening_lengths = softening_lengths
+        self.softening_lengths = ensure_array_c_compatible_double(
+            softening_lengths
+        )
 
         # Set the particle masses
-        self.masses = masses
+        self.masses = ensure_array_c_compatible_double(masses)
 
         # Set the redshift of the particles
         self.redshift = redshift
@@ -138,7 +140,7 @@ class Particles:
         self.nparticles = nparticles
 
         # Set the centre of the particle distribution
-        self.centre = centre
+        self.centre = ensure_array_c_compatible_double(centre)
 
         # Set the radius to None, this will be populated when needed and
         # can then be subsequently accessed

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -333,7 +333,7 @@ class Stars(Particles, StarsComponent):
             log10ages (array)
                 log10 stellar ages
         """
-        return np.log10(self.ages) * dimensionless
+        return np.log10(self.ages, dtype=np.float64) * dimensionless
 
     def _check_star_args(self):
         """

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -478,6 +478,10 @@ def ensure_array_c_compatible_double(arr):
     if arr is None:
         return arr
 
+    # Convert a list to a numpy array before we move on
+    if isinstance(arr, list):
+        arr = np.array(arr)
+
     # If we have units we need to strip them off temporarily
     units = None
     if isinstance(arr, (unyt_array, unyt_quantity)):

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -530,6 +530,10 @@ def get_attr_c_compatible_double(obj, attr):
     # Get the attribute from the object
     arr = getattr(obj, attr)
 
+    # Just return it if it's None
+    if arr is None:
+        return arr
+
     # Handle singular floats
     if np.isscalar(arr):
         return np.float64(arr)

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -474,6 +474,10 @@ def ensure_array_c_compatible_double(arr):
     Args:
         arr (np.ndarray): The input array to be checked.
     """
+    # If the array is None, return it as is
+    if arr is None:
+        return arr
+
     # If we have units we need to strip them off temporarily
     units = None
     if isinstance(arr, (unyt_array, unyt_quantity)):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,95 @@
+"""A test suite for the utils module."""
+
+import numpy as np
+import unyt
+
+from synthesizer.emission_models.utils import (
+    ensure_array_c_compatible_double,
+)
+
+
+class TestEnsureCompatibles:
+    """A test suite for functions helping ensure compatibility."""
+
+    def test_c_compatible_array_scalar(self):
+        """Test the ensure_array_c_compatible_double function."""
+        # Test with a single value
+        value = 1.0
+        result = ensure_array_c_compatible_double(value)
+        assert result == np.float64(1.0), (
+            "Expected a single float value to be returned as np.float64 "
+            f"but got {result}"
+        )
+
+    def test_c_compatible_array_list(self):
+        """Test the ensure_array_c_compatible_double function."""
+        # Test with a list of values
+        value = [1.0, 2.0, 3.0]
+        result = ensure_array_c_compatible_double(value)
+        assert isinstance(result, np.ndarray), (
+            "Expected a list to be converted to a numpy array "
+            f"but got {result}"
+        )
+        assert (
+            result.dtype == np.float64
+        ), f"Expected a numpy array of type float64 but got {result.dtype}"
+
+    def test_c_compatible_array_numpy32(self):
+        """Test the ensure_array_c_compatible_double function."""
+        # Test with a numpy array of type float32
+        value = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        result = ensure_array_c_compatible_double(value)
+        assert isinstance(
+            result, np.ndarray
+        ), f"Expected a numpy array to be returned but got {result}"
+        assert (
+            result.dtype == np.float64
+        ), f"Expected a numpy array of type float64 but got {result.dtype}"
+
+    def test_c_compatible_array_numpy64(self):
+        """Test the ensure_array_c_compatible_double function."""
+        # Test with a numpy array of type float64
+        value = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+        result = ensure_array_c_compatible_double(value)
+        assert isinstance(
+            result, np.ndarray
+        ), f"Expected a numpy array to be returned but got {result}"
+        assert (
+            result.dtype == np.float64
+        ), f"Expected a numpy array of type float64 but got {result.dtype}"
+
+    def test_c_compatible_array_unyt32(self):
+        """Test the ensure_array_c_compatible_double function."""
+        value = unyt.unyt_array(
+            np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            "cm",
+        )
+        result = ensure_array_c_compatible_double(value)
+        assert isinstance(
+            result, unyt.unyt_array
+        ), f"Expected a numpy array to be returned but got {result}"
+        assert (
+            result.dtype == np.float64
+        ), f"Expected a numpy array of type float64 but got {result.dtype}"
+        assert result.units == value.units, (
+            f"Expected a numpy array of type {value.units} but "
+            f"got {result.units}"
+        )
+
+    def test_c_compatible_array_unyt64(self):
+        """Test the ensure_array_c_compatible_double function."""
+        value = unyt.unyt_array(
+            np.array([1.0, 2.0, 3.0], dtype=np.float32),
+            "cm",
+        )
+        result = ensure_array_c_compatible_double(value)
+        assert isinstance(
+            result, unyt.unyt_array
+        ), f"Expected a numpy array to be returned but got {result}"
+        assert (
+            result.dtype == np.float64
+        ), f"Expected a numpy array of type float64 but got {result.dtype}"
+        assert result.units == value.units, (
+            f"Expected a numpy array of type {value.units} but "
+            f"got {result.units}"
+        )


### PR DESCRIPTION
I and @marcoleonardi97 have separately had issues where simulation-specific readers are reading in float32 values but the C extension requires doubles (float64). Similarly, if you mask data then it is not contiguous (unless numpy makes a copy). Both of these can lead to garbage values but not an explicit failure. 

This PR introduces a helpful handler for the backend to do this conversion at the point of use. Importantly:
- We only want to do this conversion once. To make sure of this one of the helpers will get, convert and set if a conversion is needed, otherwise it just returns the value. 
- Only values that will actually be handed to the C are converted if needs be. 
- A user should never see any of this or need to care about this.

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Stellar age and metallicity computations now produce results with enhanced precision by specifying data types.
  - Emission model parameters are processed with improved compatibility for more reliable numerical operations.
  - Additional utility functions enhance numerical handling and compatibility with C extensions, contributing to overall stability and accuracy.
  - New test suite introduced to validate the functionality of compatibility functions, ensuring robust performance.

- **Bug Fixes**
  - Improved handling of input data types for attributes in the `Particles` class, ensuring compatibility with C-style double arrays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->