### PR TITLE
Add load_Simba_slab function for loading cuboid regions

### DIFF
--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -12,6 +12,7 @@ from astropy.cosmology import FlatLambdaCDM
 from unyt import Mpc, Msun, km, kpc, s, yr
 
 from synthesizer.load_data.utils import age_lookup_table, lookup_age
+from synthesizer.synth_warnings import warn
 
 from ..particle.galaxy import Galaxy
 from ..particle.particles import Particles
@@ -307,7 +308,7 @@ def load_Simba_slab(
             )
 
             if np.sum(star_mask) == 0:
-                print("Warning: No star particles found in specified region")
+                warn("No star particles found in specified region")
 
             # Load star data for selected particles
             form_time = hf["PartType4/StellarFormationTime"][:][star_mask]
@@ -321,7 +322,7 @@ def load_Simba_slab(
             gas_coords_raw = hf["PartType0/Coordinates"][:]
             gas_coords = (
                 gas_coords_raw * scale_factor / h
-            )  # Convert to physical Mpc
+            )  # Convert to physical kpc
 
             # Select gas particles within bounds
             gas_mask = (
@@ -334,7 +335,7 @@ def load_Simba_slab(
             )
 
             if np.sum(gas_mask) == 0:
-                print("Warning: No gas particles found in specified region")
+                warn("No gas particles found in specified region")
 
             # Load gas data for selected particles
             g_masses = hf["PartType0/Masses"][:][gas_mask]
@@ -352,7 +353,7 @@ def load_Simba_slab(
             dm_coords_raw = hf["PartType1/Coordinates"][:]
             dm_coords = (
                 dm_coords_raw * scale_factor / h
-            )  # Convert to physical Mpc
+            )  # Convert to physical kpc
 
             # Select dark matter particles within bounds
             dm_mask = (
@@ -365,10 +366,7 @@ def load_Simba_slab(
             )
 
             if np.sum(dm_mask) == 0:
-                print(
-                    "Warning: No dark matter particles found in "
-                    "specified region"
-                )
+                warn("No dark matter particles found in specified region")
 
             # Load dark matter data for selected particles
             dm_masses = hf["PartType1/Masses"][:][dm_mask]


### PR DESCRIPTION
- New function to load particles from a specified cuboid region
- Supports optional loading of stars, gas, and dark matter particles
- Returns single Galaxy object containing all particles in region
- Includes proper unit conversions and stellar age calculations
- Handles empty regions gracefully with warnings

🤖 Generated with [Claude Code](https://claude.ai/code)

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to load all particles within a specified cuboid region from a Simba simulation snapshot into a single object, regardless of galaxy membership. Users can specify spatial bounds and select which particle types (stars, gas, dark matter) to include.

* **Improvements**
  * Improved initialization of galaxy centers and updated handling of galaxy positions for increased accuracy.
  * Enhanced particle data loading with detailed properties and unit conversions for more precise analysis.
  * Added warnings to inform users when no particles are found in the specified region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->