### PR TITLE
Minor change to parametric DenseBasis SFH to improve performance

### DIFF
--- a/src/synthesizer/parametric/sf_hist.py
+++ b/src/synthesizer/parametric/sf_hist.py
@@ -761,7 +761,7 @@ class DenseBasis(Common):
 
         # define these intervals in log space
         finewidths = 10 ** (self.log_finegrid + tbw / 2) - 10 ** (
-            self.finegrid - tbw / 2
+            self.log_finegrid - tbw / 2
         )
 
         # Interpolate the SFH on to finer grid in units of SFR


### PR DESCRIPTION
6x speedup in creating parametric DenseBasis SFHs by not repeatedly calling 10\**self.finegrid in every _sfr loop. Renamed self.finegrid to self.log_fingrid and defined self.finegrid as 10**self.finegrid upon initialization. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved SFH grid handling: spacing defined logarithmically while interpolation and SFR evaluation use a linear age grid, yielding smoother, more consistent star-formation history reconstructions.
  * Refined bin-width and interpolation scaling for more accurate age-resolved results.
  * No changes to public interfaces; existing workflows and APIs remain compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->