### PR TITLE
my beloved flam

### DIFF
--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -503,7 +503,17 @@ class Sed:
             flux (unyt_array):
                 The spectral flux density per Angstrom array.
         """
-        return self.obsnu * self.fnu / self.obslam
+        return (self.obsnu * self.fnu / self.obslam).to("erg/s/cm**2/angstrom")
+
+    @property
+    def _flam(self):
+        """Get the unitless spectral flux density per Angstrom.
+
+        Returns:
+            flux (np.ndarray):
+                The unitless spectral flux density per Angstrom array.
+        """
+        return self.flam.value
 
     @property
     def luminosity_nu(self):


### PR DESCRIPTION
Fixed unit + unitless flam


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to access unitless spectral flux density per Angstrom as a plain NumPy array.

* **Improvements**
  * Spectral flux density per Angstrom is now explicitly provided in "erg/s/cm²/angstrom" units for greater clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->