### PR TITLE
Only update the docs when pushing a new release

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,9 +2,10 @@
 name: Documentation
 
 on:
-  # Runs on pushes targeting the default branch
+  # Runs on releases to enure docs are in step with PyPI deployment
   push:
-    branches: ["main"]
+    tags:
+      - "v*.*.*" # Matches version tags like v1.0.0, v2.1.3, etc.
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -45,9 +45,9 @@ These commands will store the test data in the `tests` directory at the root of 
 
 ### Setting up pre-commit hooks
 
-Once you have developed your new functionality you'll want to commit it to the repo. We employ a pre-commit hook to ensure any code you commit will pass our tests and you won't be stuck with a failing Pull Request. This pre-commit hook will guard against files containing merge conflict strings, check case conflicts in file names, guard against the commiting of large files, santise jupyter notebooks (using `nb-clean`) and, most importantly, will run `ruff` in both linter and formatter mode.
+Once you have developed your new functionality, you'll want to commit it to the repo. We employ a pre-commit hook to ensure any code you commit will pass our tests and you won't be stuck with a failing Pull Request. This pre-commit hook will guard against files containing merge conflict strings, check case conflicts in file names, guard against the committing of large files, sanitise Jupyter notebooks (using `nb-clean`) and, most importantly, will run `ruff` in both linter and formatter mode.
 
-This requires a small amount of set up on your part, some of which was done when you installed the optional development dependencies above. The rest of the setup requires you run
+This requires a small amount of set-up on your part, some of which was done when you installed the optional development dependencies above. The rest of the setup requires you run
 
 ```bash
 pre-commit install
@@ -73,8 +73,8 @@ We use the [Google docstring format](https://google.github.io/styleguide/pyguide
 
 Some specific examples of common style issues:
 
-- Do not use capatilised single letters for attributes. For example, `T` could be transmission or temperature. Instead, one should write out the full word.
-- Operators should be surrounded with whitespace.
+- Do not use capitalised single letters for attributes. For example, `T` could be transmission or temperature. Instead, one should write out the full word.
+- Operators should be surrounded by whitespace.
 - We use `get_` and/or `calculate_` nomenclature for methods that perform a calculation and return the result to the user.
 - Variables should adhere to `snake_case` style while class names should be in `PascalCase`.
 - Block comments should have their first letter capitalised, i.e.
@@ -84,7 +84,7 @@ Some specific examples of common style issues:
 x = y
 ```
 
