### PR TITLE
Ensuring units are associated to LOS outputs 

### DIFF
--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -30,7 +30,7 @@ from synthesizer.parametric.stars import Stars as ParametricStars
 from synthesizer.particle.gas import Gas
 from synthesizer.particle.stars import Stars
 from synthesizer.synth_warnings import warn
-from synthesizer.units import accepts
+from synthesizer.units import accepts, unyt_to_ndview
 from synthesizer.utils.geometry import get_rotation_matrix
 
 
@@ -528,10 +528,8 @@ class Galaxy(BaseGalaxy):
             nthreads=nthreads,
         )  # Msun / Mpc**2
 
-        los_dustsds /= (1e6) ** 2  # Msun / pc**2
-
         # Finalise the calculation
-        tau_v = kappa * los_dustsds
+        tau_v = kappa * unyt_to_ndview(los_dustsds, Msun / pc**2)
 
         # Apply the mask if provided
         if mask is not None:
@@ -627,10 +625,8 @@ class Galaxy(BaseGalaxy):
             nthreads=nthreads,
         )
 
-        los_dustsds /= (1e6) ** 2  # Msun / pc**2
-
         # Finalise the calculation
-        tau_v = kappa * los_dustsds
+        tau_v = kappa * unyt_to_ndview(los_dustsds, Msun / pc**2)
 
         # Apply the mask if provided
         if mask is not None:

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -10,7 +10,7 @@ import inspect
 
 import numpy as np
 from numpy.random import multivariate_normal
-from unyt import Mpc, Msun, km, pc, rad, s
+from unyt import Mpc, Msun, km, pc, rad, s, unyt_array
 
 from synthesizer import exceptions
 from synthesizer.emission_models.utils import get_param
@@ -1050,6 +1050,20 @@ class Particles:
             nthreads,
         )
 
+    def _get_los_column_density_units(self, other_parts, density_attr):
+        """Get the units for a LOS column density result."""
+        density = getattr(other_parts, density_attr)
+
+        return density.units / other_parts.coordinates.units**2
+
+    def _wrap_los_column_density(self, column_density, units):
+        """Attach LOS column-density units without copying the data."""
+        return unyt_array(
+            column_density,
+            units,
+            bypass_validation=True,
+        )
+
     def get_los_column_density(
         self,
         other_parts,
@@ -1105,13 +1119,30 @@ class Particles:
             compute_column_density,
         )
 
+        column_density_units = self._get_los_column_density_units(
+            other_parts,
+            density_attr,
+        )
+
         # If have no particles return 0
         if self.nparticles == 0:
-            return np.zeros(self.nparticles)
+            col_den = self._wrap_los_column_density(
+                np.zeros(self.nparticles),
+                column_density_units,
+            )
+            if column_density_attr is not None:
+                setattr(self, column_density_attr, col_den)
+            return col_den
 
         # If the other particles have no particles return 0
         if other_parts.nparticles == 0:
-            return np.zeros(self.nparticles)
+            col_den = self._wrap_los_column_density(
+                np.zeros(self.nparticles),
+                column_density_units,
+            )
+            if column_density_attr is not None:
+                setattr(self, column_density_attr, col_den)
+            return col_den
 
         # If we don't have a mask make a fake one for consistency
         if mask is None:
@@ -1129,6 +1160,10 @@ class Particles:
                 min_count,
                 nthreads,
             )
+        )
+        col_den = self._wrap_los_column_density(
+            col_den,
+            column_density_units,
         )
 
         # Set the column density attribute (if requested)

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -1105,6 +1105,7 @@ class Particles:
             compute_column_density,
         )
 
+        # Get the units for the column density from the inputs
         column_density_units = (
             getattr(other_parts, density_attr).units
             / other_parts.coordinates.units**2
@@ -1149,6 +1150,8 @@ class Particles:
                 nthreads,
             )
         )
+
+        # Associate with the correct units
         col_den = unyt_array(
             col_den,
             column_density_units,

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -1130,6 +1130,11 @@ class Particles:
             raise exceptions.InconsistentArguments(
                 f"{other_parts.name} object is missing {density_attr}!"
             )
+        if not hasattr(density, "units"):
+            raise exceptions.InconsistentArguments(
+                f"{other_parts.name} object attribute {density_attr} must "
+                "have units to compute LOS column densities."
+            )
 
         # Get the units for the column density from the inputs
         column_density_units = density.units / other_parts.coordinates.units**2

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -1105,16 +1105,39 @@ class Particles:
             compute_column_density,
         )
 
