### PR TITLE
Fixed the transformation of lines including a wavelength mask

### DIFF
--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2497,6 +2497,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
                         particle_spectra,
                         emitter,
                         this_mask,
+                        self.lam,
                     )
                 except Exception as e:
                     if sys.version_info >= (3, 11):
@@ -2848,6 +2849,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
                         particle_lines,
                         emitter,
                         this_mask,
+                        self.lam,
                     )
                 except Exception as e:
                     if sys.version_info >= (3, 11):

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -711,7 +711,7 @@ class Transformation:
             )
 
             # Translate these indices into a mask
-            lam_mask = np.zeros_like(line_lams, dtype=bool)
+            lam_mask = np.zeros(apply_to.nlines, dtype=bool)
             for i, ind in enumerate(line_indices):
                 if this_model._lam_mask[ind]:
                     lam_mask[i] = True

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -705,9 +705,12 @@ class Transformation:
 
             # Get the indices that would bin the lines into the
             # spectra grid wavelength array
-            line_indices = np.digitize(
-                line_lams,
-                lam,
+            line_indices = (
+                np.digitize(
+                    line_lams,
+                    lam,
+                )
+                - 1
             )
 
             # Translate these indices into a mask

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -280,13 +280,18 @@ class Extraction:
         if this_model._lam_mask is not None:
             # Get the indices that would bin the lines into the
             # spectra grid wavelength array
-            line_indices = np.digitize(
-                extractor._line_lams,
-                extractor._grid.lam,
+            line_indices = (
+                np.digitize(
+                    extractor._line_lams,
+                    extractor._grid.lam,
+                )
+                - 1
             )
 
             # Remove any lines which are masked out in the lam_mask
             for ind in line_indices:
+                if ind < 0 or ind >= this_model._lam_mask.size:
+                    continue
                 if not this_model._lam_mask[ind]:
                     lam_mask[ind] = False
 
@@ -716,6 +721,8 @@ class Transformation:
             # Translate these indices into a mask
             lam_mask = np.zeros(apply_to.nlines, dtype=bool)
             for i, ind in enumerate(line_indices):
+                if ind < 0 or ind >= this_model._lam_mask.size:
+                    continue
                 if this_model._lam_mask[ind]:
                     lam_mask[i] = True
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -712,13 +712,10 @@ class Transformation:
 
             # Get the indices that would bin the lines into the
             # spectra grid wavelength array
-            raw_indices = (
-                np.digitize(
-                    line_lams,
-                    lam,
-                    right=False,
-                )
-                - 1
+            raw_indices = np.digitize(
+                line_lams,
+                lam,
+                right=False,
             )
 
             # Translate these indices into a mask

--- a/src/synthesizer/emissions/line.py
+++ b/src/synthesizer/emissions/line.py
@@ -1131,6 +1131,30 @@ class LineCollection:
         else:
             mask = None
 
+        # Handle some mask munging we have to do to make shapes work
+        if mask is not None:
+            if mask.shape == lum.shape:
+                # If the mask is the same shape as the luminosity we can use it
+                # directly
+                pass
+            elif mask.ndim == 1 and mask.shape[0] == lum.shape[0]:
+                # If the mask is 1D and matches the first dimension of the
+                # luminosity we don't need to do anything
+                pass
+            elif mask.ndim == 1 and mask.shape[0] == lum.shape[-1]:
+                # If the mask is 1D and matches the last dimension of the
+                # luminosity we need to expand it to match the luminosity shape
+                mask = np.broadcast_to(mask[np.newaxis, :], lum.shape)
+            else:
+                # Otherwise, we have an incompatible mask
+                raise exceptions.InconsistentArguments(
+                    f"Mask shape {mask.shape} is incompatible with the"
+                    f" luminosity {lum.shape} or "
+                    f"wavelength {self.lam.shape} "
+                    "wavelength shape. Please provide a mask with the same "
+                    "shape as the luminosity or wavelength."
+                )
+
         # First we will handle the luminosity scaling (we need to do each
         # individually because the scalings can have different dimensions
         # depending on the conversion done above)

--- a/src/synthesizer/emissions/line.py
+++ b/src/synthesizer/emissions/line.py
@@ -1060,7 +1060,7 @@ class LineCollection:
 
         return self._get_ratio(*ab), self._get_ratio(*cd)
 
-    def scale(self, scaling, inplace=False, mask=None, **kwargs):
+    def scale(self, scaling, inplace=False, mask=None, lam_mask=None):
         """Scale the lines by a given factor.
 
         Note: this will only scale the rest frame continuum and luminosity.
@@ -1076,8 +1076,10 @@ class LineCollection:
                 A mask array with an entry for each line. Masked out
                 spectra will not be scaled. Only applicable for
                 multidimensional lines.
-            **kwargs (dict):
-                Additional keyword arguments to pass to the scaling function.
+            lam_mask (array-like, bool):
+                A mask array with an entry for each wavelength bin.
+                Masked out wavelengths will not be scaled. Only applicable
+                for multidimensional lines.
 
         Returns:
             LineCollection
@@ -1112,6 +1114,22 @@ class LineCollection:
         # Unpack the arrays we'll need during the scaling
         lum = self._luminosity.copy()
         cont = self._continuum.copy()
+
+        # Combine the masks if we have both a mask and a wavelength mask
+        if (
+            mask is not None
+            and lam_mask is not None
+            and mask.shape[-1] == lam_mask.shape[0]
+        ):
+            mask = np.logical_and(mask, lam_mask)
+        elif mask is not None and lam_mask is not None:
+            mask = np.logical_and(mask[:, None], lam_mask)
+        elif lam_mask is not None and mask is None:
+            mask = lam_mask
+        elif mask is not None and lam_mask is None:
+            pass
+        else:
+            mask = None
 
         # First we will handle the luminosity scaling (we need to do each
         # individually because the scalings can have different dimensions


### PR DESCRIPTION
The wavelength masks weren't handled properly when scaling a LineCollection in a transformation. This PR fixes this oversight by combining the normal mask (if given) with the wavelength mask.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wavelength-aware emission transformations using a provided wavelength grid.
  * Per-wavelength masking for line emissions, automatically mapped from grid masks to individual lines.
  * Line scaling can be restricted by a wavelength mask and combined with per-line masks (with broadcasting).

* **Bug Fixes**
  * Correct application of grid-based masks to line emissions during transformations.

* **Refactor**
  * Public APIs updated to accept a wavelength grid and wavelength-mask parameters for consistent mask propagation.

* **Documentation**
  * Parameter descriptions updated to reflect wavelength-mask support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->