### PR TITLE
Removing fork from dust extinction dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "scipy",
   "unyt",
   "cmasher",
-  "dust_extinction",
+  "dust_extinction>=1.6",
   "matplotlib",
   "spectres",
   "tqdm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "scipy",
   "unyt",
   "cmasher",
-  "dust_extinction @ git+https://github.com/WillJRoper/dust_extinction.git@master#egg=dust_extinction",
+  "dust_extinction",
   "matplotlib",
   "spectres",
   "tqdm",


### PR DESCRIPTION
PyPI version of dust extinction is now updated, so we can revert the fork. 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency management for "dust_extinction" to use the standard package index instead of a direct GitHub reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->