-- While inline comments should be proceeded by two whitespaces and start with a lowercase letter, i.e.
+- While inline comments should be preceded by two whitespaces and start with a lowercase letter, i.e.
 
 ```
 z = x * 2  # this is an inline comment
@@ -92,17 +92,26 @@ z = x * 2  # this is an inline comment
 
 - Inheritance should use `Parent.__init__` instansiation of the parent class over `super()` for clarity.
 
+## Development documentation 
+
+The [published documentation](https://synthesizer-project.github.io/synthesizer/) reflects the current distribution available on PyPI. If you would like to see the current development version in your branch or the main branch, you will have to build the documentation locally. To do so, navigate to the ``docs`` directory and run:
+
+```bash
+make clean; make html
+```
+This will build a local copy of the documentation representative of the currently checked out branch.
+
 ## Contributing to the Documentation
 
-The synthesizer documentation is written in a combination of restructuredText, Jupyter notebooks and Python scripts.
-Adding content should be relatively simple, if you follow the instructions below.
+The synthesizer documentation is written in a combination of reStructuredText, Jupyter notebooks and Python scripts.
+Adding content should be relatively simple if you follow the instructions below.
 
 ### Adding notebooks
 
-To add jupyter notebooks to the documentation:
+To add Jupyter notebooks to the documentation:
 
-1. Add your jupyter notebook to the `source` directory. Make sure that you 'Restart Kernel and run all cells' to ensure that the notebook is producing up to date, consistent outputs.
-2. Add your notebook to the relevant toctree. See below for an example toctree. Each toctree is contained within a sphinx `.rst` file in each documentation source directory. The top level file is `source/index.rst`. If your file is in a subfolder, you need to update the `.rst` file in that directory.
+1. Add your Jupyter notebook to the `source` directory. Make sure that you 'Restart Kernel and run all cells' to ensure that the notebook is producing up to date, consistent outputs.
+2. Add your notebook to the relevant toctree. See below for an example toctree. Each toctree is contained within a Sphinx `.rst` file in each documentation source directory. The top-level file is `source/index.rst`. If your file is in a subfolder, you need to update the `.rst` file in that directory.
 
 - If you're creating a new sub-directory of documentation, you will need to carry out a couple more steps:
 
@@ -136,11 +145,11 @@ Example toctree:
 
 ### Adding example scripts
 
-The `examples/` top level directory contains a number of self contained example scripts (python, `.py`) for particular use cases that may not belong in the main documentation, but are still useful for many users. We use the [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html) extension to build a gallery of our examples in the documentation. A helpful side effect of this is that we can use the examples suite as a further test suite of more advanced use cases (though this requires certain conventions to be followed, see below)
+The `examples/` top level directory contains a number of self-contained example scripts (Python, `.py`) for particular use cases that may not belong in the main documentation, but are still useful for many users. We use the [sphinx-gallery](https://sphinx-gallery.github.io/stable/index.html) extension to build a gallery of our examples in the documentation. A helpful side effect of this is that we can use the examples suite as a further test suite of more advanced use cases (though this requires certain conventions to be followed, see below)
 
-**Important**: If an example is named `plot_*.py` then `sphinx-gallery` will attempt to run the script and use any images generated in the gallery thumbnail. Images should be generated using `plt.show()` and not saved to disk. If examples are not preceded with `plot_` then they will **not** be run when compiling the documentation, and any errors will not be caught.
+**Important**: If an example is named `plot_*.py`, then `sphinx-gallery` will attempt to run the script and use any images generated in the gallery thumbnail. Images should be generated using `plt.show()` and not saved to disk. If examples are not preceded with `plot_`, then they will **not** be run when compiling the documentation, and no errors will be caught.
 
-Each script (`.py`) should have a top level docstring written in reST, with a header. Examples that do not will fail the automated build process. Further details are provided [here](https://sphinx-gallery.github.io/stable/syntax.html). For example:
+Each script (`.py`) should have a top-level docstring written in reST, with a header. Examples that do not will fail the automated build process. Further details are provided [here](https://sphinx-gallery.github.io/stable/syntax.html). For example:
 
     """
     "This" is my example-script
@@ -161,6 +170,6 @@ debugging code...
 #endif
 ```
 
-To activate debugging checks simply install with `WITH_DEBUGGING_CHECKS=1 pip install .`.
+To activate debugging checks, install with `WITH_DEBUGGING_CHECKS=1 pip install .`.
 
-It is also advisable to turn warnings into errors by including `-Werror` in the CFLAGS, however, the Python source code itself will fail with this turned on for some compilers because it does produce some warnings (observed with gcc).
+It is also advisable to turn warnings into errors by including `-Werror` in the CFLAGS; however, the Python source code itself will fail with this turned on for some compilers because it does produce some warnings (observed with gcc).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,6 +8,7 @@ The GitHub workflow will automatically run [Ruff](https://github.com/astral-sh/r
 - [Setting up your development environment](#setting-up-your-development-environment)
 - [Using Ruff](#using-ruff)
 - [Style guide](#style-guide)
+- [Development Documentation](#development-documentation)
 - [Contributing to the Documentation](#contributing-to-the-documentation)
   - [Getting set up](#getting-set-up)
   - [Adding notebooks](#adding-notebooks)


### PR DESCRIPTION
We now need to ensure our published docs are in line with the PyPI distribution rather than the main branch.

## Issue Type
<!-- delete options below as required -->
- Bug
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated workflow to run on version tag pushes (e.g., v1.0.0) instead of all pushes to the main branch.
  - Improved workflow documentation to reflect the new trigger conditions.
  - Corrected typos and enhanced clarity in contribution guidelines.
  - Added a new section to help users build development documentation locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->