### PR TITLE
Adds a method for flattening axes 

### DIFF
--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -20,6 +20,8 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
+    "from matplotlib import colormaps as cm\n",
+    "from matplotlib.colors import Normalize\n",
     "from unyt import angstrom\n",
     "\n",
     "from synthesizer.grid import Grid"
@@ -320,6 +322,70 @@
     "\n",
     "# Measure the balmer break for all spectra in the grid (limiting the output)\n",
     "sed.measure_balmer_break()[5:10, 5:10]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "9cc8a97d",
+   "metadata": {},
+   "source": [
+    "## Working with flattened grids\n",
+    "\n",
+    "Sometimes it's useful to work with flattened (i.e. one dimensional) versions of a grid of spectra, photometry etc. To facilitate this the `get_flattened_axes_values` method on `grid` can be used to get the flattend axes values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9337ebca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cm[\"plasma\"](0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c5bf32d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid._axes_units[\"ages\"]\n",
+    "grid._axes_values[\"ages\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4a47c96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the balmer breaks of the entire grid\n",
+    "balmer_breaks = sed.measure_balmer_break()\n",
+    "\n",
+    "# Get a flattened version of the Balmer break grid\n",
+    "flattened_balmer_breaks = balmer_breaks.flatten()\n",
+    "\n",
+    "# Get the flattened version of the axes\n",
+    "flattend_axes_values = grid.get_flattened_axes_values()\n",
+    "\n",
+    "# Normlise metallicities and create an array of colors\n",
+    "norm = Normalize(vmin=-4, vmax=-1.5, clip=True)\n",
+    "colors = cm[\"plasma\"](norm(np.log10(flattend_axes_values[\"metallicities\"])))\n",
+    "\n",
+    "# Plot\n",
+    "plt.scatter(\n",
+    "    flattend_axes_values[\"ages\"].to(\"Myr\").value,\n",
+    "    flattened_balmer_breaks,\n",
+    "    c=colors,\n",
+    ")\n",
+    "plt.xscale(\"log\")\n",
+    "plt.xlabel(\"ages/Myr\")\n",
+    "plt.ylabel(\"Blamer break\")\n",
+    "plt.show()"
    ]
   }
  ],

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1464,6 +1464,29 @@ class Grid:
         # Return tuple of wavelengths and delta lambda
         return self.lam, delta_lambda
 
+    def get_flattened_axes_values(self):
+        """
+        Create flattened of the axes values
+
+        Returns:
+            dict
+                A dictionary containing the flattened versions of the axes.
+        """
+
+        # Create a tuple of the axes values
+        axes_values_tuple = (self.axes_values[axis] for axis in self.axes)
+
+        # Create a meshgrid of the axes_values
+        axes_values_mesh_tuple = np.meshgrid(*axes_values_tuple, indexing="ij")
+
+        # Create a dictionary with flattened versions of the axes values
+        flattened_axes_values = {
+            axis: axes_values_mesh_tuple[axis_index].flatten()
+            for axis_index, axis in enumerate(self.axes)
+        }
+
+        return flattened_axes_values
+
     def get_sed(self, spectra_type):
         """
         Get the spectra grid as an Sed object.

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1474,14 +1474,17 @@ class Grid:
         """
 
         # Create a tuple of the axes values
-        axes_values_tuple = (self.axes_values[axis] for axis in self.axes)
+        axes_values_tuple = (self._axes_values[axis] for axis in self.axes)
 
         # Create a meshgrid of the axes_values
         axes_values_mesh_tuple = np.meshgrid(*axes_values_tuple, indexing="ij")
 
         # Create a dictionary with flattened versions of the axes values
         flattened_axes_values = {
-            axis: axes_values_mesh_tuple[axis_index].flatten()
+            axis: unyt_array(
+                axes_values_mesh_tuple[axis_index].flatten(),
+                self._axes_units[axis],
+            )
             for axis_index, axis in enumerate(self.axes)
         }
 

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1466,13 +1466,15 @@ class Grid:
 
     def get_flattened_axes_values(self):
         """
-        Create flattened of the axes values
+        Get the flattened axis values for the grid.
+
+        This will return a dictionary of the axes values that correspond to
+        the grid once flattened.
 
         Returns:
             dict
                 A dictionary containing the flattened versions of the axes.
         """
-
         # Create a tuple of the axes values
         axes_values_tuple = (self._axes_values[axis] for axis in self.axes)
 


### PR DESCRIPTION
Adds a method to flatten axes values for use with flattened sed/line etc. grids. This is useful when exploring grids.

Also includes an example of usage in the docs.

Closes #902.

## Issue Type
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new example demonstrating how to work with and visualize flattened (1D) versions of multidimensional spectral grids, including color-coding by metallicity.
- **Documentation**
  - Expanded the grids example notebook with a workflow for plotting flattened grid data using colormaps and normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->