### PR TITLE
Fixing the ASCII table width

### DIFF
--- a/src/synthesizer/utils/ascii_table.py
+++ b/src/synthesizer/utils/ascii_table.py
@@ -342,6 +342,20 @@ class TableFormatter:
             for col in zip(*rows, ("Property", "Value"))
         ]
 
+        # Calculate minimum width needed for the title (uppercased)
+        # The title needs: "| " + title + " |" = title + 4
+        # The content needs: col_widths[0] + " | " + col_widths[1] + " |"
+        #                  = col_widths[0] + col_widths[1] + 5
+        title_text_upper = title_text.upper()
+        min_content_width = len(title_text_upper) + 4 - 5  # -5 for separators
+        current_content_width = col_widths[0] + col_widths[1]
+
+        # If title is wider than content, expand columns proportionally
+        if min_content_width > current_content_width:
+            extra_width = min_content_width - current_content_width
+            # Add extra width to the second column (usually the values)
+            col_widths[1] += extra_width
+
         def format_row(row):
             return f"| {row[0]:<{col_widths[0]}} | {row[1]:<{col_widths[1]}} |"
 
@@ -351,9 +365,7 @@ class TableFormatter:
         )
 
         # Define the title
-        title = (
-            f"| {title_text:^{col_widths[0] + col_widths[1] + 3}} |".upper()
-        )
+        title = f"| {title_text_upper:^{col_widths[0] + col_widths[1] + 3}} |"
 
         lines = [
             "+" + "-" * (col_widths[0] + col_widths[1] + 5) + "+",


### PR DESCRIPTION
The `TableFormatter` didn't factor the width of the title into the width it sets for the table. Now it does.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced ASCII table rendering to dynamically adjust column widths when titles exceed content width, improving table layout and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->