### PR TITLE
Enabling the naming of optical depth attribute in Pipeline

### DIFF
--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -1206,7 +1206,7 @@ class Pipeline:
         """
         # Store the arguments for the operation
         self._operation_kwargs.add(
-            NO_MODEL_LABEL,  # TODO: make this work for arbitrary los
+            NO_MODEL_LABEL,
             "get_los_optical_depths",
             kernel=kernel,
             kernel_threshold=kernel_threshold,


### PR DESCRIPTION
As the title says, you can now tell the pipeline the name of the attribute to store the optical depth under (though running these column density calculations during galaxy set up may still be preferable for total flexibility). 

Closes #894 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Public API updated: optical depth calculation now uses a customizable attribute name instead of a write flag, which may require callers to adjust how they request/store LOS optical depths.

* **Documentation**
  * Docs and parameter descriptions updated to explain the new attribute-name semantics and usage guidance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->