### PR TITLE
BUGFIX: Fixing missing fnu error

### DIFF
--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1160,7 +1160,7 @@ class Sed:
         """
         # Ensure fluxes actually exist
         if (self.obslam is None) | (self.fnu is None):
-            return ValueError(
+            raise ValueError(
                 (
                     "Fluxes not calculated, run `get_fnu` or "
                     "`get_fnu0` for observer frame or rest-frame "

--- a/src/synthesizer/imaging/extensions/image.cpp
+++ b/src/synthesizer/imaging/extensions/image.cpp
@@ -451,7 +451,6 @@ PyObject *make_img(PyObject *self, PyObject *args) {
   populate_smoothed_image(pix_values, smoothing_lengths, pos, kernel, res,
                           npix_x, npix_y, npart, threshold, kdim, img, nimgs,
                           nthreads);
-  printf("Populated image");
 
   toc("Computing smoothed image", start_time);
 


### PR DESCRIPTION
Instead of raising an error, a method for particle photometry returned the error... this led to a nightmare of debugging 😂.  Also removes a rogue `printf`

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for flux density calculations to ensure errors are properly raised and can be caught by calling code.

- **Chores**
  - Removed an unnecessary debug print statement from image processing to reduce console clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->