### PR TITLE
fix casting errors

### DIFF
--- a/src/synthesizer/extensions/integration.c
+++ b/src/synthesizer/extensions/integration.c
@@ -110,7 +110,7 @@ static PyObject *trapz_last_axis_integration(PyObject *self, PyObject *args) {
     result_shape[i] = shape[i];
   }
   PyObject *result =
-      c_array_to_numpy(ndim - 1, result_shape, NPY_DOUBLE, integral);
+      (PyObject *)c_array_to_numpy(ndim - 1, result_shape, NPY_DOUBLE, integral);
 
   return result; /* Return the computed integral */
 }
@@ -232,7 +232,7 @@ static PyObject *simps_last_axis_integration(PyObject *self, PyObject *args) {
     result_shape[i] = shape[i];
   }
   PyObject *result =
-      c_array_to_numpy(ndim - 1, result_shape, NPY_DOUBLE, integral);
+      (PyObject *)c_array_to_numpy(ndim - 1, result_shape, NPY_DOUBLE, integral);
 
   return result; /* Return the computed integral */
 }

--- a/src/synthesizer/extensions/weights.c
+++ b/src/synthesizer/extensions/weights.c
@@ -167,7 +167,7 @@ static void weight_loop_cic_omp(struct grid *grid, struct particles *parts,
 
     /* Get local pointers to the particle properties. */
     double *local_part_masses = part_masses + start;
-    int *local_mask = (mask == NULL) ? mask : mask + start;
+    npy_bool *local_mask = (mask == NULL) ? mask : mask + start;
 
     /* Allocate a local output array. */
     double *local_out_arr = calloc(out_size, sizeof(double));
@@ -180,7 +180,7 @@ static void weight_loop_cic_omp(struct grid *grid, struct particles *parts,
     for (int p = 0; p < end - start; p++) {
 
       /* Skip if this particle is masked. */
-      if (local_mask != NULL && !local_mask[p]) {
+      if (local_mask != NULL && !(int)local_mask[p]) {
         continue;
       }
 


### PR DESCRIPTION
There were some casting errors between numpy types when compiling with gcc 14.1.0. This PR fixes those instances.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type handling in array integration and weighting operations, ensuring more robust and consistent behavior when processing data arrays and masks. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->