### PR TITLE
Temporarily switching to a fork of dust_extinction to avoid setuptools-scm error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "scipy",
   "unyt",
   "cmasher",
-  "dust_extinction",
+  "dust_extinction @ git+https://github.com/WillJRoper/dust_extinction.git@master#egg=dust_extinction",
   "matplotlib",
   "spectres",
   "tqdm",


### PR DESCRIPTION
DWISOTT 

Open PR fix [here](https://github.com/karllark/dust_extinction/pull/255).

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
