### PR TITLE
Enable loading grids without spectra or ignoring spectra

### DIFF
--- a/docs/source/emission_grids/grids_example.ipynb
+++ b/docs/source/emission_grids/grids_example.ipynb
@@ -180,13 +180,16 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "67d20f67",
    "metadata": {},
    "source": [
     "### Passing wavelength limits\n",
     "\n",
-    "If you don't want to modify the underlying grid resolution, but only care about a specific wavelength range, you can pass limits to truncate the grid at."
+    "If you don't want to modify the underlying grid resolution, but only care about a specific wavelength range, you can pass limits to truncate the grid at.\n",
+    "\n",
+    "Note however, this may result in line quantities outside that range no longer been available."
    ]
   },
   {
@@ -199,6 +202,33 @@
     "# Create a new grid\n",
     "grid = Grid(\"test_grid\", lam_lims=(10**3 * angstrom, 10**4 * angstrom))\n",
     "print(grid.shape)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "6905164e",
+   "metadata": {},
+   "source": [
+    "### Ignoring spectra or lines\n",
+    "\n",
+    "It is also possible to ignore spectra or lines. This can be useful if, for example, you have a large multi-dimensional grid and only want lines or spectra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c17cad3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a new grid without spectra\n",
+    "grid = Grid(\"test_grid\", ignore_spectra=True)\n",
+    "\n",
+    "print(grid.available_spectra)\n",
+    "\n",
+    "# Create a new grid without lines\n",
+    "grid = Grid(\"test_grid\", ignore_lines=True)"
    ]
   },
   {

--- a/docs/source/emission_grids/grids_example.ipynb
+++ b/docs/source/emission_grids/grids_example.ipynb
@@ -189,7 +189,7 @@
     "\n",
     "If you don't want to modify the underlying grid resolution, but only care about a specific wavelength range, you can pass limits to truncate the grid at.\n",
     "\n",
-    "Note however, this may result in line quantities outside that range no longer been available."
+    "Note however, this may result in line quantities outside that range no longer being available."
    ]
   },
   {
@@ -212,7 +212,7 @@
    "source": [
     "### Ignoring spectra or lines\n",
     "\n",
-    "It is also possible to ignore spectra or lines. This can be useful if, for example, you have a large multi-dimensional grid and only want lines or spectra."
+    "It is also possible to ignore spectra or lines. This can be useful if, for example, you have a large multi-dimensional grid and only want to consider lines since these are much smaller in memory."
    ]
   },
   {

--- a/docs/source/emission_models/dust_emission.ipynb
+++ b/docs/source/emission_models/dust_emission.ipynb
@@ -216,7 +216,7 @@
     "from synthesizer.grid import Grid\n",
     "\n",
     "grid_name = \"draine_li_dust_emission_grid_MW_3p1.hdf5\"\n",
-    "grid = Grid(grid_name, read_lines=False)\n",
+    "grid = Grid(grid_name)\n",
     "print(grid.axes)"
    ]
   },

--- a/examples/grids/plot_line_cont.py
+++ b/examples/grids/plot_line_cont.py
@@ -16,7 +16,7 @@ from synthesizer.grid import Grid
 # define grid
 grid_name = "test_grid"
 
-grid = Grid(grid_name, read_lines=True)
+grid = Grid(grid_name)
 
 # define grid point
 grid_point = grid.get_grid_point(log10ages=6.5, metallicity=0.01)

--- a/examples/grids/plot_lines.py
+++ b/examples/grids/plot_lines.py
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     grid_name = "test_grid"
 
     # initialise grid
-    grid = Grid(grid_name, read_lines=True)
+    grid = Grid(grid_name)
 
     # get list of lines
     print(grid.available_lines)

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -57,7 +57,7 @@ class Extraction:
             raise exceptions.MissingSpectraType(
                 f"The Grid does not contain the key '{extract}' "
                 f"(available types for spectra are {grid.available_spectra}"
-                f"and for lines: {grid.lines_lums.keys()})"
+                f"and for lines: {grid.line_lums.keys()})"
             )
 
         # Should the emission take into account the velocity shift due to

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -53,10 +53,11 @@ class Extraction:
         self._extract = extract
 
         # Ensure the grid has the right key
-        if extract not in grid.spectra and extract not in grid.lines:
+        if extract not in grid.spectra and extract not in grid.line_lums:
             raise exceptions.MissingSpectraType(
                 f"The Grid does not contain the key '{extract}' "
-                f"(available types are {grid.available_spectra}."
+                f"(available types for spectra are {grid.available_spectra}"
+                f"and for lines: {grid.lines_lums.keys()})"
             )
 
         # Should the emission take into account the velocity shift due to

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -486,7 +486,7 @@ class Grid:
 
         # If a full cloudy grid is available calculate some
         # other spectra for convenience.
