### PR TITLE
Fix unknown pleasures method

### DIFF
--- a/src/synthesizer/imaging/image.py
+++ b/src/synthesizer/imaging/image.py
@@ -781,10 +781,13 @@ class Image(ImagingBase):
         # Calcualate the eventual number of lines.
         nlines = int(data.shape[0] / (data.shape[0] // target_lines))
 
-        # Reshape data to keep the x-axis resolution but reduced number of
-        # lines.
-        new_shape = nlines, data.shape[0] // nlines, data.shape[1], 1
-        data = data.reshape(new_shape).mean(-1).mean(1)
+        # Resample the data to have the same x resolution but nlines y
+        # resolution.
+        data = zoom(
+            data,
+            (nlines / data.shape[0], 1),
+            order=3,
+        )
 
         # Create new Figure with black background
         fig = plt.figure(figsize=figsize, facecolor="black")

--- a/src/synthesizer/imaging/image.py
+++ b/src/synthesizer/imaging/image.py
@@ -754,25 +754,23 @@ class Image(ImagingBase):
             title (str):
                 The title to add to the image. If None no title is added.
         """
-        # extract data
-        data = 1 * self.arr
+        # Extract data
+        data = self.arr
 
-        # normalise to the maximum
+        # Normalise to the maximum and take the log10
         data /= np.max(data)
-
-        # log10
         data = np.log10(data)
 
-        # set any -np.inf values to zero (once renormalised)
+        # Set any -np.inf values to zero (once renormalised)
         data[data == -np.inf] = -np.log10(contrast)
 
-        # define normalising function
+        # Define normalising function
         norm = Normalize(vmin=-np.log10(contrast), vmax=0.0)
 
-        # normalise data
+        # Normalise data
         data = norm(data) * 5
 
-        # set any data <0.0 to zero
+        # Set any data <0.0 to zero
         data[data < 0.0] = 0.0
 
         # Unknown Pleasures works best with about 50 lines so reshape the data


### PR DESCRIPTION
I encountered an issue where `plot_unknown_pelasures` failed. This appear to be due to the resolution of the input image relative to the number of lines required. This PR fixes that by using a more robust resampling of the image to get the number of lines.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the image data preparation process for plotting, resulting in more accurate and visually consistent plots.
  - Enhanced vertical resampling of data for plots, leading to smoother and more precise line rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->