### PR TITLE
Fix depleted abundances

### DIFF
--- a/src/synthesizer/photoionisation/cloudy17.py
+++ b/src/synthesizer/photoionisation/cloudy17.py
@@ -190,7 +190,7 @@ def create_cloudy_input(
             cinput.append(
                 (
                     f"element abundance {abundances.element_name[ele]} "
-                    f"{abundances.total[ele]} no grains\n"
+                    f"{abundances.gas[ele]} no grains\n"
                 )
             )
 

--- a/src/synthesizer/photoionisation/cloudy23.py
+++ b/src/synthesizer/photoionisation/cloudy23.py
@@ -193,10 +193,6 @@ def create_cloudy_input(
     # update default_params with kwargs
     params = default_params | kwargs
 
-    # old approach for updated parameters
-    # for key, value in list(kwargs.items()):
-    #     params[key] = value
-
     # begin input list
     cinput = []
 
@@ -216,7 +212,7 @@ def create_cloudy_input(
                 cinput.append(
                     (
                         f"element abundance {abundances.element_name[ele]} "
-                        f"{abundances.total[ele]} no grains\n"
+                        f"{abundances.gas[ele]} no grains\n"
                     )
                 )
 


### PR DESCRIPTION
Fixes a bug in which the abundances used were not depleted but still total.

## Issue Type
- [x] Bug
- Document
- Enhancement



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected element abundances for depletion-model runs without grains — simulations now use gas-phase values for all elements (including helium), improving accuracy.

* **Refactor**
  * Simplified parameter handling by consolidating default and override merging.
  * Removed obsolete commented code for cleaner maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->