-        if (self.reprocessed is True) and (spectra_to_read is not None):
+        if self.reprocessed is True:
             # The total emission (ignoring any dust reprocessing) is just
             # the transmitted plus the nebular
             self.spectra["total"] = (

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -104,8 +104,9 @@ class Grid:
         self,
         grid_name,
         grid_dir=None,
+        ignore_spectra=False,
         spectra_to_read=None,
-        read_lines=True,
+        ignore_lines=False,
         new_lam=None,
         lam_lims=(),
     ):
@@ -120,12 +121,13 @@ class Grid:
                 hdf5 is assumed).
             grid_dir (str):
                 The file path to the directory containing the grid file.
+            ignore_spectra (bool):
+                Should we ignore spectra?
             spectra_to_read (list):
                 A list of spectra to read in. If None then all available
                 spectra will be read. Default is None.
-            read_lines (bool):
-                Should we read lines? If a list then a subset of lines will be
-                read.
+            ignore_lines (bool):
+                Should we ignore lines?
             new_lam (np.ndarray of float):
                 An optional user defined wavelength array the spectra will be
                 interpolated onto, see Grid.interp_spectra.
@@ -172,22 +174,20 @@ class Grid:
         # Get the ionising luminosity (if available)
         self._get_ionising_luminosity()
 
-        # We always read spectra, but can read a subset if requested
-        self.lam = None
-        self.available_spectra = None
-        self._get_spectra_grid(spectra_to_read)
+        # Read in spectra
+        if not ignore_spectra:
+            self.lam = None
+            self.available_spectra = None
+            self._get_spectra_grid(spectra_to_read)
 
-        # Prepare lines attributes
-        self.available_lines = []
+            # Prepare the wavelength axis (if new_lam and lam_lims are
+            # all None, this will do nothing, leaving the grid's wavelength
+            # array as it is in the HDF5 file)
+            self._prepare_lam_axis(new_lam, lam_lims)
 
-        # Read in lines
-        if read_lines or isinstance(read_lines, list):
-            self._get_lines_grid(read_lines)
-
-        # Prepare the wavelength axis (if new_lam and lam_lims are
-        # all None, this will do nothing, leaving the grid's wavelength array
-        # as it is in the HDF5 file)
-        self._prepare_lam_axis(new_lam, lam_lims)
+        # Read in lines but only if the grid has been reprocessed
+        if (not ignore_lines) and (self.reprocessed):
+            self._get_lines_grid()
 
     def _parse_grid_path(self, grid_dir, grid_name):
         """Parse the grid path and set the grid directory and filename."""
@@ -477,16 +477,17 @@ class Grid:
                     "containing a subset of spectra to read."
                 )
 
-            # Read the wavelengths
-            self.lam = hf["spectra/wavelength"][:]
+            if spectra_to_read is not None:
+                # Read the wavelengths
+                self.lam = hf["spectra/wavelength"][:]
 
-            # Get all our spectra
-            for spectra_id in self.available_spectra:
-                self.spectra[spectra_id] = hf["spectra"][spectra_id][:]
+                # Get all our spectra
+                for spectra_id in self.available_spectra:
+                    self.spectra[spectra_id] = hf["spectra"][spectra_id][:]
 
         # If a full cloudy grid is available calculate some
         # other spectra for convenience.
-        if self.reprocessed:
+        if (self.reprocessed is True) and (spectra_to_read is not None):
             # The total emission (ignoring any dust reprocessing) is just
             # the transmitted plus the nebular
             self.spectra["total"] = (
@@ -501,14 +502,8 @@ class Grid:
             )
             self.available_spectra.append("nebular_continuum")
 
-    def _get_lines_grid(self, read_lines):
-        """Get the lines grid from the HDF5 file.
-
-        Args:
-            read_lines (bool/list):
-                Flag for whether to read all available lines or subset of
-                lines to read.
-        """
+    def _get_lines_grid(self):
+        """Get the lines grid from the HDF5 file."""
         # Double check we actually have lines to read
         if not self.lines_available:
             if not self.reprocessed:
@@ -531,30 +526,6 @@ class Grid:
             self.available_lines = np.array(
                 [id.decode("utf-8") for id in hf["lines"]["id"][:]]
             )
-
-            # Read the line wavelengths
-            lams = hf["lines"]["wavelength"][...]
-            lam_units = hf["lines"]["wavelength"].attrs.get("Units")
-            self.line_lams = unyt_array(lams, lam_units).to(angstrom)
-
-            # Check the lines are within the wavelength range of the grid. Its
-            # not a big issue if any are outside the range but we should warn
-            # the user since it could lead to confusion.
-            lines_outside_lam = []
-            for ind, line in enumerate(self.available_lines):
-                if (
-                    self.line_lams[ind] < self.lam[0]
-                    or self.line_lams[ind] > self.lam[-1]
-                ):
-                    lines_outside_lam.append(line)
-
-            # If we have lines outside the wavelength range of the grid
-            # warn the user
-            if len(lines_outside_lam) > 0:
-                warn(
-                    "The following lines are outside the wavelength "
-                    f"range of the grid: {lines_outside_lam}"
-                )
 
             # Get the units, we only do this once since all the
             # luminosities and continuums will have the same units
