### PR TITLE
Fixing an issue with 0 tranmission in `apply_filter`

### DIFF
--- a/src/synthesizer/instruments/filters.py
+++ b/src/synthesizer/instruments/filters.py
@@ -1841,7 +1841,7 @@ class Filter:
         if arr_in_band.size == 0:
             if arr.shape[0] > 0:
                 warn(f"{self.filter_code} outside of emission array.")
-            return 0 if arr.ndim == 1 else np.zeros(arr.shape[0])
+            return np.zeros(arr.shape[:-1]) if arr.ndim > 1 else 0
 
         # Multiply the array by the filter transmission curve
         transmission = arr_in_band * t_in_band
@@ -1849,7 +1849,7 @@ class Filter:
         # Ensure we actually have some transmission in this band, no point
         # in calling the C extensions if not
         if np.sum(transmission) == 0:
-            return 0 if arr.ndim == 1 else np.zeros(arr.shape[0])
+            return np.zeros(arr.shape[:-1]) if arr.ndim > 1 else 0
 
         # Sum over the final axis to "collect" transmission in this filer
         sum_per_x = integrate_last_axis(


### PR DESCRIPTION
I was playing with applying filters to `Sed` objects derived from entire grids. While doing so, I stumbled across an error where the early exits in `apply_filter` returned arrays of the wrong shape when the input was more than 2-dimensional. This minor change fixes the issue.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of edge cases in filter operations when encountering empty datasets or zero transmission values, improving the reliability and consistency of results across different data input types and configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->