### PR TITLE
Add internal energy to gas particle properties output in Simba

### DIFF
--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -347,6 +347,7 @@ def load_Simba_slab(
             g_hsml = hf["PartType0/SmoothingLength"][:][gas_mask]
             g_dustmass = hf["PartType0/Dust_Masses"][:][gas_mask]
             g_h2fraction = hf["PartType0/FractionH2"][:][gas_mask]
+            g_internalenergy = hf["PartType0/InternalEnergy"][:][gas_mask]
 
         # Load dark matter particles if requested
         if load_dark_matter:
@@ -449,6 +450,7 @@ def load_Simba_slab(
             smoothing_lengths=g_hsml * kpc,
             dust_masses=g_dustmass * Msun,
             centre=center * kpc,
+            internal_energy=g_internalenergy,
         )
     else:
         galaxy.sf_gas_mass = 0.0 * Msun


### PR DESCRIPTION
DWISOTT.

In future we should probably make these loaders more robust by making these properties optional, either through kwargs or a selection dict.

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gas data loading now captures and assigns internal energy for gas particles from SIMBA datasets, enabling analyses that leverage thermodynamic properties.
  * The gas-loading API now accepts an optional internal energy parameter to populate this data when available; existing usage remains unaffected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->