### PR TITLE
Fix rotation methods

### DIFF
--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -16,6 +16,7 @@ from synthesizer.synth_warnings import deprecation
 from synthesizer.units import Quantity, accepts
 from synthesizer.utils import TableFormatter
 from synthesizer.utils.geometry import get_rotation_matrix
+from synthesizer.particle.utils import rotate
 
 
 class Particles:
@@ -812,34 +813,13 @@ class Particles:
                 A new instance of the particles with the rotated coordinates,
                 if inplace is False.
         """
-        # Are we using angles?
-        if rot_matrix is None:
-            # Rotation matrix around z-axis (phi)
-            rot_matrix_z = np.array(
-                [
-                    [np.cos(phi), -np.sin(phi), 0],
-                    [np.sin(phi), np.cos(phi), 0],
-                    [0, 0, 1],
-                ]
-            )
-
-            # Rotation matrix around y-axis (theta)
-            rot_matrix_y = np.array(
-                [
-                    [np.cos(theta), 0, np.sin(theta)],
-                    [0, 1, 0],
-                    [-np.sin(theta), 0, np.cos(theta)],
-                ]
-            )
-
-            # Combined rotation matrix
-            rot_matrix = np.dot(rot_matrix_y, rot_matrix_z)
-
         # Are we rotating in place or returning a new instance?
         if inplace:
             # Rotate the coordinates
-            self.coordinates = np.dot(self.coordinates, rot_matrix.T)
-            self.velocities = np.dot(self.velocities, rot_matrix.T)
+            self.coordinates = rotate(self.coordinates, phi, theta, rot_matrix)
+            self.velocities = rotate(self.velocities, phi, theta, rot_matrix)
+            if self.centre is not None:
+                self.centre = rotate(self.centre, phi, theta, rot_matrix)
 
             return
 
@@ -847,8 +827,10 @@ class Particles:
         new_parts = copy.deepcopy(self)
 
         # Rotate the coordinates
-        new_parts.coordinates = np.dot(new_parts.coordinates, rot_matrix.T)
-        new_parts.velocities = np.dot(new_parts.velocities, rot_matrix.T)
+        new_parts.coordinates = rotate(new_parts.coordinates, phi, theta, rot_matrix)
+        new_parts.velocities = rotate(new_parts.velocities, phi, theta, rot_matrix)
+        if self.centre is not None:
+            new_parts.centre = rotate(new_parts.centre, phi, theta, rot_matrix)
 
         # Return the new one
         return new_parts

--- a/src/synthesizer/particle/utils.py
+++ b/src/synthesizer/particle/utils.py
@@ -2,10 +2,66 @@
 
 import numpy as np
 from scipy.spatial import cKDTree
-from unyt import Mpc, unyt_array
+from unyt import Mpc, unyt_array, rad
 
 from synthesizer.units import accepts
 
+
+@accepts(phi=rad, theta=rad)
+def rotate(
+    coordinates,
+    phi=0 * rad,
+    theta=0 * rad,
+    rot_matrix=None,
+):
+    """
+    Rotate 3D array of coordinates
+
+    Args:
+        coordinates (np.array)
+            1D or 2D array of coordinates
+        phi (unyt_quantity):
+            The angle in radians to rotate around the z-axis. If rot_matrix
+            is defined this will be ignored.
+        theta (unyt_quantity):
+            The angle in radians to rotate around the y-axis. If rot_matrix
+            is defined this will be ignored.
+        rot_matrix (array-like, float):
+            A 3x3 rotation matrix to apply to the coordinates
+            instead of phi and theta.
+
+    returns 
+        coordinates (np.array)
+            transformed coordinate array
+    """
+
+    if len(coordinates.shape) == 1:
+        coordinates = np.array([coordinates])
+
+    # Are we using angles?
+    if rot_matrix is None:
+        # Rotation matrix around z-axis (phi)
+        rot_matrix_z = np.array(
+            [
+                [np.cos(phi), -np.sin(phi), 0],
+                [np.sin(phi), np.cos(phi), 0],
+                [0, 0, 1],
+            ]
+        )
+
+        # Rotation matrix around y-axis (theta)
+        rot_matrix_y = np.array(
+            [
+                [np.cos(theta), 0, np.sin(theta)],
+                [0, 1, 0],
+                [-np.sin(theta), 0, np.cos(theta)],
+            ]
+        )
+
+        # Combined rotation matrix
+        rot_matrix = np.dot(rot_matrix_y, rot_matrix_z)
+
+    return np.dot(coordinates, rot_matrix.T)
 
 @accepts(coordinates=Mpc, boxsize=Mpc)
 def calculate_smoothing_lengths(


### PR DESCRIPTION
Fixes a number of issues in the rotation methods.
- rotate centres of each component, to fix imaging
- Moved rotate to the utils method to allow more generalised rotation of different components

Still to do:
- edge on and face on rotation methods don't seem to work...

## Issue Type
- Bug
- Enhancement

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
