### PR TITLE
Implementing conservative resampling in parametric `get_sfzh` equivalent

### DIFF
--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -710,7 +710,7 @@ class Stars(StarsComponent):
             Stars: New Stars object on the requested grid.
         """
         # If the axes are the same as our existing ones just return our SFZH
-        if np.array_equal(log10ages, self.log10ages) and np.array_equal(
+        if np.allclose(log10ages, self.log10ages) and np.allclose(
             metallicities, self.metallicities
         ):
             return deepcopy(self)


### PR DESCRIPTION
The previous implementation of `get_sfzh` on a parametric stars object hadn't really been used much at all. It turns out this was far from conservative and failed very readily when the requested axes differed greatly from those already on the object. This has now been fixed by using the parametric -> particle -> parametric pattern for resampling.

This is a temporary fix, really, since the entirety of the parametric machinery related to this and spectra extraction should be pivoted to a grid point agnostic "overlay-style" method, but that will come in the future. 

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic particle-based remapping to reparameterize SFZH data onto requested coordinate grids; returns a copy when the requested grid matches the existing grid.

* **Refactor**
  * SFZH retrieval now returns a Stars object on the requested grid instead of a raw array, improving consistency and usability.

* **Documentation**
  * Docstrings updated to describe remapping behavior, new return type, and bin-center interpretation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->