### PR TITLE
Nice line labels

### DIFF
--- a/src/synthesizer/emissions/utils.py
+++ b/src/synthesizer/emissions/utils.py
@@ -236,13 +236,55 @@ S2 = aliases["S2"]
 
 # Dictionary of common line labels to use by default
 line_labels = {
-    "O 2 3726.03A,O 2 3728.81A": "[OII]3726,3729",
-    "H 1 4861.32A": r"H\beta",
-    "O 3 4958.91A,O 3 5006.84A": "[OIII]4959,5007",
-    "H 1 6562.80A": r"H\alpha",
-    "O 3 5006.84A": "[OIII]5007",
-    "N 2 6583.45A": "[NII]6583",
+    "C 4 1548.19A,C 4 1550.77A": (
+        r"$[\mathrm{C\,IV}]\,\lambda\lambda1548,1551$"
+    ),
+    "O 3 1660.81A,O 3 1666.15A": (
+        r"$\mathrm{O\,III}]\,\lambda\lambda1661,1666$"
+    ),
+    "C 3 1906.68A,C 3 1908.73A": (
+        r"$\mathrm{C\,III}]\,\lambda\lambda1907,1909$"
+    ),
+    "He 2 1640.41A": r"$\mathrm{He\,II}\,\lambda1640$",
+    "O 2 3726.03A,O 2 3728.81A": (
+        r"$[\mathrm{O\,II}]\,\lambda\lambda3726,3729$"
+    ),
+    "Ne 3 3868.76A": r"$[\mathrm{Ne\,III}]\,\lambda3869$",
+    "H 1 4862.69A": r"$\mathrm{H}\beta$",
+    "O 3 5006.84A": r"$[\mathrm{O\,III}]\,\lambda5007$",
+    "O 3 4958.91A,O 3 5006.84A": (
+        r"$[\mathrm{O\,III}]\,\lambda\lambda4959,5007$"
+    ),
+    "H 1 6564.62A": r"$\mathrm{H}\alpha$",
+    "N 2 6583.45A": r"$[\mathrm{N\,II}]\,\lambda6583$",
+    "O 1 6300.30A": r"$[\mathrm{O\,I}]\,\lambda6300$",
+    "H 1 6562.80A": r"$\mathrm{H}\alpha$",
+    "S 2 6716.44A,S 2 6730.82A": (
+        r"$[\mathrm{S\,II}]\,\lambda\lambda6716,6731$"
+    ),
+    "S 2 6730.82A": r"$[\mathrm{S\,II}]\,\lambda6731$",
+    "S 2 6716.44A": r"$[\mathrm{S\,II}]\,\lambda6716$",
 }
+
+
+def get_line_label(line_id):
+    """Get a nice (LaTeX) line label.
+
+    Checks if the line_id in the
+    line_labels dictionary and otherwise simply returns the line_id.
+
+    Args:
+        line_id (str):
+            The Synthesizer/cloudy line id.
+
+    Returns:
+        line_label (str):
+            The nicely formatted line label.
+    """
+    if line_id in line_labels.keys():
+        return line_labels(line_id)
+    else:
+        return line_id
 
 
 def alias_to_line_id(alias):


### PR DESCRIPTION
Replaces the current line_labels dictionary with more lines and nicer formatting.

Adds a function that grabs this label if available or otherwise returns the line_id.

## Issue Type
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