+        # If we don't have a mask make a fake one for consistency
+        if mask is None:
+            mask = np.ones(self.nparticles, dtype=bool)
+        else:
+            mask = np.asarray(mask, dtype=bool)
+
+        if mask.size != self.nparticles:
+            raise exceptions.InconsistentArguments(
+                "The mask must be the same length as the number of "
+                f"particles. Got {mask.size} but expected {self.nparticles}."
+            )
+
+        masked_nparticles = np.count_nonzero(mask)
+
+        # Validate inputs before accessing their units
+        if other_parts.coordinates is None:
+            raise exceptions.InconsistentArguments(
+                f"{other_parts.name} object is missing coordinates!"
+            )
+
+        density = getattr(other_parts, density_attr, None)
+        if density is None:
+            raise exceptions.InconsistentArguments(
+                f"{other_parts.name} object is missing {density_attr}!"
+            )
+
         # Get the units for the column density from the inputs
-        column_density_units = (
-            getattr(other_parts, density_attr).units
-            / other_parts.coordinates.units**2
-        )
+        column_density_units = density.units / other_parts.coordinates.units**2
 
         # If have no particles return 0
-        if self.nparticles == 0:
+        if self.nparticles == 0 or masked_nparticles == 0:
             col_den = unyt_array(
-                np.zeros(self.nparticles),
+                np.zeros(masked_nparticles),
                 column_density_units,
                 bypass_validation=True,
             )
@@ -1125,17 +1148,13 @@ class Particles:
         # If the other particles have no particles return 0
         if other_parts.nparticles == 0:
             col_den = unyt_array(
-                np.zeros(self.nparticles),
+                np.zeros(masked_nparticles),
                 column_density_units,
                 bypass_validation=True,
             )
             if column_density_attr is not None:
                 setattr(self, column_density_attr, col_den)
             return col_den
-
-        # If we don't have a mask make a fake one for consistency
-        if mask is None:
-            mask = np.ones(self.nparticles, dtype=bool)
 
         # Compute the column density
         col_den = compute_column_density(

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -1050,20 +1050,6 @@ class Particles:
             nthreads,
         )
 
-    def _get_los_column_density_units(self, other_parts, density_attr):
-        """Get the units for a LOS column density result."""
-        density = getattr(other_parts, density_attr)
-
-        return density.units / other_parts.coordinates.units**2
-
-    def _wrap_los_column_density(self, column_density, units):
-        """Attach LOS column-density units without copying the data."""
-        return unyt_array(
-            column_density,
-            units,
-            bypass_validation=True,
-        )
-
     def get_los_column_density(
         self,
         other_parts,
@@ -1119,16 +1105,17 @@ class Particles:
             compute_column_density,
         )
 
