### PR TITLE
Introduces a test to verify parametric stars generated from particle stars

### DIFF
--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -631,10 +631,15 @@ def test_param_stars_from_parts(
     stars = random_part_stars
     grid = incident.grid
 
-    spectra = stars.get_spectra(incident, verbose=True)
+    spectra = stars.get_spectra(
+        incident,
+        grid_assignment_method="cic",
+        verbose=True,
+    )
     param_stars = stars.get_sfzh(
         log10ages=grid.log10age,
         log10metallicities=grid.log10metallicity,
+        grid_assignment_method="cic",
     )
     param_spectra = param_stars.get_spectra(incident, verbose=True)
 


### PR DESCRIPTION
A quick test to verify that spectra generated from a particle stars object match the spectra generated from a parametric stars object generated from the particles via `get_sfzh`.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test that compares spectra produced by two different generation methods to ensure their outputs match and validate consistency of the spectrum generation pipeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->