### PR TITLE
Catch incompatible emitters passed to an `EmissionModel`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -153,7 +153,7 @@ def bimodal_pacman_emission_model(test_grid):
 @pytest.fixture
 def template_emission_model_bh(test_template):
     """Return a TemplateEmission object."""
-    return TemplateEmission(test_template, "blackhole")
+    return TemplateEmission(test_template, emitter="blackhole")
 
 
 # ================================= IGMS ======================================

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -257,7 +257,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
                 self.
             emitter (str):
                 The emitter this emission model acts on. Default is
-                "galaxy". Can be "stellar", "gas", "black_hole", or "galaxy".
+                "galaxy". Can be "stellar", "gas", "blackhole", or "galaxy".
             scale_by (str/list/tuple/EmissionModel):
                 Either a component attribute to scale the resultant spectra by,
                 a spectra key to scale by (based on the bolometric luminosity).
@@ -308,16 +308,16 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
         if emitter is None:
             raise exceptions.InconsistentArguments(
                 "Must specify an emitter, either 'stellar', 'gas', "
-                "'black_hole', or 'galaxy'."
+                "'blackhole', or 'galaxy'."
             )
 
         # Attach which emitter we are working with
         self._emitter = emitter.lower()
 
         # Ensure emitter is an acceptable value
-        if self._emitter not in ["stellar", "gas", "black_hole", "galaxy"]:
+        if self._emitter not in ["stellar", "gas", "blackhole", "galaxy"]:
             raise exceptions.InconsistentArguments(
-                "Emitter must be either 'stellar', 'gas', 'black_hole', or "
+                "Emitter must be either 'stellar', 'gas', 'blackhole', or "
                 f"'galaxy' (got {self._emitter})."
             )
         elif self._emitter == "gas":


### PR DESCRIPTION
Introduces clear errors and signposts for malformed emitter arguments at the point of `EmissionModel` construction. In particular, it adds a catch for per-particle galaxy models, which was handled on the wrapper class but not the base model. 

This also now requires that an emitter be passed, which I was shocked to see was never checked before. Clearly, it has always been passed, but it needs to be checked. I would have changed it to a positional argument, but that would have changed the order and could be a breaking change.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Galaxy emitter handling in image generation now correctly skips unsupported operations.
  * Prevented invalid per-particle emission configurations for galaxy emitters.

* **Improvements**
  * Enforced strict validation and normalization of emitter types during initialization.
  * Added clearer errors for unsupported emitters (e.g., gas).
  * Wrapper classes now provide sensible default emitters while preserving the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->