### PR TITLE
Removed the calculation of unused "total" spectra in Grid

### DIFF
--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -501,8 +501,7 @@ class Grid:
         """Get the spectra grid from the HDF5 file.
 
         If using a cloudy reprocessed grid this method will automatically
-        calculate 2 spectra not native to the grid file:
-            total = transmitted + nebular
+        calculate the nebular continuum spectra not native to the grid file:
             nebular_continuum = nebular - linecont
 
         Args:
@@ -541,12 +540,6 @@ class Grid:
         # If a full cloudy grid is available calculate some
         # other spectra for convenience.
         if self.reprocessed is True:
-            # The total emission (ignoring any dust reprocessing) is just
-            # the transmitted plus the nebular
-            self.spectra["total"] = (
-                self.spectra["transmitted"] + self.spectra["nebular"]
-            )
-
             # The nebular continuum is the nebular emission with the line
             # contribution removed
             self.spectra["nebular_continuum"] = (


### PR DESCRIPTION
Removing the confusing `"total"` key from the `Grid` has no ill effects since it is unused anywhere else in the codebase. This PR removes its calculation entirely. 

Closes #977.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected behavior for reprocessed (cloudy) spectra: the derived “total” spectrum is no longer produced. Only the nebular continuum (nebular minus line continuum) is computed for non-native spectra, preventing misleading combined outputs.
* **Documentation**
  * Updated descriptions to reflect that reprocessed grids now provide only the nebular continuum and not a derived total spectrum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->