### PR TITLE
Ensure models have unique names

### DIFF
--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -718,9 +718,17 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
             # The model is already in the tree so nothing to do
             pass
         else:
-            raise exceptions.InconsistentArguments(
-                f"Label {model.label} is already in use."
-            )
+            # Ensure model has a unique name
+            if len(self.masks) > 0:
+                model.label += (
+                    f"_{self.masks['mask_attr']}_"
+                    f"{self.masks['mask_op']}_"
+                    f"{self.masks['mask_thresh']}"
+                )
+            else:
+                model.label += "_B"
+
+            self._models[model.label] = model
 
         # If we are extracting an emission, store the key
         if model._is_extracting:

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -719,7 +719,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
             pass
         else:
             # Ensure model has a unique name
-            if len(self.masks) > 0:
+            if len(model.masks) > 0:
                 model.label += (
                     f"_{self.masks['mask_attr']}_"
                     f"{self.masks['mask_op']}_"

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -720,13 +720,16 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
         else:
             # Ensure model has a unique name
             if len(model.masks) > 0:
-                model.label += (
-                    f"_{self.masks['mask_attr']}_"
-                    f"{self.masks['mask_op']}_"
-                    f"{self.masks['mask_thresh']}"
-                )
+                for _m in model.masks:
+                    model.label += (
+                        f"_{_m['mask_attr']}_"
+                        f"{_m['mask_op']}_"
+                        f"{_m['mask_thresh']}"
+                    )
             else:
-                model.label += "_B"
+                raise exceptions.InconsistentArguments(
+                    f"Label {model.label} is already in use."
+                )
 
             self._models[model.label] = model
 


### PR DESCRIPTION
Fixes a bug where sub-models with different masks would lead to errors since they had identical model names.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of duplicate model labels to prevent errors by automatically generating unique labels when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->