### PR TITLE
Add function to calculate tau at wavelength, not normalised to V-band

### DIFF
--- a/src/synthesizer/emission_models/transformers/dust_attenuation.py
+++ b/src/synthesizer/emission_models/transformers/dust_attenuation.py
@@ -897,7 +897,6 @@ class ParametricLi08(AttenuationLaw):
             float/array-like, float
                 The optical depth.
         """
-
         raise exceptions.UnimplementedFunctionality(
             "ParametricLi08 form is fit to the normalised Alam/Av values"
             "for the different models, so does not make sense to have this"

--- a/src/synthesizer/emission_models/transformers/dust_attenuation.py
+++ b/src/synthesizer/emission_models/transformers/dust_attenuation.py
@@ -60,7 +60,14 @@ class AttenuationLaw(Transformer):
         Transformer.__init__(self, required_params=("tau_v",))
 
     def get_tau(self, *args):
-        """Compute the optical depth."""
+        """Compute the V-band normalised optical depth."""
+        raise exceptions.UnimplementedFunctionality(
+            "AttenuationLaw should not be instantiated directly!"
+            " Instead use one to child models (" + ", ".join(__all__) + ")"
+        )
+
+    def get_tau_at_lam(self, *args):
+        """Compute the optical depth at wavelength."""
         raise exceptions.UnimplementedFunctionality(
             "AttenuationLaw should not be instantiated directly!"
             " Instead use one to child models (" + ", ".join(__all__) + ")"
@@ -676,7 +683,7 @@ class GrainsWD01(AttenuationLaw):
     @accepts(lam=angstrom)
     def get_tau_at_lam(self, lam, interp="slinear"):
         """
-        Calculate V-band normalised optical depth.
+        Calculate optical depth at a wavelength.
 
         Args:
             lam (float/array-like, float)
@@ -863,7 +870,7 @@ class ParametricLi08(AttenuationLaw):
 
         Returns:
             float/array-like, float
-                The optical depth.
+                The V-band normalised optical depth.
         """
         return Li08(
             lam=lam,
@@ -873,3 +880,27 @@ class ParametricLi08(AttenuationLaw):
             bump=self.bump,
             model=self.model,
         )
+
+    @accepts(lam=angstrom)
+    def get_tau_at_lam(self, lam):
+        """
+        Calculate optical depth at a wavelength.
+
+        (Uses the Li_08 function defined above.)
+
+        Args:
+            lam (float/array-like, float)
+                An array of wavelengths or a single wavlength at which to
+                calculate optical depths (in AA, global unit).
+
+        Returns:
+            float/array-like, float
+                The optical depth.
+        """
+
+        raise exceptions.UnimplementedFunctionality(
+            "ParametricLi08 form is fit to the normalised Alam/Av values"
+            "for the different models, so does not make sense to have this"
+            "function. Use other attenuation curve models to get tau_v or Av"
+        )
+

--- a/src/synthesizer/emission_models/transformers/dust_attenuation.py
+++ b/src/synthesizer/emission_models/transformers/dust_attenuation.py
@@ -515,7 +515,7 @@ class Calzetti2000(AttenuationLaw):
         lam_v = 0.55
 
         k_v = 4.05 + 2.659 * (
-        -2.156 + (1.509 / lam_v) - (0.198 / lam_v**2) + (0.011 / lam_v**3)
+            -2.156 + (1.509 / lam_v) - (0.198 / lam_v**2) + (0.011 / lam_v**3)
         )
 
         return k_v * tau_x_v
@@ -903,4 +903,3 @@ class ParametricLi08(AttenuationLaw):
             "for the different models, so does not make sense to have this"
             "function. Use other attenuation curve models to get tau_v or Av"
         )
-

--- a/src/synthesizer/emission_models/transformers/dust_attenuation.py
+++ b/src/synthesizer/emission_models/transformers/dust_attenuation.py
@@ -324,6 +324,7 @@ class PowerLaw(AttenuationLaw):
 def N09Tau(lam, slope, cent_lam, ampl, gamma):
     """
     Generate the transmission curve for the Noll+2009 attenuation curve.
