### PR TITLE
Surpress warnings when building the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -79,6 +79,9 @@ set_type_checking_flag = (
 )
 
 nbsphinx_allow_errors = True  # Continue through Jupyter errors
+os.environ["PYTHONWARNINGS"] = (
+    "ignore"  # Suppress warnings in notebook execution
+)
 
 templates_path = ["templates"]
 


### PR DESCRIPTION
There are some unavoidable warnings that appear in the docs (particularly some instances of logs taken of arrays with 0s). Rather than convolut the message of the docs by handling these explicitly it would be better to just silence the warnings. This removes any confusing warnings. 

Lucklily, this supression is nice and easy and simply requires the setting of an environment variable during the build.

Closes #1073. 

## Issue Type
<!-- delete options below as required -->
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated runtime configuration for documentation generation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->