### PR TITLE
BUGFIX: Fixing mask type for parametric stars

### DIFF
--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -469,11 +469,11 @@ class Stars(StarsComponent):
         # Broadcast the mask to get a mask for SFZH bins
         if new_mask.size == self.sfzh.shape[0]:
             new_mask = np.outer(
-                new_mask, np.ones(self.sfzh.shape[1], dtype=int)
+                new_mask, np.ones(self.sfzh.shape[1], dtype=bool)
             )
         elif new_mask.size == self.sfzh.shape[1]:
             new_mask = np.outer(
-                np.ones(self.sfzh.shape[0], dtype=int), new_mask
+                np.ones(self.sfzh.shape[0], dtype=bool), new_mask
             )
         elif new_mask.shape == self.sfzh.shape:
             pass  # nothing to do here


### PR DESCRIPTION
A certain branch through the masking logic for a parametric Stars object could yield a mask with integer data type. When this was then used it gets treated as indices not a mask and all hell breaks loose. Thanks to @tHarvey303 for finding this! 

Closes #914

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mask handling in the synthesizer to ensure more accurate masking by using boolean arrays instead of integer arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->