### PR TITLE
wrong warning in filter.py/apply_filter when passing galaxy with zero stars

### DIFF
--- a/src/synthesizer/instruments/filters.py
+++ b/src/synthesizer/instruments/filters.py
@@ -1783,7 +1783,8 @@ class Filter:
 
         # Warn and exit if there are no array elements in this band
         if arr_in_band.size == 0:
-            warn(f"{self.filter_code} outside of emission array.")
+            if arr.shape[0] > 0:
+                warn(f"{self.filter_code} outside of emission array.")
             return 0 if arr.ndim == 1 else np.zeros(arr.shape[0])
 
         # Multiply the array by the filter transmission curve


### PR DESCRIPTION
Closes issue 1038


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced filter operation warnings. The system now provides more targeted feedback by only alerting users when filtering produces unexpected empty results. Warnings for empty input arrays are suppressed, reducing noise and allowing users to focus on genuine filtering concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->