### PR TITLE
Implement a minimum warning width of 80

### DIFF
--- a/src/synthesizer/synth_warnings.py
+++ b/src/synthesizer/synth_warnings.py
@@ -163,6 +163,8 @@ def _wrap_with_prefix(message, stacklevel, category):
     This inserts a new line after the warning prefix to ensure the whole
     message is wrapped correctly.
 
+    We default to a minimum warning width of 80 characters.
+
     Args:
         message (str): The message to wrap.
         stacklevel (int): The stack level for the warning.
@@ -180,8 +182,8 @@ def _wrap_with_prefix(message, stacklevel, category):
     # Subtract some padding for the warning
     width -= 4
 
-    # Ensure width is > 0
-    width = max(1, width)
+    # Ensure width is > 80
+    width = max(80, width)
 
     # Wrap the message
     wrapped = textwrap.fill(


### PR DESCRIPTION
When running with SLURM you can get a width of 1 for the warning which puts every word of the warning on a new line... while entertaining... we should just set a minimum of 80 wide, and if a warning gets wrapped so be it.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved warning message formatting and text wrapping for enhanced readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->