@@ -605,61 +576,87 @@ class Grid:
             )
 
             # Now that we have read the line data itself we need to populate
-            # the other spectra entries. the line luminosities for all entries
-            # other than nebular are 0 but the continuums need to be sampled
-            # from the spectra.
-            for spectra in self.available_spectra:
-                # Define the extraction key
-                extract = spectra
+            # the other spectra entries, if any exist. the line luminosities
+            # for all entries other than nebular are 0 but the continuums
+            # need to be sampled from the spectra.
 
-                # Skip those we have already read
-                if extract in self.line_conts:
-                    continue
+            # Before doing this though, we need to check the lines are within
+            # the wavelength range of the grid. Its not a big issue if any are
+            # outside the range but we should warn the user since it could lead
+            # to confusion.
 
-                # Create an interpolation function for this spectra
-                interp_func = interp1d(
-                    self._lam,
-                    self.spectra[extract],
-                    axis=-1,
-                    kind="linear",
-                    fill_value=0.0,
-                    bounds_error=False,
-                )
+            if self.available_spectra:
+                lines_outside_lam = []
+                for ind, line in enumerate(self.available_lines):
+                    if (
+                        self.line_lams[ind] < self.lam[0]
+                        or self.line_lams[ind] > self.lam[-1]
+                    ):
+                        lines_outside_lam.append(line)
 
