### PR TITLE
Adding BH accretion rate calculation when eddington ratio version is provided

### DIFF
--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -208,7 +208,6 @@ class BlackholesComponent(Component):
                 """Both accretion rate and bolometric luminosity provided but
                 that is confusing. Provide one or the other!"""
             )
-
         if (self.accretion_rate_eddington is not None) and (
             self.bolometric_luminosity is not None
         ):
@@ -216,6 +215,17 @@ class BlackholesComponent(Component):
                 """Both accretion rate (in terms of Eddington) and bolometric
                 luminosity provided but that is confusing. Provide one or
                 the other!"""
+            )
+
+        # Ensure that both accretion_rate and accretion_rate_eddington are not
+        # provided, this is also confusing.
+        if (self.accretion_rate is not None) and (
+            self.accretion_rate_eddington is not None
+        ):
+            raise exceptions.InconsistentArguments(
+                """Both accretion rate and accretion rate in terms of
+                Eddington provided but that is confusing. Provide one or the
+                other!"""
             )
 
         # If mass calculate the Eddington luminosity.


### PR DESCRIPTION
Passing the accretion rate in terms of Eddington leads to required attributes not being populated. This fixes this by slightly reordering the property calculation and introducing an explicit calculation of accretion rate to be used when needed. 

Closes #1011 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Automatic calculation of Eddington luminosity when an object mass is provided.
  - Automatic derivation of accretion rate when an Eddington-scaled rate and luminosity are available.
  - Added an on-demand calculation to compute accretion rate from Eddington parameters and radiative efficiency.

- **Bug Fixes**
  - Removed a redundant recalculation during initialization to ensure consistent values and avoid duplicate work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->