+    (https://ui.adsabs.harvard.edu/abs/2009A%26A...499...69N)
 
     Attenuation curve using a modified version of the Calzetti
     attenuation (Calzetti+2000) law allowing for a varying UV slope
@@ -467,7 +468,7 @@ class Calzetti2000(AttenuationLaw):
 
         Returns:
             float/array-like, float
-                The optical depth.
+                The V-band noramlised optical depth.
         """
         return N09Tau(
             lam=lam,
@@ -476,6 +477,41 @@ class Calzetti2000(AttenuationLaw):
             ampl=self.ampl,
             gamma=self.gamma,
         )
+        
+    @accepts(lam=angstrom)
+    def get_tau_at_lam(self, lam):
+        """
+        Calculate optical depth at a wavelength.
+
+        (Uses the N09Tau function defined above.)
+
+        Args:
+            lam (float/array-like, float)
+                An array of wavelengths or a single wavlength at which to
+                calculate optical depths (in AA, global unit).
+
+        Returns:
+            float/array-like, float
+                The optical depth.
+        """
+        
+        tau_x_v = N09Tau(
+            lam=lam,
+            slope=self.slope,
+            cent_lam=self.cent_lam,
+            ampl=self.ampl,
+            gamma=self.gamma,
+        )
+        
+        # V-band wavelength in micron
+        # Since the N09Tau funciton uses micron
+        lam_v = 0.55
+        
+        k_v = 4.05 + 2.659 * (
+        -2.156 + (1.509 / lam_v) - (0.198 / lam_v**2) + (0.011 / lam_v**3)
+        )
+        
+        return k_v * tau_x_v
 
 
 class MWN18(AttenuationLaw):
@@ -530,6 +566,34 @@ class MWN18(AttenuationLaw):
             fill_value="extrapolate",
         )
         return func(lam) / self.tau_lam_v
+    
+    @accepts(lam=angstrom)
+    def get_tau_at_lam(self, lam, interp="cubic"):
+        """
+        Calculate the optical depth at a wavelength.
+
+        Args:
+            lam (float/array, float)
+                An array of wavelengths or a single wavlength at which to
+                calculate optical depths (in AA, global unit).
+            interp (str)
+                The type of interpolation to use. Can be 'linear', 'nearest',
+                'nearest-up', 'zero', 'slinear', 'quadratic', 'cubic',
+                'previous', or 'next'. 'zero', 'slinear', 'quadratic' and
+                'cubic' refer to a spline interpolation of zeroth, first,
+                second or third order. Uses scipy.interpolate.interp1d.
+
+        Returns:
+            float/array, float
+                The optical depth.
+        """
+        func = interpolate.interp1d(
+            self.data.f.mw_df_lam[::-1],
+            self.data.f.mw_df_chi[::-1],
+            kind=interp,
+            fill_value="extrapolate",
+        )
+        return func(lam)
 
 
 class GrainsWD01(AttenuationLaw):
@@ -600,6 +664,44 @@ class GrainsWD01(AttenuationLaw):
             fill_value="extrapolate",
         )
         out = func(lam) / func(lam_v)
+
+        if np.isscalar(lam):
+            if lam > lam_lims[-1]:
+                out = func(lam_lims[-1])
+        elif np.sum(lam > lam_lims[-1]) > 0:
+            out[(lam > lam_lims[-1])] = func(lam_lims[-1])
+
+        return out
+    
+    @accepts(lam=angstrom)
+    def get_tau_at_lam(self, lam, interp="slinear"):
+        """
+        Calculate V-band normalised optical depth.
+
+        Args:
+            lam (float/array-like, float)
+                An array of wavelengths or a single wavlength at which to
+                calculate optical depths (in AA, global unit).
+
+            interp (str)
+                The type of interpolation to use. Can be 'linear', 'nearest',
+                'nearest-up', 'zero', 'slinear', 'quadratic', 'cubic',
+                'previous', or 'next'. 'zero', 'slinear', 'quadratic' and
+                'cubic' refer to a spline interpolation of zeroth, first,
+                second or third order. Uses scipy.interpolate.interp1d.
+
+        Returns:
+            float/array-like, float
+                The optical depth.
+        """
+        lam_lims = np.logspace(2, 8, 10000) * angstrom
+        func = interpolate.interp1d(
+            lam_lims,
+            self.emodel(lam_lims.to_astropy()),
+            kind=interp,
+            fill_value="extrapolate",
+        )
+        out = func(lam)
 
         if np.isscalar(lam):
             if lam > lam_lims[-1]:

--- a/src/synthesizer/emission_models/transformers/dust_attenuation.py
+++ b/src/synthesizer/emission_models/transformers/dust_attenuation.py
@@ -477,7 +477,7 @@ class Calzetti2000(AttenuationLaw):
             ampl=self.ampl,
             gamma=self.gamma,
         )
-        
+
     @accepts(lam=angstrom)
     def get_tau_at_lam(self, lam):
         """
@@ -494,7 +494,7 @@ class Calzetti2000(AttenuationLaw):
             float/array-like, float
                 The optical depth.
         """
-        
+
         tau_x_v = N09Tau(
             lam=lam,
             slope=self.slope,
@@ -502,15 +502,15 @@ class Calzetti2000(AttenuationLaw):
             ampl=self.ampl,
             gamma=self.gamma,
         )
-        
+
         # V-band wavelength in micron
         # Since the N09Tau funciton uses micron
         lam_v = 0.55
-        
+
         k_v = 4.05 + 2.659 * (
         -2.156 + (1.509 / lam_v) - (0.198 / lam_v**2) + (0.011 / lam_v**3)
         )
-        
+
         return k_v * tau_x_v
 
 
@@ -566,7 +566,7 @@ class MWN18(AttenuationLaw):
             fill_value="extrapolate",
         )
         return func(lam) / self.tau_lam_v
-    
+
     @accepts(lam=angstrom)
     def get_tau_at_lam(self, lam, interp="cubic"):
         """
@@ -672,7 +672,7 @@ class GrainsWD01(AttenuationLaw):
             out[(lam > lam_lims[-1])] = func(lam_lims[-1])
 
         return out
-    
+
     @accepts(lam=angstrom)
     def get_tau_at_lam(self, lam, interp="slinear"):
         """


### PR DESCRIPTION
## Issue Type
- Enhancement

I have added a function for the dust attenuation curve to calculate the tau value at a wavelength, that is not normalised to the V-band. This has not been done for the ParametricLi08, since that form is fit to the normalised Alam/Av values and the paper does not give the observed Av for the different forms.

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to directly compute optical depth at specific wavelengths for Calzetti2000, MWN18, and GrainsWD01 attenuation models.
  - Provided clear guidance on model-specific support for optical depth calculations.
  - Improved documentation for these new methods, including usage details and relevant citations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->