### PR TITLE
Minor fix to warning formatter to stop crash when running in slurm/detached terminal

### DIFF
--- a/src/synthesizer/synth_warnings.py
+++ b/src/synthesizer/synth_warnings.py
@@ -180,6 +180,9 @@ def _wrap_with_prefix(message, stacklevel, category):
     # Subtract some padding for the warning
     width -= 4
 
+    # Ensure width is > 0
+    width = max(1, width)
+
     # Wrap the message
     wrapped = textwrap.fill(
         str(message),


### PR DESCRIPTION
I've had this warning formatter occasionally cause a crash when running a script in slurm or a detached terminal. Just added a simple check to avoid negative widths. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when using small terminal windows by preventing edge case errors during text formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->