### PR TITLE
Cloudy nend

### DIFF
--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -705,7 +705,7 @@ class Grid:
                 self._reprocessed = old_grids or new_grid
 
         return self._reprocessed
-
+    
     @property
     def lines_available(self):
         """Flag for whether line emission exists.
@@ -848,6 +848,11 @@ class Grid:
 
         return formatter.get_table("Grid")
 
+    @property
+    def axes_values(self):
+        """Returns the grid axes values."""
+        return self._axes_values    
+    
     @property
     def shape(self):
         """Return the shape of the grid."""

--- a/src/synthesizer/photoionisation/cloudy23.py
+++ b/src/synthesizer/photoionisation/cloudy23.py
@@ -153,6 +153,9 @@ def create_cloudy_input(
         "stop_efrac": None,
         # log10(N_H/cm^2), if not provided the command is not used
         "stop_column_density": None,
+        # sets the default limit to the number of zones
+        # that will be computed, default is 1400
+        "nend": None,
         # K, if not provided the command is not used
         "T_floor": None,
         # Hydrogen density
@@ -430,6 +433,9 @@ def create_cloudy_input(
         # For some horrible reason the above is ignored in favour of a
         # built in temperature stop (4000K) unless that is turned off.
         cinput.append("stop temperature off\n")
+    
+    if params["nend"] is not None:
+        cinput.append(f"set nend {params['nend']}\n")
 
     # --- output commands
 


### PR DESCRIPTION
## Issue Type
- Enhancement

I have added option to add the number of zones in cloudy calculation, this determines the adaptive size of the zones that the calculation will use. 
Also added axes_values property to grid.py for use in grid-generation

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