-                # Get the continuum luminosities by interpolating the to get
-                # the continuum at the line wavelengths (we use scipy here
-                # because spectres can't handle single value interpolation).
-                # The linecont continuum is explicitly 0 and set above.
-                self.line_conts[spectra] = unyt_array(
-                    interp_func(self.line_lams),
-                    cont_units,
-                )
-
-                # Set the line luminosities to 0 as long as they haven't
-                # already been set
-                self.line_lums[spectra] = unyt_array(
-                    np.zeros((*self.spectra[spectra].shape[:-1], self.nlines)),
-                    lum_units,
-                )
-
-            # Ensure the line luminosities and continuums are contiguous
-            for spectra in self.available_spectra:
-                lum_units = self.line_lums[spectra].units
-                cont_units = self.line_conts[spectra].units
-                self.line_lums[spectra] = (
-                    np.ascontiguousarray(
-                        self.line_lums[spectra],
-                        dtype=np.float64,
+                # If we have lines outside the wavelength range of the grid
+                # warn the user
+                if len(lines_outside_lam) > 0:
+                    warn(
+                        "The following lines are outside the wavelength "
+                        f"range of the grid: {lines_outside_lam}"
                     )
-                    * lum_units
-                )
-                self.line_conts[spectra] = (
-                    np.ascontiguousarray(
-                        self.line_conts[spectra],
-                        dtype=np.float64,
+
+                for spectra in self.available_spectra:
+                    # Define the extraction key
+                    extract = spectra
+
+                    # Skip those we have already read
+                    if extract in self.line_conts:
+                        continue
+
+                    # Create an interpolation function for this spectra
+                    interp_func = interp1d(
+                        self._lam,
+                        self.spectra[extract],
+                        axis=-1,
+                        kind="linear",
+                        fill_value=0.0,
+                        bounds_error=False,
                     )
-                    * cont_units
-                )
+
+                    # Get the continuum luminosities by interpolating the to
+                    # get the continuum at the line wavelengths (we use scipy
+                    # here because spectres can't handle single value
+                    # interpolation). The linecont continuum is explicitly 0
+                    # and set above.
+                    self.line_conts[spectra] = unyt_array(
+                        interp_func(self.line_lams),
+                        cont_units,
+                    )
+
+                    # Set the line luminosities to 0 as long as they haven't
+                    # already been set
+                    self.line_lums[spectra] = unyt_array(
+                        np.zeros(
+                            (*self.spectra[spectra].shape[:-1], self.nlines)
+                        ),
+                        lum_units,
+                    )
+
+                # Ensure the line luminosities and continuums are contiguous
+                for spectra in self.available_spectra:
+                    lum_units = self.line_lums[spectra].units
+                    cont_units = self.line_conts[spectra].units
+                    self.line_lums[spectra] = (
+                        np.ascontiguousarray(
+                            self.line_lums[spectra],
+                            dtype=np.float64,
+                        )
+                        * lum_units
+                    )
+                    self.line_conts[spectra] = (
+                        np.ascontiguousarray(
+                            self.line_conts[spectra],
+                            dtype=np.float64,
+                        )
+                        * cont_units
+                    )
 
     def _prepare_lam_axis(
         self,

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -122,12 +122,12 @@ class Grid:
             grid_dir (str):
                 The file path to the directory containing the grid file.
             ignore_spectra (bool):
-                Should we ignore spectra?
+                Should we ignore spectra (i.e. not load them into the Grid)?
             spectra_to_read (list):
                 A list of spectra to read in. If None then all available
                 spectra will be read. Default is None.
             ignore_lines (bool):
-                Should we ignore lines?
+                Should we ignore lines  (i.e. not load them into the Grid)?
             new_lam (np.ndarray of float):
                 An optional user defined wavelength array the spectra will be
                 interpolated onto, see Grid.interp_spectra.
@@ -186,7 +186,7 @@ class Grid:
             self._prepare_lam_axis(new_lam, lam_lims)
 
         # Read in lines but only if the grid has been reprocessed
-        if (not ignore_lines) and (self.reprocessed):
+        if not ignore_lines and self.reprocessed:
             self._get_lines_grid()
 
     def _parse_grid_path(self, grid_dir, grid_name):

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -527,6 +527,11 @@ class Grid:
                 [id.decode("utf-8") for id in hf["lines"]["id"][:]]
             )
 
+            # Read the line wavelengths
+            lams = hf["lines"]["wavelength"][...]
+            lam_units = hf["lines"]["wavelength"].attrs.get("Units")
+            self.line_lams = unyt_array(lams, lam_units).to(angstrom)
+
             # Get the units, we only do this once since all the
             # luminosities and continuums will have the same units
             lum_units = hf["lines"]["luminosity"].attrs.get("Units")
@@ -639,24 +644,24 @@ class Grid:
                         lum_units,
                     )
 
-                # Ensure the line luminosities and continuums are contiguous
-                for spectra in self.available_spectra:
-                    lum_units = self.line_lums[spectra].units
-                    cont_units = self.line_conts[spectra].units
-                    self.line_lums[spectra] = (
-                        np.ascontiguousarray(
-                            self.line_lums[spectra],
-                            dtype=np.float64,
-                        )
-                        * lum_units
+            # Ensure the line luminosities and continuums are contiguous
+            for spectra in self.line_lums.keys():
+                lum_units = self.line_lums[spectra].units
+                cont_units = self.line_conts[spectra].units
+                self.line_lums[spectra] = (
+                    np.ascontiguousarray(
+                        self.line_lums[spectra],
+                        dtype=np.float64,
                     )
-                    self.line_conts[spectra] = (
-                        np.ascontiguousarray(
-                            self.line_conts[spectra],
-                            dtype=np.float64,
-                        )
-                        * cont_units
+                    * lum_units
+                )
+                self.line_conts[spectra] = (
+                    np.ascontiguousarray(
+                        self.line_conts[spectra],
+                        dtype=np.float64,
                     )
+                    * cont_units
+                )
 
     def _prepare_lam_axis(
         self,

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -477,13 +477,12 @@ class Grid:
                     "containing a subset of spectra to read."
                 )
 
-            if spectra_to_read is not None:
-                # Read the wavelengths
-                self.lam = hf["spectra/wavelength"][:]
+            # Read the wavelengths
+            self.lam = hf["spectra/wavelength"][:]
 
-                # Get all our spectra
-                for spectra_id in self.available_spectra:
-                    self.spectra[spectra_id] = hf["spectra"][spectra_id][:]
+            # Get all our spectra
+            for spectra_id in self.available_spectra:
+                self.spectra[spectra_id] = hf["spectra"][spectra_id][:]
 
         # If a full cloudy grid is available calculate some
         # other spectra for convenience.


### PR DESCRIPTION
- renames `read_lines` flag to `ignore_lines` set to False by default. 
- adds a condition so it doesn't read lines if the grid doesn't contain any.
- add a flag `ignore_spectra` to ignore spectra.
- At the moment, ignoring spectra will leave lines missing the incident type, which will affect some emission models. However, this has been added to the grid creation package so will work with the next set of grids.
- Removed cases of `read_lines=True` in the examples and docs.
- Added a section to the docs.


## Issue Type
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced notebook documentation with new explanatory text, usage notes, and additional example code for grid usage and behavior when truncating by wavelength.
  - Added a new section demonstrating how to ignore spectra or lines when creating grids.

- **New Features**
  - Introduced the ability to ignore spectra or lines when initializing grids, providing more flexible grid creation options.

- **Refactor**
  - Updated parameter names and logic for grid initialization to improve clarity and consistency.
  - Improved error messages and validation for extraction keys.

- **Style**
  - Streamlined example scripts and documentation by removing unnecessary arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->