### PR TITLE
work with single lam and add limits to Li08 docs

### DIFF
--- a/src/synthesizer/emission_models/transformers/dust_attenuation.py
+++ b/src/synthesizer/emission_models/transformers/dust_attenuation.py
@@ -395,11 +395,9 @@ def N09Tau(lam, slope, cent_lam, ampl, gamma):
     tau_x_v = (k_lam + D_lam) / k_v
     tau_x = tau_x_v * (_lam.value / lam_v) ** slope
 
-    func = interpolate.interp1d(_lam, tau_x, bounds_error=False, fill_value=(tau_x[0], tau_x[-1]))
-    # out = np.zeros(len(lam))
-    # ok = lam.to("um") < 3.1 * um
-    # out[ok] = func(lam[ok].to("um"))
-    # out[~ok] = tau_x[-1]
+    func = interpolate.interp1d(
+        _lam, tau_x, bounds_error=False, fill_value=(tau_x[0], tau_x[-1])
+    )
 
     return func(lam.to("um"))
 
@@ -773,9 +771,9 @@ class ParametricLi08(AttenuationLaw):
 
     Attributes:
         UV_slope (float):
-            Dimensionless parameter describing the UV-FUV slope (0, 50) 
+            Dimensionless parameter describing the UV-FUV slope (0, 50)
         OPT_NIR_slope (float):
-            Dimensionless parameter describing the optical/NIR slope (0, 10) 
+            Dimensionless parameter describing the optical/NIR slope (0, 10)
         FUV_slope (float):
             Dimensionless parameter describing the FUV slope (-1, 75)
         bump (float):
@@ -793,15 +791,16 @@ class ParametricLi08(AttenuationLaw):
         OPT_NIR_slope=7.56,
         FUV_slope=61.2,
         bump=0.0,
-        model='Calzetti',
+        model="Calzetti",
     ):
         """Initialise the dust curve.
 
         Args:
             UV_slope (float):
-                Dimensionless parameter describing the UV-FUV slope (0, 50) 
+                Dimensionless parameter describing the UV-FUV slope (0, 50)
             OPT_NIR_slope (float):
-                Dimensionless parameter describing the optical/NIR slope (0, 10) 
+                Dimensionless parameter describing the optical/NIR
+                slope (0, 10)
             FUV_slope (float):
                 Dimensionless parameter describing the FUV slope (-1, 75)
             bump (float):


### PR DESCRIPTION
## Issue Type
- Bug
- Document

The correction implemented to Calzetti curve had a bug that it did not work with single wavelengths. 
Also added in the docstring sensible limits to ParametricLi08 from Markov+23.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced interpolation for dust attenuation calculations, providing more consistent results across all wavelengths.
  * Updated default parameter values and documentation for dust attenuation model options, offering clearer guidance and improved default behavior for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->