-        column_density_units = self._get_los_column_density_units(
-            other_parts,
-            density_attr,
+        column_density_units = (
+            getattr(other_parts, density_attr).units
+            / other_parts.coordinates.units**2
         )
 
         # If have no particles return 0
         if self.nparticles == 0:
-            col_den = self._wrap_los_column_density(
+            col_den = unyt_array(
                 np.zeros(self.nparticles),
                 column_density_units,
+                bypass_validation=True,
             )
             if column_density_attr is not None:
                 setattr(self, column_density_attr, col_den)
@@ -1136,9 +1123,10 @@ class Particles:
 
         # If the other particles have no particles return 0
         if other_parts.nparticles == 0:
-            col_den = self._wrap_los_column_density(
+            col_den = unyt_array(
                 np.zeros(self.nparticles),
                 column_density_units,
+                bypass_validation=True,
             )
             if column_density_attr is not None:
                 setattr(self, column_density_attr, col_den)
@@ -1161,9 +1149,10 @@ class Particles:
                 nthreads,
             )
         )
-        col_den = self._wrap_los_column_density(
+        col_den = unyt_array(
             col_den,
             column_density_units,
+            bypass_validation=True,
         )
 
         # Set the column density attribute (if requested)

--- a/tests/test_los.py
+++ b/tests/test_los.py
@@ -145,6 +145,33 @@ class TestLOSColumnDensity:
         assert col_den.size == 0
         assert empty_stars.sigmalos_mass.units == expected_units
 
+    def test_column_density_zero_particle_mask_returns_masked_shape(
+        self, one_gas_front
+    ):
+        """Zero-particle early returns respect the masked output shape."""
+        empty_stars = Stars(
+            initial_masses=np.array([]) * Msun,
+            ages=np.array([]) * Myr,
+            metallicities=np.array([]),
+            redshift=0.0,
+            tau_v=np.array([]),
+            coordinates=np.empty((0, 3)) * Mpc,
+            smoothing_lengths=np.array([]) * Mpc,
+        )
+
+        col_den = empty_stars.get_los_column_density(
+            one_gas_front,
+            "masses",
+            np.array([1.0]),
+            mask=np.array([], dtype=bool),
+            column_density_attr="sigmalos_mass",
+            force_loop=1,
+            min_count=10,
+        )
+
+        assert col_den.shape == (0,)
+        assert empty_stars.sigmalos_mass.shape == (0,)
+
     def test_column_density_empty_source_returns_unitful_array(self, one_star):
         """Empty source particles still yield a unitful zero array."""
         empty_gas = Gas(
@@ -173,6 +200,56 @@ class TestLOSColumnDensity:
         assert col_den.units == expected_units
         assert np.allclose(col_den.value, np.zeros(one_star.nparticles))
         assert one_star.sigmalos_mass.units == expected_units
+
+    def test_column_density_empty_source_mask_returns_masked_shape(
+        self, one_star
+    ):
+        """Empty source early returns match the number of masked targets."""
+        empty_gas = Gas(
+            masses=np.array([]) * Msun,
+            metallicities=np.array([]),
+            redshift=0.0,
+            coordinates=np.empty((0, 3)) * Mpc,
+            dust_to_metal_ratio=1.0,
+            smoothing_lengths=np.array([]) * Mpc,
+        )
+        mask = np.array([True])
+
+        col_den = one_star.get_los_column_density(
+            empty_gas,
+            "masses",
+            np.array([1.0]),
+            mask=mask,
+            column_density_attr="sigmalos_mass",
+            force_loop=1,
+            min_count=10,
+        )
+
+        assert col_den.shape == (mask.sum(),)
+        assert one_star.sigmalos_mass.shape == (mask.sum(),)
+
+    def test_column_density_missing_attr_raises_consistent_error(
+        self, one_star
+    ):
+        """Missing density attributes should raise the LOS validation error."""
+        bad_gas = Gas(
+            masses=np.array([1e6]) * Msun,
+            metallicities=np.array([0.01]),
+            redshift=0.0,
+            coordinates=np.array([[0.0, 0.0, 0.0]]) * Mpc,
+            dust_to_metal_ratio=1.0,
+            smoothing_lengths=np.array([1.0]) * Mpc,
+        )
+        bad_gas.masses = None
+
+        with pytest.raises(InconsistentArguments):
+            one_star.get_los_column_density(
+                bad_gas,
+                "masses",
+                np.array([1.0]),
+                force_loop=1,
+                min_count=10,
+            )
 
     def test_tau_v_unit_conversion_uses_surface_density_units(
         self, one_star, one_gas_front

--- a/tests/test_los.py
+++ b/tests/test_los.py
@@ -2,10 +2,11 @@
 
 import numpy as np
 import pytest
-from unyt import Mpc, Msun, Myr
+from unyt import Mpc, Msun, Myr, pc, unyt_array
 
 from synthesizer.exceptions import InconsistentArguments
 from synthesizer.particle import Galaxy, Gas, Stars
+from synthesizer.units import unyt_to_ndview
 
 
 @pytest.fixture
@@ -87,6 +88,132 @@ class TestLOSColumnDensity:
         assert np.allclose(one_star.tau_v, expected), (
             f"Expected star tau_v {expected}, got {one_star.tau_v}"
         )
+
+    def test_column_density_returns_units_and_stores_attr(
+        self, one_star, one_gas_front
+    ):
+        """LOS column density keeps the correct surface-density units."""
+        kernel = np.array([1.0])
+
+        col_den = one_star.get_los_column_density(
+            one_gas_front,
+            "masses",
+            kernel,
+            column_density_attr="sigmalos_mass",
+            force_loop=1,
+            min_count=10,
+        )
+
+        expected_units = (
+            one_gas_front.masses.units / one_gas_front.coordinates.units**2
+        )
+
+        assert isinstance(col_den, unyt_array)
+        assert col_den.units == expected_units
+        assert one_star.sigmalos_mass.units == expected_units
+        assert col_den is one_star.sigmalos_mass
+
+    def test_column_density_zero_particle_returns_unitful_array(
+        self, one_gas_front
+    ):
+        """Zero-particle LOS returns still carry the right units."""
+        empty_stars = Stars(
+            initial_masses=np.array([]) * Msun,
+            ages=np.array([]) * Myr,
+            metallicities=np.array([]),
+            redshift=0.0,
+            tau_v=np.array([]),
+            coordinates=np.empty((0, 3)) * Mpc,
+            smoothing_lengths=np.array([]) * Mpc,
+        )
+
+        col_den = empty_stars.get_los_column_density(
+            one_gas_front,
+            "masses",
+            np.array([1.0]),
+            column_density_attr="sigmalos_mass",
+            force_loop=1,
+            min_count=10,
+        )
+
+        expected_units = (
+            one_gas_front.masses.units / one_gas_front.coordinates.units**2
+        )
+
+        assert isinstance(col_den, unyt_array)
+        assert col_den.units == expected_units
+        assert col_den.size == 0
+        assert empty_stars.sigmalos_mass.units == expected_units
+
+    def test_column_density_empty_source_returns_unitful_array(self, one_star):
+        """Empty source particles still yield a unitful zero array."""
+        empty_gas = Gas(
+            masses=np.array([]) * Msun,
+            metallicities=np.array([]),
+            redshift=0.0,
+            coordinates=np.empty((0, 3)) * Mpc,
+            dust_to_metal_ratio=1.0,
+            smoothing_lengths=np.array([]) * Mpc,
+        )
+
+        col_den = one_star.get_los_column_density(
+            empty_gas,
+            "masses",
+            np.array([1.0]),
+            column_density_attr="sigmalos_mass",
+            force_loop=1,
+            min_count=10,
+        )
+
+        expected_units = (
+            empty_gas.masses.units / empty_gas.coordinates.units**2
+        )
+
+        assert isinstance(col_den, unyt_array)
+        assert col_den.units == expected_units
+        assert np.allclose(col_den.value, np.zeros(one_star.nparticles))
+        assert one_star.sigmalos_mass.units == expected_units
+
+    def test_tau_v_unit_conversion_uses_surface_density_units(
+        self, one_star, one_gas_front
+    ):
+        """Tau_v conversion uses unit conversion rather than raw relabeling."""
+        gal = Galaxy(
+            stars=one_star,
+            gas=one_gas_front,
+            redshift=0.0,
+            centre=None,
+        )
+
+        los_dustsds = one_star.get_los_column_density(
+            one_gas_front,
+            "dust_masses",
+            np.array([1.0]),
+            force_loop=1,
+            min_count=10,
+        )
+
+        expected_units = (
+            one_gas_front.dust_masses.units
+            / one_gas_front.coordinates.units**2
+        )
+
+        assert los_dustsds.units == expected_units
+        los_dustsds_pc = los_dustsds.copy()
+        assert np.allclose(
+            unyt_to_ndview(los_dustsds_pc, Msun / pc**2), [1e-8]
+        )
+
+        tau = gal.get_stellar_los_tau_v(
+            kappa=2.0,
+            kernel=np.array([1.0]),
+            force_loop=1,
+            min_count=10,
+        )
+
+        assert np.allclose(tau, np.array([2e-8]))
+        assert not hasattr(tau, "units")
+        assert not hasattr(one_star.tau_v, "units")
 
     def test_column_density_behind_zero(self, one_star, one_gas_behind):
         """Test Gas particle behind column density."""

--- a/tests/test_los.py
+++ b/tests/test_los.py
@@ -251,6 +251,29 @@ class TestLOSColumnDensity:
                 min_count=10,
             )
 
+    def test_column_density_unitless_attr_raises_consistent_error(
+        self, one_star
+    ):
+        """Unitless density attributes should fail before unit access."""
+        bad_gas = Gas(
+            masses=np.array([1e6]) * Msun,
+            metallicities=np.array([0.01]),
+            redshift=0.0,
+            coordinates=np.array([[0.0, 0.0, 0.0]]) * Mpc,
+            dust_to_metal_ratio=1.0,
+            smoothing_lengths=np.array([1.0]) * Mpc,
+        )
+        bad_gas.unitless_density = np.array([1.0])
+
+        with pytest.raises(InconsistentArguments, match="unitless_density"):
+            one_star.get_los_column_density(
+                bad_gas,
+                "unitless_density",
+                np.array([1.0]),
+                force_loop=1,
+                min_count=10,
+            )
+
     def test_tau_v_unit_conversion_uses_surface_density_units(
         self, one_star, one_gas_front
     ):


### PR DESCRIPTION
LOS column density outputs were not properly assigned units based on the inputs. This is simply fixed by... actually associating the units as we should have all along!

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected optical-depth calculations to use proper unit conversion, producing numerically accurate, unitless tau outputs.
  * Ensured column-density computations consistently produce unit-aware surface-density values and handle masked/empty particle cases with correctly sized results.

* **Tests**
  * Added comprehensive tests for line-of-sight column density and optical depth, including unit preservation, sizing, and edge-case behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->