### PR TITLE
BUGFIX: Two minor bug fixes to parametric stars methods

### DIFF
--- a/src/synthesizer/parametric/sf_hist.py
+++ b/src/synthesizer/parametric/sf_hist.py
@@ -36,7 +36,8 @@ parametrisations = (
     "Exponential",
     "TruncatedExponential",
     "DecliningExponential",
-    "DelayedExponentialLogNormal",
+    "DelayedExponential",
+    "LogNormal",
     "DoublePowerLaw",
     "DenseBasis",
 )

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -924,10 +924,10 @@ class Stars(StarsComponent):
             )
 
         # Get the attribute and the weights
-        attr = getattr(self, attr)
         if "age" in attr:
             weight = self.sf_hist
         else:
             weight = self.metal_dist
+        attr = getattr(self, attr)
 
         return weighted_mean(attr, weight)


### PR DESCRIPTION
1. Error in list of parametric SFHs due to typo.
2. Logical issue in `Stars.get_weighted_attr` due to ambiguous nature of `attr` variable. This meant weighted age methods (e.g. `get_mass_weighted_age()`) were broken. `attr` was referenced as a string after it had been replaced by the attribute it represented.

Both very minor, but since I fixed them in my local branch I figured I should just push them. 

## Issue Type
- Bug



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the list of available star formation history parametrisations to separately include "DelayedExponential" and "LogNormal" options.

* **Bug Fixes**
  * Improved attribute handling logic for weighted mean calculations, ensuring more accurate selection of weighting arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->