### PR TITLE
Clearer error in imaging

### DIFF
--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -1232,6 +1232,14 @@ class BaseGalaxy:
                 "Parametric Galaxies can only produce smoothed images."
             )
 
+        # Ensure we aren't trying to make an image for a particle galaxy
+        # without a per particle model
+        if self.galaxy_type == "Particle" and not emission_model.per_particle:
+            raise exceptions.InconsistentArguments(
+                "Particle Galaxies can only produce images from per particle "
+                "emission models."
+            )
+
         # If we haven't got an instrument create one
         # TODO: we need to eventually fully pivot to taking only an instrument
         # this will be done when we introduced some premade instruments
@@ -1423,6 +1431,14 @@ class BaseGalaxy:
         if self.galaxy_type == "Parametric" and img_type == "hist":
             raise exceptions.InconsistentArguments(
                 "Parametric Galaxies can only produce smoothed images."
+            )
+
+        # Ensure we aren't trying to make an image for a particle galaxy
+        # without a per particle model
+        if self.galaxy_type == "Particle" and not emission_model.per_particle:
+            raise exceptions.InconsistentArguments(
+                "Particle Galaxies can only produce images from per particle "
+                "emission models."
             )
 
         # If we haven't got an instrument create one


### PR DESCRIPTION
Recently, there was an issue where a user was getting an error from the imaging that was rooted in the fact their model was not a `per_particle` model. This should have had a high-level catch, but did not. Now it does.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation to ensure that particle galaxies only generate images when using per-particle emission models, providing clearer error messages for inconsistent configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->