### PR TITLE
Adding a Cosmic SED method to the Pipeline

### DIFF
--- a/docs/source/pipeline/pipeline_example.ipynb
+++ b/docs/source/pipeline/pipeline_example.ipynb
@@ -314,6 +314,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Cosmic SED\n",
+    "\n",
+    "The pipeline can also accumulate the total rest-frame and observer-frame cosmic SED across the attached galaxy sample. This can be done for the whole sample by simply calling ``get_cosmic_sed`` (or ``get_observed_cosmic_sed``), or for a subsample selected based on integrated galaxy properties. This can be done for an arbitrary number of filters, and each can be given a label to distinguish them in the output file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.get_cosmic_sed()\n",
+    "pipeline.get_cosmic_sed(\n",
+    "    gal_attr=\"stellar_mass\",\n",
+    "    lower_bound=1e8,\n",
+    "    upper_bound=1e9,\n",
+    "    label=\"LowStellarMass\",\n",
+    ")\n",
+    "pipeline.get_observed_cosmic_sed(cosmo)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Line Emission\n",
     "\n",
     "Next we'll generate the emission lines. Here we can pass exactly which emission lines we want to generate based on line ID. We'll just generate all lines offered by the ``Grid``."
@@ -551,6 +576,8 @@
     "pipeline.add_galaxies(galaxies)\n",
     "pipeline.get_spectra()\n",
     "pipeline.get_observed_spectra(cosmo)\n",
+    "pipeline.get_cosmic_sed()\n",
+    "pipeline.get_observed_cosmic_sed(cosmo)\n",
     "pipeline.get_lines(line_ids=grid.available_lines)\n",
     "pipeline.get_observed_lines(cosmo)\n",
     "pipeline.get_photometry_luminosities(uvj_inst, webb_inst, miri_inst)\n",

--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -51,6 +51,7 @@ from synthesizer.pipeline.pipeline_utils import (
     get_full_memory,
     plot_timing_analysis,
     print_timing_analysis_table,
+    sanitise_hdf5_key_part,
     sum_dicts_recursive,
     validate_noise_unit_compatibility,
     write_timing_analysis_summary,
@@ -1838,11 +1839,11 @@ class Pipeline:
                         if op_kwargs["upper_bound"] is not None
                         else "inf"
                     )
-                    label = (
-                        f"{lower} < {op_kwargs['gal_attr']} < {upper}".replace(
-                            ".", "p"
-                        )
+                    label = sanitise_hdf5_key_part(
+                        f"{lower} < {op_kwargs['gal_attr']} < {upper}"
                     )
+            else:
+                label = sanitise_hdf5_key_part(label)
 
             # Loop over the spectra on the galaxy and all its components and
             # sum them into the cosmic SED dictionary on the pipeline with the
@@ -1988,11 +1989,11 @@ class Pipeline:
                         if op_kwargs["upper_bound"] is not None
                         else "inf"
                     )
-                    label = (
-                        f"{lower} < {op_kwargs['gal_attr']} < {upper}".replace(
-                            ".", "p"
-                        )
+                    label = sanitise_hdf5_key_part(
+                        f"{lower} < {op_kwargs['gal_attr']} < {upper}"
                     )
+            else:
+                label = sanitise_hdf5_key_part(label)
 
             for model_label, sed in galaxy.spectra.items():
                 cosmic_sed = self.cosmic_fnus["Galaxy"].setdefault(label, {})
@@ -4053,14 +4054,6 @@ class Pipeline:
                 if self._do_fnu_spectra:
                     self._get_observed_spectra(_gal)
 
-                # Are we generating rest-frame cosmic SEDs?
-                if self._do_cosmic_lnu:
-                    self._get_cosmic_sed(_gal)
-
-                # Are we generating observer-frame cosmic SEDs?
-                if self._do_cosmic_fnu:
-                    self._get_observed_cosmic_sed(_gal)
-
                 # Are we generating photometric luminosities?
                 if self._do_luminosities:
                     self._get_photometry_luminosities(_gal)
@@ -4110,6 +4103,14 @@ class Pipeline:
 
                     with timer("Pipeline.run.cleanup_child"):
                         del _gal
+
+            # Cosmic SEDs must be measured on the fully accumulated parent
+            # galaxy so any split-galaxy filtering uses integrated properties.
+            if self._do_cosmic_lnu:
+                self._get_cosmic_sed(gal)
+
+            if self._do_cosmic_fnu:
+                self._get_observed_cosmic_sed(gal)
 
             # Run any extra analysis functions
             self._run_extra_analysis(gal)

--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -51,6 +51,7 @@ from synthesizer.pipeline.pipeline_utils import (
     get_full_memory,
     plot_timing_analysis,
     print_timing_analysis_table,
+    sum_dicts_recursive,
     validate_noise_unit_compatibility,
     write_timing_analysis_summary,
 )
@@ -232,6 +233,8 @@ class Pipeline:
         self._do_los_optical_depths = False
         self._do_lnu_spectra = False
         self._do_fnu_spectra = False
+        self._do_cosmic_lnu = False
+        self._do_cosmic_fnu = False
         self._do_luminosities = False
         self._do_fluxes = False
         self._do_lum_lines = False
@@ -256,6 +259,8 @@ class Pipeline:
         # Define flags for what we will write out
         self._write_lnu_spectra = False
         self._write_fnu_spectra = False
+        self._write_cosmic_lnu = False
+        self._write_cosmic_fnu = False
         self._write_luminosities = False
         self._write_fluxes = False
         self._write_lines = False
@@ -319,6 +324,8 @@ class Pipeline:
             "SFH": 0.0,
             "Lnu Spectra": 0.0,
             "Fnu Spectra": 0.0,
+            "Cosmic SED Lnu": 0.0,
+            "Cosmic SED Fnu": 0.0,
             "Luminosities": 0.0,
             "Fluxes": 0.0,
             "Emission Line Luminosities": 0.0,
@@ -344,6 +351,8 @@ class Pipeline:
             "SFH": 0,
             "Lnu Spectra": 0,
             "Fnu Spectra": 0,
+            "Cosmic SED Lnu": 0,
+            "Cosmic SED Fnu": 0,
             "Luminosities": 0,
             "Fluxes": 0,
             "Emission Line Luminosities": 0,
@@ -1031,6 +1040,16 @@ class Pipeline:
             + str(self._write_fnu_spectra).rjust(15)
         )
         self._print(
+            "Cosmic SED Lnu".ljust(30)
+            + str(self._do_cosmic_lnu).rjust(15)
+            + str(self._write_cosmic_lnu).rjust(15)
+        )
+        self._print(
+            "Cosmic SED Fnu".ljust(30)
+            + str(self._do_cosmic_fnu).rjust(15)
+            + str(self._write_cosmic_fnu).rjust(15)
+        )
+        self._print(
             "Photometric Luminosities".ljust(30)
             + str(self._do_luminosities).rjust(15)
             + str(self._write_luminosities).rjust(15)
@@ -1226,7 +1245,7 @@ class Pipeline:
     def _add_instruments(self, instruments):
         """Add instruments to the Pipeline.
 
-        This is a helprer used to attach instruments to the pipeline. Note
+        This is a helper used to attach instruments to the pipeline. Note
         that these instruments are only used for book keeping. The machinery
         to apply instruments to the right operation is handled by the
         OperationKwargsHandler (self._operation_kwargs).
@@ -1770,78 +1789,90 @@ class Pipeline:
             galaxy (Galaxy):
                 The galaxy to compute the cosmic SED contribution for.
         """
-        # Get the operation kwargs for this operation
-        op_kwargs = self._operation_kwargs.get_unique_kwargs("get_cosmic_sed")
+        start = time.perf_counter()
 
-        # Set up the filter based on the provided kwargs
-        if op_kwargs["gal_attr"] is not None:
-            # Get the value of the attribute to apply the filter to
-            gal_value = getattr(galaxy, op_kwargs["gal_attr"], None)
+        for _, op_kwargs in self._operation_kwargs["get_cosmic_sed"]:
+            # Set up the filter based on the provided kwargs
+            if op_kwargs["gal_attr"] is not None:
+                # Get the value of the attribute to apply the filter to
+                gal_value = getattr(galaxy, op_kwargs["gal_attr"], None)
 
-            # If the galaxy doesn't have the attribute throw an error, we
-            # can't proceed
-            if gal_value is None:
-                raise exceptions.PipelineNotReady(
-                    f"Galaxy does not have attribute {op_kwargs['gal_attr']} "
-                    "to apply the cosmic SED filter: "
-                    f"{op_kwargs['lower_bound']} < "
-                    f"{op_kwargs['gal_attr']} < {op_kwargs['upper_bound']}"
-                )
+                # If the galaxy doesn't have the attribute throw an error, we
+                # can't proceed
+                if gal_value is None:
+                    raise exceptions.PipelineNotReady(
+                        "Galaxy does not have attribute "
+                        f"{op_kwargs['gal_attr']} "
+                        "to apply the cosmic SED filter: "
+                        f"{op_kwargs['lower_bound']} < "
+                        f"{op_kwargs['gal_attr']} < "
+                        f"{op_kwargs['upper_bound']}"
+                    )
 
-            # If we are outside the bounds we have nothing to contribute
-            if (
-                op_kwargs["lower_bound"] is not None
-                and gal_value < op_kwargs["lower_bound"]
-            ):
-                return
-            if (
-                op_kwargs["upper_bound"] is not None
-                and gal_value > op_kwargs["upper_bound"]
-            ):
-                return
+                # If we are outside the bounds we have nothing to contribute
+                if (
+                    op_kwargs["lower_bound"] is not None
+                    and gal_value < op_kwargs["lower_bound"]
+                ):
+                    continue
+                if (
+                    op_kwargs["upper_bound"] is not None
+                    and gal_value > op_kwargs["upper_bound"]
+                ):
+                    continue
 
-        # Get the label for this contribution to the cosmic SED
-        label = op_kwargs["label"]
-        if label is None:
-            # We have no label, make one
-            if op_kwargs["gal_attr"] is None:
-                label = "All"
-            else:
-                lower = (
-                    op_kwargs["lower_bound"]
-                    if op_kwargs["lower_bound"] is not None
-                    else "-inf"
-                )
-                upper = (
-                    op_kwargs["upper_bound"]
-                    if op_kwargs["upper_bound"] is not None
-                    else "inf"
-                )
-                label = f"{lower} < {op_kwargs['gal_attr']} < {upper}".replace(
-                    ".", "p"
-                )
+            # Get the label for this contribution to the cosmic SED
+            label = op_kwargs["label"]
+            if label is None:
+                # We have no label, make one
+                if op_kwargs["gal_attr"] is None:
+                    label = "All"
+                else:
+                    lower = (
+                        op_kwargs["lower_bound"]
+                        if op_kwargs["lower_bound"] is not None
+                        else "-inf"
+                    )
+                    upper = (
+                        op_kwargs["upper_bound"]
+                        if op_kwargs["upper_bound"] is not None
+                        else "inf"
+                    )
+                    label = (
+                        f"{lower} < {op_kwargs['gal_attr']} < {upper}".replace(
+                            ".", "p"
+                        )
+                    )
 
-        # Loop over the spectra on the galaxy and all its components and sum
-        # them into the cosmic SED dictionary on the pipeline with the label
-        # as the key.
-        for model_label, sed in galaxy.spectra.items():
-            cosmic_sed = self.cosmic_lnus["Galaxy"].setdefault(label, {})
-            cosmic_sed.setdefault(model_label, np.zeros_like(sed._lnu))
-            cosmic_sed[model_label] += sed._lnu
-        if galaxy.stars is not None:
-            for model_label, sed in galaxy.stars.spectra.items():
-                cosmic_sed = self.cosmic_lnus["Stars"].setdefault(label, {})
-                cosmic_sed.setdefault(model_label, np.zeros_like(sed._lnu))
-                cosmic_sed[model_label] += sed._lnu
-        if galaxy.black_holes is not None:
-            for model_label, sed in galaxy.black_holes.spectra.items():
-                cosmic_sed = self.cosmic_lnus["BlackHoles"].setdefault(
-                    label, {}
-                )
-                cosmic_sed.setdefault(model_label, np.zeros_like(sed._lnu))
-                cosmic_sed[model_label] += sed._lnu
-        if galaxy.gas is not None:
-            pass  # TODO: At the moment gas can't contribute to the cosmic SED
+            # Loop over the spectra on the galaxy and all its components and
+            # sum them into the cosmic SED dictionary on the pipeline with the
+            # label as the key.
+            for model_label, sed in galaxy.spectra.items():
+                cosmic_sed = self.cosmic_lnus["Galaxy"].setdefault(label, {})
+                cosmic_sed.setdefault(model_label, 0 * sed.lnu)
+                cosmic_sed[model_label] += sed.lnu
+            if galaxy.stars is not None:
+                for model_label, sed in galaxy.stars.spectra.items():
+                    cosmic_sed = self.cosmic_lnus["Stars"].setdefault(
+                        label, {}
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * sed.lnu)
+                    cosmic_sed[model_label] += sed.lnu
+            if galaxy.black_holes is not None:
+                for model_label, sed in galaxy.black_holes.spectra.items():
+                    cosmic_sed = self.cosmic_lnus["BlackHole"].setdefault(
+                        label, {}
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * sed.lnu)
+                    cosmic_sed[model_label] += sed.lnu
+            if galaxy.gas is not None:
+                pass  # TODO: At the moment gas can't contribute
+
+        # Count the number of cosmic SED contributions
+        self._op_counts["Cosmic SED Lnu"] += 1
+
+        # Record the time taken
+        self._op_timing["Cosmic SED Lnu"] += time.perf_counter() - start
 
     def get_photometry_luminosities(
         self,
@@ -3791,6 +3822,8 @@ class Pipeline:
             self._do_los_optical_depths,
             self._do_lnu_spectra,
             self._do_fnu_spectra,
+            self._do_cosmic_lnu,
+            self._do_cosmic_fnu,
             self._do_luminosities,
             self._do_fluxes,
             self._do_lum_lines,
@@ -3872,6 +3905,14 @@ class Pipeline:
                 # Are we generating fnu spectra?
                 if self._do_fnu_spectra:
                     self._get_observed_spectra(_gal)
+
+                # Are we generating rest-frame cosmic SEDs?
+                if self._do_cosmic_lnu:
+                    self._get_cosmic_sed(_gal)
+
+                # Are we generating observer-frame cosmic SEDs?
+                if self._do_cosmic_fnu:
+                    self._get_observed_cosmic_sed(_gal)
 
                 # Are we generating photometric luminosities?
                 if self._do_luminosities:
@@ -3984,6 +4025,27 @@ class Pipeline:
             self.fnu_spectra["Stars"][spec_type] = unyt_array(spec)
         for spec_type, spec in self.fnu_spectra["BlackHole"].items():
             self.fnu_spectra["BlackHole"][spec_type] = unyt_array(spec)
+
+        # Combine the cosmic SED dictionaries across ranks and normalise the
+        # result types for writing.
+        if self.using_mpi:
+            cosmic_lnus = self.comm.gather(self.cosmic_lnus, root=0)
+            cosmic_fnus = self.comm.gather(self.cosmic_fnus, root=0)
+            if self.rank == 0:
+                self.cosmic_lnus = sum_dicts_recursive(cosmic_lnus)
+                self.cosmic_fnus = sum_dicts_recursive(cosmic_fnus)
+        for component in self.cosmic_lnus:
+            for label, spectra in self.cosmic_lnus[component].items():
+                for spec_type, spec in spectra.items():
+                    self.cosmic_lnus[component][label][spec_type] = unyt_array(
+                        spec
+                    )
+        for component in self.cosmic_fnus:
+            for label, spectra in self.cosmic_fnus[component].items():
+                for spec_type, spec in spectra.items():
+                    self.cosmic_fnus[component][label][spec_type] = unyt_array(
+                        spec
+                    )
 
         # Convert the lists of luminosities to unyt arrays
         for spec_type, phot in self.luminosities["Galaxy"].items():
@@ -4275,6 +4337,36 @@ class Pipeline:
                 self.fnu_spectra["BlackHole"],
                 "Galaxies/BlackHoles/Photometry/SpectralFluxDensities",
                 galaxy_indices,
+            )
+
+        # Write cosmic spectral luminosity densities
+        if self._write_cosmic_lnu:
+            self.io_helper.write_data(
+                self.cosmic_lnus["Galaxy"],
+                "CosmicSED/Galaxy/SpectralLuminosityDensities",
+            )
+            self.io_helper.write_data(
+                self.cosmic_lnus["Stars"],
+                "CosmicSED/Stars/SpectralLuminosityDensities",
+            )
+            self.io_helper.write_data(
+                self.cosmic_lnus["BlackHole"],
+                "CosmicSED/BlackHoles/SpectralLuminosityDensities",
+            )
+
+        # Write cosmic spectral flux densities
+        if self._write_cosmic_fnu:
+            self.io_helper.write_data(
+                self.cosmic_fnus["Galaxy"],
+                "CosmicSED/Galaxy/SpectralFluxDensities",
+            )
+            self.io_helper.write_data(
+                self.cosmic_fnus["Stars"],
+                "CosmicSED/Stars/SpectralFluxDensities",
+            )
+            self.io_helper.write_data(
+                self.cosmic_fnus["BlackHole"],
+                "CosmicSED/BlackHoles/SpectralFluxDensities",
             )
 
         # Write photometric luminosities

--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -4329,6 +4329,7 @@ class Pipeline:
 
         # Convert any requested summed cosmic SEDs into averages once all
         # contributions have been combined locally or across MPI ranks.
+        averaged = set()
         for _, op_kwargs in self._operation_kwargs["get_cosmic_sed"]:
             if op_kwargs["average"]:
                 label = op_kwargs["label"]
@@ -4353,16 +4354,21 @@ class Pipeline:
                     label = sanitise_hdf5_key_part(label)
 
                 for component in self.cosmic_lnus:
-                    if label in self.cosmic_lnus[component]:
+                    if (
+                        label in self.cosmic_lnus[component]
+                        and (component, label) not in averaged
+                    ):
                         self.cosmic_lnus[component][label] = (
                             divide_dicts_recursive(
                                 self.cosmic_lnus[component][label],
                                 self._cosmic_lnu_counts[component][label],
                             )
                         )
+                        averaged.add((component, label))
 
         # Observer-frame cosmic SEDs follow the same post-reduction averaging
         # path as the rest-frame version.
+        averaged = set()
         for _, op_kwargs in self._operation_kwargs["get_observed_cosmic_sed"]:
             if op_kwargs["average"]:
                 label = op_kwargs["label"]
@@ -4387,13 +4393,17 @@ class Pipeline:
                     label = sanitise_hdf5_key_part(label)
 
                 for component in self.cosmic_fnus:
-                    if label in self.cosmic_fnus[component]:
+                    if (
+                        label in self.cosmic_fnus[component]
+                        and (component, label) not in averaged
+                    ):
                         self.cosmic_fnus[component][label] = (
                             divide_dicts_recursive(
                                 self.cosmic_fnus[component][label],
                                 self._cosmic_fnu_counts[component][label],
                             )
                         )
+                        averaged.add((component, label))
 
         for component in self.cosmic_lnus:
             for label, spectra in self.cosmic_lnus[component].items():

--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -1874,6 +1874,153 @@ class Pipeline:
         # Record the time taken
         self._op_timing["Cosmic SED Lnu"] += time.perf_counter() - start
 
+    def get_observed_cosmic_sed(
+        self,
+        cosmo,
+        igm=None,
+        gal_attr=None,
+        lower_bound=None,
+        upper_bound=None,
+        label=None,
+        write=True,
+    ):
+        """Flag that the Pipeline should compute the observed cosmic SED.
+
+        This will signal the Pipeline to sum the observed spectra into a
+        single observer-frame cosmic SED when the run method is called.
+
+        Args:
+            cosmo (astropy.cosmology.Cosmology):
+                The cosmology to use for the observed spectra.
+            igm (IGMBase):
+                The IGM model to use for the attenuation of the spectra.
+            gal_attr (str):
+                The name of a galaxy attribute to use as a filter for the
+                cosmic SED.
+            lower_bound (float/unyt_quantity):
+                The lower bound to apply to the filter attribute.
+            upper_bound (float/unyt_quantity):
+                The upper bound to apply to the filter attribute.
+            label (str):
+                An optional label for this cosmic SED in the outputs.
+            write (bool):
+                Whether to write out the observed cosmic SED. Default is True.
+        """
+        # If either bound is provided we need an emitter attribute to apply
+        # the filter to
+        if (
+            lower_bound is not None or upper_bound is not None
+        ) and gal_attr is None:
+            raise exceptions.InconsistentArguments(
+                "If either lower_bound or upper_bound is provided, gal_attr "
+                "must be provided to apply the filter to."
+            )
+
+        # Store the arguments for the operation
+        self._operation_kwargs.add(
+            NO_MODEL_LABEL,
+            "get_observed_cosmic_sed",
+            cosmo=cosmo,
+            igm=igm,
+            gal_attr=gal_attr,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            label=label,
+        )
+
+        # Flag that we will compute the observed cosmic SED
+        self._do_cosmic_fnu = True
+
+        # Flag that we will want to write out the observed cosmic SED
+        self._write_cosmic_fnu = write or self._write_cosmic_fnu
+
+        # To compute the observed cosmic SED we need the observed spectra.
+        self.get_observed_spectra(cosmo=cosmo, igm=igm, write=False)
+
+    @timed("Pipeline._get_observed_cosmic_sed")
+    def _get_observed_cosmic_sed(self, galaxy):
+        """Compute the observed cosmic SED contribution for a galaxy.
+
+        Args:
+            galaxy (Galaxy):
+                The galaxy to compute the observed cosmic SED contribution for.
+        """
+        start = time.perf_counter()
+
+        for _, op_kwargs in self._operation_kwargs["get_observed_cosmic_sed"]:
+            # Set up the filter based on the provided kwargs
+            if op_kwargs["gal_attr"] is not None:
+                gal_value = getattr(galaxy, op_kwargs["gal_attr"], None)
+
+                if gal_value is None:
+                    raise exceptions.PipelineNotReady(
+                        f"Galaxy does not have attribute "
+                        f"{op_kwargs['gal_attr']} "
+                        "to apply the cosmic SED filter: "
+                        f"{op_kwargs['lower_bound']} < "
+                        f"{op_kwargs['gal_attr']} < "
+                        f"{op_kwargs['upper_bound']}"
+                    )
+
+                if (
+                    op_kwargs["lower_bound"] is not None
+                    and gal_value < op_kwargs["lower_bound"]
+                ):
+                    continue
+                if (
+                    op_kwargs["upper_bound"] is not None
+                    and gal_value > op_kwargs["upper_bound"]
+                ):
+                    continue
+
+            label = op_kwargs["label"]
+            if label is None:
+                if op_kwargs["gal_attr"] is None:
+                    label = "All"
+                else:
+                    lower = (
+                        op_kwargs["lower_bound"]
+                        if op_kwargs["lower_bound"] is not None
+                        else "-inf"
+                    )
+                    upper = (
+                        op_kwargs["upper_bound"]
+                        if op_kwargs["upper_bound"] is not None
+                        else "inf"
+                    )
+                    label = (
+                        f"{lower} < {op_kwargs['gal_attr']} < {upper}".replace(
+                            ".", "p"
+                        )
+                    )
+
+            for model_label, sed in galaxy.spectra.items():
+                cosmic_sed = self.cosmic_fnus["Galaxy"].setdefault(label, {})
+                cosmic_sed.setdefault(model_label, 0 * sed.fnu)
+                cosmic_sed[model_label] += sed.fnu
+            if galaxy.stars is not None:
+                for model_label, sed in galaxy.stars.spectra.items():
+                    cosmic_sed = self.cosmic_fnus["Stars"].setdefault(
+                        label, {}
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * sed.fnu)
+                    cosmic_sed[model_label] += sed.fnu
+            if galaxy.black_holes is not None:
+                for model_label, sed in galaxy.black_holes.spectra.items():
+                    cosmic_sed = self.cosmic_fnus["BlackHole"].setdefault(
+                        label, {}
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * sed.fnu)
+                    cosmic_sed[model_label] += sed.fnu
+            if galaxy.gas is not None:
+                pass  # TODO: At the moment gas can't contribute
+
+        # Count the number of observed cosmic SED contributions
+        self._op_counts["Cosmic SED Fnu"] += 1
+
+        # Record the time taken
+        self._op_timing["Cosmic SED Fnu"] += time.perf_counter() - start
+
     def get_photometry_luminosities(
         self,
         *instruments,

--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -32,7 +32,7 @@ import time
 from pathlib import Path
 
 import numpy as np
-from unyt import unyt_array
+from unyt import unyt_array, unyt_quantity
 
 from synthesizer import check_atomic_timing, check_openmp, exceptions
 from synthesizer.instruments import InstrumentCollection
@@ -47,6 +47,7 @@ from synthesizer.pipeline.pipeline_utils import (
     combine_atomic_timing_snapshots,
     combine_list_of_dicts,
     count_and_check_dict_recursive,
+    divide_dicts_recursive,
     get_atomic_timing_snapshot,
     get_full_memory,
     plot_timing_analysis,
@@ -297,6 +298,16 @@ class Pipeline:
         self.fnu_spectra = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.cosmic_lnus = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.cosmic_fnus = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
+        self._cosmic_lnu_counts = {
+            "Galaxy": {},
+            "Stars": {},
+            "BlackHole": {},
+        }
+        self._cosmic_fnu_counts = {
+            "Galaxy": {},
+            "Stars": {},
+            "BlackHole": {},
+        }
         self.luminosities = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.fluxes = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.line_lums = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
@@ -1708,6 +1719,8 @@ class Pipeline:
         lower_bound=None,
         upper_bound=None,
         label=None,
+        average=False,
+        volume=None,
         write=True,
     ):
         """Flag that the Pipeline should compute the cosmic SED.
@@ -1741,6 +1754,12 @@ class Pipeline:
                 provided and no bounds are provided the label will be "All".
                 If bounds are provided but no label is provided the label will
                 be "{lower_bound}<{gal_attr}<{upper_bound}". Default is None.
+            average (bool):
+                Whether to return the average cosmic SED rather than the sum.
+                Default is False.
+            volume (unyt_quantity):
+                An optional volume used to normalise each contribution during
+                accumulation. Default is None.
             write (bool):
                 Whether to write out the cosmic SED. Default is True.
         """
@@ -1754,6 +1773,13 @@ class Pipeline:
                 "must be provided to apply the filter to."
             )
 
+        # Volume normalisation needs a unit-carrying quantity so the cosmic
+        # SED keeps physically meaningful units.
+        if volume is not None and not isinstance(volume, unyt_quantity):
+            raise exceptions.InconsistentArguments(
+                "volume must be a unyt_quantity with units if provided."
+            )
+
         # Store the arguments for the operation
         self._operation_kwargs.add(
             NO_MODEL_LABEL,
@@ -1762,6 +1788,8 @@ class Pipeline:
             lower_bound=lower_bound,
             upper_bound=upper_bound,
             label=label,
+            average=average,
+            volume=volume,
         )
 
         # Flag that we will compute the cosmic SED
@@ -1793,6 +1821,10 @@ class Pipeline:
         start = time.perf_counter()
 
         for _, op_kwargs in self._operation_kwargs["get_cosmic_sed"]:
+            # Volume normalisation is applied per contribution so the final MPI
+            # reduction can remain a simple additive sum.
+            volume = op_kwargs["volume"]
+
             # Set up the filter based on the provided kwargs
             if op_kwargs["gal_attr"] is not None:
                 # Get the value of the attribute to apply the filter to
@@ -1847,25 +1879,49 @@ class Pipeline:
 
             # Loop over the spectra on the galaxy and all its components and
             # sum them into the cosmic SED dictionary on the pipeline with the
-            # label as the key.
+            # label as the key. When averaging is requested we also keep a
+            # parallel count dictionary so the final mean can be computed after
+            # all ranks have been combined.
             for model_label, sed in galaxy.spectra.items():
                 cosmic_sed = self.cosmic_lnus["Galaxy"].setdefault(label, {})
-                cosmic_sed.setdefault(model_label, 0 * sed.lnu)
-                cosmic_sed[model_label] += sed.lnu
+                cosmic_counts = self._cosmic_lnu_counts["Galaxy"].setdefault(
+                    label, {}
+                )
+                contribution = sed.lnu if volume is None else sed.lnu / volume
+                cosmic_sed.setdefault(model_label, 0 * contribution)
+                cosmic_counts.setdefault(model_label, 0)
+                cosmic_sed[model_label] += contribution
+                cosmic_counts[model_label] += 1
             if galaxy.stars is not None:
                 for model_label, sed in galaxy.stars.spectra.items():
                     cosmic_sed = self.cosmic_lnus["Stars"].setdefault(
                         label, {}
                     )
-                    cosmic_sed.setdefault(model_label, 0 * sed.lnu)
-                    cosmic_sed[model_label] += sed.lnu
+                    cosmic_counts = self._cosmic_lnu_counts[
+                        "Stars"
+                    ].setdefault(label, {})
+                    contribution = (
+                        sed.lnu if volume is None else sed.lnu / volume
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * contribution)
+                    cosmic_counts.setdefault(model_label, 0)
+                    cosmic_sed[model_label] += contribution
+                    cosmic_counts[model_label] += 1
             if galaxy.black_holes is not None:
                 for model_label, sed in galaxy.black_holes.spectra.items():
                     cosmic_sed = self.cosmic_lnus["BlackHole"].setdefault(
                         label, {}
                     )
-                    cosmic_sed.setdefault(model_label, 0 * sed.lnu)
-                    cosmic_sed[model_label] += sed.lnu
+                    cosmic_counts = self._cosmic_lnu_counts[
+                        "BlackHole"
+                    ].setdefault(label, {})
+                    contribution = (
+                        sed.lnu if volume is None else sed.lnu / volume
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * contribution)
+                    cosmic_counts.setdefault(model_label, 0)
+                    cosmic_sed[model_label] += contribution
+                    cosmic_counts[model_label] += 1
             if galaxy.gas is not None:
                 pass  # TODO: At the moment gas can't contribute
 
@@ -1883,6 +1939,8 @@ class Pipeline:
         lower_bound=None,
         upper_bound=None,
         label=None,
+        average=False,
+        volume=None,
         write=True,
     ):
         """Flag that the Pipeline should compute the observed cosmic SED.
@@ -1904,6 +1962,12 @@ class Pipeline:
                 The upper bound to apply to the filter attribute.
             label (str):
                 An optional label for this cosmic SED in the outputs.
+            average (bool):
+                Whether to return the average observed cosmic SED rather than
+                the sum. Default is False.
+            volume (unyt_quantity):
+                An optional volume used to normalise each contribution during
+                accumulation. Default is None.
             write (bool):
                 Whether to write out the observed cosmic SED. Default is True.
         """
@@ -1917,6 +1981,13 @@ class Pipeline:
                 "must be provided to apply the filter to."
             )
 
+        # As for the rest-frame path, volume normalisation must be unit-aware
+        # so observer-frame cosmic SEDs carry the correct dimensions.
+        if volume is not None and not isinstance(volume, unyt_quantity):
+            raise exceptions.InconsistentArguments(
+                "volume must be a unyt_quantity with units if provided."
+            )
+
         # Store the arguments for the operation
         self._operation_kwargs.add(
             NO_MODEL_LABEL,
@@ -1927,6 +1998,8 @@ class Pipeline:
             lower_bound=lower_bound,
             upper_bound=upper_bound,
             label=label,
+            average=average,
+            volume=volume,
         )
 
         # Flag that we will compute the observed cosmic SED
@@ -1949,6 +2022,10 @@ class Pipeline:
         start = time.perf_counter()
 
         for _, op_kwargs in self._operation_kwargs["get_observed_cosmic_sed"]:
+            # Apply the same per-contribution volume normalisation in the
+            # observer frame as the rest-frame path.
+            volume = op_kwargs["volume"]
+
             # Set up the filter based on the provided kwargs
             if op_kwargs["gal_attr"] is not None:
                 gal_value = getattr(galaxy, op_kwargs["gal_attr"], None)
@@ -1995,24 +2072,49 @@ class Pipeline:
             else:
                 label = sanitise_hdf5_key_part(label)
 
+            # As for the rest-frame cosmic SED we accumulate both the summed
+            # contribution and, when needed, the number of contributors per
+            # leaf so averages can be formed after MPI reduction.
             for model_label, sed in galaxy.spectra.items():
                 cosmic_sed = self.cosmic_fnus["Galaxy"].setdefault(label, {})
-                cosmic_sed.setdefault(model_label, 0 * sed.fnu)
-                cosmic_sed[model_label] += sed.fnu
+                cosmic_counts = self._cosmic_fnu_counts["Galaxy"].setdefault(
+                    label, {}
+                )
+                contribution = sed.fnu if volume is None else sed.fnu / volume
+                cosmic_sed.setdefault(model_label, 0 * contribution)
+                cosmic_counts.setdefault(model_label, 0)
+                cosmic_sed[model_label] += contribution
+                cosmic_counts[model_label] += 1
             if galaxy.stars is not None:
                 for model_label, sed in galaxy.stars.spectra.items():
                     cosmic_sed = self.cosmic_fnus["Stars"].setdefault(
                         label, {}
                     )
-                    cosmic_sed.setdefault(model_label, 0 * sed.fnu)
-                    cosmic_sed[model_label] += sed.fnu
+                    cosmic_counts = self._cosmic_fnu_counts[
+                        "Stars"
+                    ].setdefault(label, {})
+                    contribution = (
+                        sed.fnu if volume is None else sed.fnu / volume
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * contribution)
+                    cosmic_counts.setdefault(model_label, 0)
+                    cosmic_sed[model_label] += contribution
+                    cosmic_counts[model_label] += 1
             if galaxy.black_holes is not None:
                 for model_label, sed in galaxy.black_holes.spectra.items():
                     cosmic_sed = self.cosmic_fnus["BlackHole"].setdefault(
                         label, {}
                     )
-                    cosmic_sed.setdefault(model_label, 0 * sed.fnu)
-                    cosmic_sed[model_label] += sed.fnu
+                    cosmic_counts = self._cosmic_fnu_counts[
+                        "BlackHole"
+                    ].setdefault(label, {})
+                    contribution = (
+                        sed.fnu if volume is None else sed.fnu / volume
+                    )
+                    cosmic_sed.setdefault(model_label, 0 * contribution)
+                    cosmic_counts.setdefault(model_label, 0)
+                    cosmic_sed[model_label] += contribution
+                    cosmic_counts[model_label] += 1
             if galaxy.gas is not None:
                 pass  # TODO: At the moment gas can't contribute
 
@@ -4174,14 +4276,97 @@ class Pipeline:
         for spec_type, spec in self.fnu_spectra["BlackHole"].items():
             self.fnu_spectra["BlackHole"][spec_type] = unyt_array(spec)
 
-        # Combine the cosmic SED dictionaries across ranks and normalise the
-        # result types for writing.
+        # Cosmic SEDs are global products rather than per-galaxy arrays, so in
+        # MPI mode we first gather and sum them onto rank 0. If averaging was
+        # requested we do the same for the parallel contributor counts so the
+        # final division is performed on the globally summed result.
         if self.using_mpi:
             cosmic_lnus = self.comm.gather(self.cosmic_lnus, root=0)
             cosmic_fnus = self.comm.gather(self.cosmic_fnus, root=0)
+            cosmic_lnu_counts = self.comm.gather(
+                self._cosmic_lnu_counts, root=0
+            )
+            cosmic_fnu_counts = self.comm.gather(
+                self._cosmic_fnu_counts, root=0
+            )
             if self.rank == 0:
                 self.cosmic_lnus = sum_dicts_recursive(cosmic_lnus)
                 self.cosmic_fnus = sum_dicts_recursive(cosmic_fnus)
+                self._cosmic_lnu_counts = sum_dicts_recursive(
+                    cosmic_lnu_counts
+                )
+                self._cosmic_fnu_counts = sum_dicts_recursive(
+                    cosmic_fnu_counts
+                )
+
+        # Convert any requested summed cosmic SEDs into averages once all
+        # contributions have been combined locally or across MPI ranks.
+        for _, op_kwargs in self._operation_kwargs["get_cosmic_sed"]:
+            if op_kwargs["average"]:
+                label = op_kwargs["label"]
+                if label is None:
+                    if op_kwargs["gal_attr"] is None:
+                        label = "All"
+                    else:
+                        lower = (
+                            op_kwargs["lower_bound"]
+                            if op_kwargs["lower_bound"] is not None
+                            else "-inf"
+                        )
+                        upper = (
+                            op_kwargs["upper_bound"]
+                            if op_kwargs["upper_bound"] is not None
+                            else "inf"
+                        )
+                        label = sanitise_hdf5_key_part(
+                            f"{lower} < {op_kwargs['gal_attr']} < {upper}"
+                        )
+                else:
+                    label = sanitise_hdf5_key_part(label)
+
+                for component in self.cosmic_lnus:
+                    if label in self.cosmic_lnus[component]:
+                        self.cosmic_lnus[component][label] = (
+                            divide_dicts_recursive(
+                                self.cosmic_lnus[component][label],
+                                self._cosmic_lnu_counts[component][label],
+                            )
+                        )
+
+        # Observer-frame cosmic SEDs follow the same post-reduction averaging
+        # path as the rest-frame version.
+        for _, op_kwargs in self._operation_kwargs["get_observed_cosmic_sed"]:
+            if op_kwargs["average"]:
+                label = op_kwargs["label"]
+                if label is None:
+                    if op_kwargs["gal_attr"] is None:
+                        label = "All"
+                    else:
+                        lower = (
+                            op_kwargs["lower_bound"]
+                            if op_kwargs["lower_bound"] is not None
+                            else "-inf"
+                        )
+                        upper = (
+                            op_kwargs["upper_bound"]
+                            if op_kwargs["upper_bound"] is not None
+                            else "inf"
+                        )
+                        label = sanitise_hdf5_key_part(
+                            f"{lower} < {op_kwargs['gal_attr']} < {upper}"
+                        )
+                else:
+                    label = sanitise_hdf5_key_part(label)
+
+                for component in self.cosmic_fnus:
+                    if label in self.cosmic_fnus[component]:
+                        self.cosmic_fnus[component][label] = (
+                            divide_dicts_recursive(
+                                self.cosmic_fnus[component][label],
+                                self._cosmic_fnu_counts[component][label],
+                            )
+                        )
+
         for component in self.cosmic_lnus:
             for label, spectra in self.cosmic_lnus[component].items():
                 for spec_type, spec in spectra.items():

--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -289,6 +289,8 @@ class Pipeline:
         self.sfhs = []
         self.lnu_spectra = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.fnu_spectra = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
+        self.cosmic_lnus = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
+        self.cosmic_fnus = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.luminosities = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.fluxes = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
         self.line_lums = {"Galaxy": {}, "Stars": {}, "BlackHole": {}}
@@ -1679,6 +1681,167 @@ class Pipeline:
 
         # Record the time taken
         self._op_timing["Fnu Spectra"] += time.perf_counter() - start
+
+    def get_cosmic_sed(
+        self,
+        gal_attr=None,
+        lower_bound=None,
+        upper_bound=None,
+        label=None,
+        write=True,
+    ):
+        """Flag that the Pipeline should compute the cosmic SED.
+
+        This will signal the Pipeline to sum the spectra into a single
+        cosmic SED when the run method is called.
+
+        The cosmic SED can be computed for a subset of galaxies based on a
+        particular galaxy/star/black hole/gas property. By default it will be
+        computed for all galaxies.
+
+        Calling this method multiple times with different property bounds will
+        compute a cosmic SED for each set of bounds, allowing for comparisons
+        between different subsets of the galaxy population.
+
+        Args:
+            gal_attr (str):
+                The name of a galaxy attribute to use as a filter for the
+                cosmic SED. This should be a singular value that can be
+                compared to the lower_bound and upper_bound, i.e.
+                lower < gal_attr < upper. If None, the cosmic SED will include
+                a contribution from all galaxies. Default is None.
+            lower_bound (float/unyt_quantity):
+                The lower bound to apply to the filter attribute. If None,
+                no lower bound will be applied. Default is None.
+            upper_bound (float/unyt_quantity):
+                The upper bound to apply to the filter attribute. If None,
+                no upper bound will be applied. Default is None.
+            label (str):
+                An optional label for this cosmic SED in the outputs. If not
+                provided and no bounds are provided the label will be "All".
+                If bounds are provided but no label is provided the label will
+                be "{lower_bound}<{gal_attr}<{upper_bound}". Default is None.
+            write (bool):
+                Whether to write out the cosmic SED. Default is True.
+        """
+        # If either bound is provided we need an emitter attribute to apply
+        # the filter to
+        if (
+            lower_bound is not None or upper_bound is not None
+        ) and gal_attr is None:
+            raise exceptions.InconsistentArguments(
+                "If either lower_bound or upper_bound is provided, gal_attr "
+                "must be provided to apply the filter to."
+            )
+
+        # Store the arguments for the operation
+        self._operation_kwargs.add(
+            NO_MODEL_LABEL,
+            "get_cosmic_sed",
+            gal_attr=gal_attr,
+            lower_bound=lower_bound,
+            upper_bound=upper_bound,
+            label=label,
+        )
+
+        # Flag that we will compute the cosmic SED
+        self._do_cosmic_lnu = True
+
+        # Flag that we will want to write out the cosmic SED (calling the
+        # get_cosmic_sed method is considered the intent to write it out by
+        # default)
+        self._write_cosmic_lnu = write or self._write_cosmic_lnu
+
+        # To compute the cosmic SED we need to ensure the spectra are computed
+        # first. Note that this is safe if the user has already called
+        # get_spectra, it will just leave the flag as True and respect the
+        # original intent to write or not write the spectra.
+        self.get_spectra(write=False)
+
+    @timed("Pipeline._get_cosmic_sed")
+    def _get_cosmic_sed(self, galaxy):
+        """Compute the cosmic SED for a galaxy.
+
+        This is a helper function that computes the contribution of a single
+        galaxy to the cosmic SED. The contributions from all galaxies will be
+        summed together to get the final cosmic SED.
+
+        Args:
+            galaxy (Galaxy):
+                The galaxy to compute the cosmic SED contribution for.
+        """
+        # Get the operation kwargs for this operation
+        op_kwargs = self._operation_kwargs.get_unique_kwargs("get_cosmic_sed")
+
+        # Set up the filter based on the provided kwargs
+        if op_kwargs["gal_attr"] is not None:
+            # Get the value of the attribute to apply the filter to
+            gal_value = getattr(galaxy, op_kwargs["gal_attr"], None)
+
+            # If the galaxy doesn't have the attribute throw an error, we
+            # can't proceed
+            if gal_value is None:
+                raise exceptions.PipelineNotReady(
+                    f"Galaxy does not have attribute {op_kwargs['gal_attr']} "
+                    "to apply the cosmic SED filter: "
+                    f"{op_kwargs['lower_bound']} < "
+                    f"{op_kwargs['gal_attr']} < {op_kwargs['upper_bound']}"
+                )
+
+            # If we are outside the bounds we have nothing to contribute
+            if (
+                op_kwargs["lower_bound"] is not None
+                and gal_value < op_kwargs["lower_bound"]
+            ):
+                return
+            if (
+                op_kwargs["upper_bound"] is not None
+                and gal_value > op_kwargs["upper_bound"]
+            ):
+                return
+
+        # Get the label for this contribution to the cosmic SED
+        label = op_kwargs["label"]
+        if label is None:
+            # We have no label, make one
+            if op_kwargs["gal_attr"] is None:
+                label = "All"
+            else:
+                lower = (
+                    op_kwargs["lower_bound"]
+                    if op_kwargs["lower_bound"] is not None
+                    else "-inf"
+                )
+                upper = (
+                    op_kwargs["upper_bound"]
+                    if op_kwargs["upper_bound"] is not None
+                    else "inf"
+                )
+                label = f"{lower} < {op_kwargs['gal_attr']} < {upper}".replace(
+                    ".", "p"
+                )
+
+        # Loop over the spectra on the galaxy and all its components and sum
+        # them into the cosmic SED dictionary on the pipeline with the label
+        # as the key.
+        for model_label, sed in galaxy.spectra.items():
+            cosmic_sed = self.cosmic_lnus["Galaxy"].setdefault(label, {})
+            cosmic_sed.setdefault(model_label, np.zeros_like(sed._lnu))
+            cosmic_sed[model_label] += sed._lnu
+        if galaxy.stars is not None:
+            for model_label, sed in galaxy.stars.spectra.items():
+                cosmic_sed = self.cosmic_lnus["Stars"].setdefault(label, {})
+                cosmic_sed.setdefault(model_label, np.zeros_like(sed._lnu))
+                cosmic_sed[model_label] += sed._lnu
+        if galaxy.black_holes is not None:
+            for model_label, sed in galaxy.black_holes.spectra.items():
+                cosmic_sed = self.cosmic_lnus["BlackHoles"].setdefault(
+                    label, {}
+                )
+                cosmic_sed.setdefault(model_label, np.zeros_like(sed._lnu))
+                cosmic_sed[model_label] += sed._lnu
+        if galaxy.gas is not None:
+            pass  # TODO: At the moment gas can't contribute to the cosmic SED
 
     def get_photometry_luminosities(
         self,

--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -1773,11 +1773,25 @@ class Pipeline:
                 "must be provided to apply the filter to."
             )
 
+        if (
+            lower_bound is not None
+            and upper_bound is not None
+            and lower_bound > upper_bound
+        ):
+            raise exceptions.InconsistentArguments(
+                "lower_bound cannot be greater than upper_bound."
+            )
+
         # Volume normalisation needs a unit-carrying quantity so the cosmic
         # SED keeps physically meaningful units.
         if volume is not None and not isinstance(volume, unyt_quantity):
             raise exceptions.InconsistentArguments(
                 "volume must be a unyt_quantity with units if provided."
+            )
+
+        if volume is not None and volume <= 0 * volume.units:
+            raise exceptions.InconsistentArguments(
+                "volume must be greater than 0 if provided."
             )
 
         # Store the arguments for the operation
@@ -1981,11 +1995,25 @@ class Pipeline:
                 "must be provided to apply the filter to."
             )
 
+        if (
+            lower_bound is not None
+            and upper_bound is not None
+            and lower_bound > upper_bound
+        ):
+            raise exceptions.InconsistentArguments(
+                "lower_bound cannot be greater than upper_bound."
+            )
+
         # As for the rest-frame path, volume normalisation must be unit-aware
         # so observer-frame cosmic SEDs carry the correct dimensions.
         if volume is not None and not isinstance(volume, unyt_quantity):
             raise exceptions.InconsistentArguments(
                 "volume must be a unyt_quantity with units if provided."
+            )
+
+        if volume is not None and volume <= 0 * volume.units:
+            raise exceptions.InconsistentArguments(
+                "volume must be greater than 0 if provided."
             )
 
         # Store the arguments for the operation

--- a/src/synthesizer/pipeline/pipeline_utils.py
+++ b/src/synthesizer/pipeline/pipeline_utils.py
@@ -981,6 +981,17 @@ def sanitise_hdf5_key_part(value):
     )
 
 
+def divide_dicts_recursive(data, divisors):
+    """Divide nested dictionary leaves by matching nested divisors."""
+    if isinstance(data, dict):
+        return {
+            key: divide_dicts_recursive(data[key], divisors[key])
+            for key in data
+            if key in divisors
+        }
+    return data / divisors
+
+
 def unify_dict_structure_across_ranks(data, comm, root=0):
     """Recursively unify the structure of a dictionary across all ranks.
 

--- a/src/synthesizer/pipeline/pipeline_utils.py
+++ b/src/synthesizer/pipeline/pipeline_utils.py
@@ -940,6 +940,40 @@ def combine_list_of_dicts(dicts):
     return recursive_merge(dicts)
 
 
+def sum_dicts_recursive(dicts):
+    """Sum a list of nested dictionaries with additive leaves.
+
+    Args:
+        dicts (list):
+            A list of dictionaries or additive leaf values.
+
+    Returns:
+        dict or object:
+            The recursively summed dictionary or leaf value.
+    """
+    values = [value for value in dicts if value is not None]
+    if len(values) == 0:
+        return {}
+
+    if not isinstance(values[0], dict):
+        total = values[0]
+        for value in values[1:]:
+            total = total + value
+        return total
+
+    summed = {}
+    keys = set()
+    for value in values:
+        keys.update(value.keys())
+
+    for key in keys:
+        summed[key] = sum_dicts_recursive(
+            [value[key] for value in values if key in value]
+        )
+
+    return summed
+
+
 def unify_dict_structure_across_ranks(data, comm, root=0):
     """Recursively unify the structure of a dictionary across all ranks.
 

--- a/src/synthesizer/pipeline/pipeline_utils.py
+++ b/src/synthesizer/pipeline/pipeline_utils.py
@@ -974,6 +974,13 @@ def sum_dicts_recursive(dicts):
     return summed
 
 
+def sanitise_hdf5_key_part(value):
+    """Return a HDF5-safe string fragment for generated labels."""
+    return (
+        str(value).replace(".", "p").replace("/", "_per_").replace("\\", "_")
+    )
+
+
 def unify_dict_structure_across_ranks(data, comm, root=0):
     """Recursively unify the structure of a dictionary across all ranks.
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2288,6 +2288,8 @@ class TestGalaxySplitting:
         for pipeline in (unsplit_pipeline, split_pipeline):
             pipeline.get_spectra()
             pipeline.get_observed_spectra(cosmo=cosmo)
+            pipeline.get_cosmic_sed()
+            pipeline.get_observed_cosmic_sed(cosmo=cosmo)
             pipeline.get_sfzh(
                 log10ages=test_grid.log10ages,
                 metallicities=test_grid.metallicities,
@@ -2298,6 +2300,8 @@ class TestGalaxySplitting:
         for attr in (
             "lnu_spectra",
             "fnu_spectra",
+            "cosmic_lnus",
+            "cosmic_fnus",
             "sfzhs",
             "sfhs",
         ):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -665,6 +665,34 @@ class TestPipelineOperations:
             > 0
         ), "No spectra were calculated"
 
+    def test_get_cosmic_sed_rejects_inverted_bounds(
+        self, pipeline_with_galaxies
+    ):
+        """Cosmic SED signalling should reject inverted bounds."""
+        with pytest.raises(
+            exceptions.InconsistentArguments,
+            match="lower_bound cannot be greater than upper_bound",
+        ):
+            pipeline_with_galaxies.get_cosmic_sed(
+                gal_attr="stellar_mass",
+                lower_bound=2,
+                upper_bound=1,
+            )
+
+    def test_get_observed_cosmic_sed_rejects_non_positive_volume(
+        self,
+        pipeline_with_galaxies,
+    ):
+        """Observed cosmic SED signalling should require positive volume."""
+        with pytest.raises(
+            exceptions.InconsistentArguments,
+            match="volume must be greater than 0 if provided",
+        ):
+            pipeline_with_galaxies.get_observed_cosmic_sed(
+                cosmo=cosmo,
+                volume=0 * Mpc**3,
+            )
+
     def test_run_pipeline_fnu_spectra(
         self,
         pipeline_with_galaxies,
@@ -2356,14 +2384,10 @@ class TestGalaxySplitting:
         n_contributors = len(galaxies_sum)
         volume = 2 * Mpc**3
 
-        sum_pipeline.get_spectra()
-        sum_pipeline.get_observed_spectra(cosmo=cosmo)
         sum_pipeline.get_cosmic_sed(label="sum")
         sum_pipeline.get_observed_cosmic_sed(cosmo=cosmo, label="sum")
         sum_pipeline.run()
 
-        avg_pipeline.get_spectra()
-        avg_pipeline.get_observed_spectra(cosmo=cosmo)
         avg_pipeline.get_cosmic_sed(
             label="avg",
             average=True,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2272,8 +2272,18 @@ class TestGalaxySplitting:
         unsplit_galaxy = copy.deepcopy(random_particle_galaxy)
         split_galaxy = copy.deepcopy(random_particle_galaxy)
         split_threshold = max(2, split_galaxy.stars.nparticles // 4)
+        unsplit_galaxy.calculate_integrated_stellar_properties()
+        split_galaxy.calculate_integrated_stellar_properties()
 
-        assert len(split_galaxy.split(split_threshold)) > 1
+        split_children = split_galaxy.split(split_threshold)
+        assert len(split_children) > 1
+
+        unsplit_galaxy._cosmic_filter_test = 2.0
+        split_galaxy._cosmic_filter_test = 2.0
+        for child in split_children:
+            child._cosmic_filter_test = 1.0
+
+        lower_bound = 1.5
 
         unsplit_pipeline = self._make_pipeline(
             copy.deepcopy(nebular_emission_model),
@@ -2288,14 +2298,26 @@ class TestGalaxySplitting:
         for pipeline in (unsplit_pipeline, split_pipeline):
             pipeline.get_spectra()
             pipeline.get_observed_spectra(cosmo=cosmo)
-            pipeline.get_cosmic_sed()
-            pipeline.get_observed_cosmic_sed(cosmo=cosmo)
+            pipeline.get_cosmic_sed(
+                gal_attr="_cosmic_filter_test",
+                lower_bound=lower_bound,
+            )
+            pipeline.get_observed_cosmic_sed(
+                cosmo=cosmo,
+                gal_attr="_cosmic_filter_test",
+                lower_bound=lower_bound,
+            )
             pipeline.get_sfzh(
                 log10ages=test_grid.log10ages,
                 metallicities=test_grid.metallicities,
             )
             pipeline.get_sfh(log10ages=test_grid.log10ages)
             pipeline.run()
+
+        assert any(unsplit_pipeline.cosmic_lnus.values())
+        assert any(unsplit_pipeline.cosmic_fnus.values())
+        assert any(split_pipeline.cosmic_lnus.values())
+        assert any(split_pipeline.cosmic_fnus.values())
 
         for attr in (
             "lnu_spectra",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2432,6 +2432,73 @@ class TestGalaxySplitting:
                     expected,
                 )
 
+    def test_cosmic_sed_duplicate_average_requests_share_label(
+        self,
+        random_particle_galaxy,
+        nebular_emission_model,
+    ):
+        """Duplicate average requests with one label should not re-average."""
+        galaxies_sum = [
+            copy.deepcopy(random_particle_galaxy),
+            copy.deepcopy(random_particle_galaxy),
+        ]
+        galaxies_avg = [copy.deepcopy(gal) for gal in galaxies_sum]
+
+        sum_pipeline = self._make_pipeline(
+            copy.deepcopy(nebular_emission_model),
+            galaxies_sum,
+        )
+        avg_pipeline = self._make_pipeline(
+            copy.deepcopy(nebular_emission_model),
+            galaxies_avg,
+        )
+
+        n_contributors = len(galaxies_sum)
+
+        sum_pipeline.get_cosmic_sed(label="sum")
+        sum_pipeline.get_observed_cosmic_sed(cosmo=cosmo, label="sum")
+        sum_pipeline.run()
+
+        avg_pipeline.get_cosmic_sed(label="dup", average=True)
+        avg_pipeline.get_cosmic_sed(label="dup", average=True)
+        avg_pipeline.get_observed_cosmic_sed(
+            cosmo=cosmo,
+            label="dup",
+            average=True,
+        )
+        avg_pipeline.get_observed_cosmic_sed(
+            cosmo=cosmo,
+            label="dup",
+            average=True,
+        )
+        avg_pipeline.run()
+
+        for component in sum_pipeline.cosmic_lnus:
+            if "sum" not in sum_pipeline.cosmic_lnus[component]:
+                continue
+            assert "dup" in avg_pipeline.cosmic_lnus[component]
+            for model_label, spec in sum_pipeline.cosmic_lnus[component][
+                "sum"
+            ].items():
+                expected = spec / n_contributors
+                _assert_nested_allclose(
+                    avg_pipeline.cosmic_lnus[component]["dup"][model_label],
+                    expected,
+                )
+
+        for component in sum_pipeline.cosmic_fnus:
+            if "sum" not in sum_pipeline.cosmic_fnus[component]:
+                continue
+            assert "dup" in avg_pipeline.cosmic_fnus[component]
+            for model_label, spec in sum_pipeline.cosmic_fnus[component][
+                "sum"
+            ].items():
+                expected = spec / n_contributors
+                _assert_nested_allclose(
+                    avg_pipeline.cosmic_fnus[component]["dup"][model_label],
+                    expected,
+                )
+
     def test_split_matches_unsplit_resolved_outputs(
         self,
         random_particle_galaxy,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2332,6 +2332,82 @@ class TestGalaxySplitting:
                 getattr(split_pipeline, attr),
             )
 
+    def test_cosmic_sed_average_and_volume(
+        self,
+        random_particle_galaxy,
+        nebular_emission_model,
+    ):
+        """Average and volume-normalised cosmic SEDs should match sums."""
+        galaxies_sum = [
+            copy.deepcopy(random_particle_galaxy),
+            copy.deepcopy(random_particle_galaxy),
+        ]
+        galaxies_avg = [copy.deepcopy(gal) for gal in galaxies_sum]
+
+        sum_pipeline = self._make_pipeline(
+            copy.deepcopy(nebular_emission_model),
+            galaxies_sum,
+        )
+        avg_pipeline = self._make_pipeline(
+            copy.deepcopy(nebular_emission_model),
+            galaxies_avg,
+        )
+
+        n_contributors = len(galaxies_sum)
+        volume = 2 * Mpc**3
+
+        sum_pipeline.get_spectra()
+        sum_pipeline.get_observed_spectra(cosmo=cosmo)
+        sum_pipeline.get_cosmic_sed(label="sum")
+        sum_pipeline.get_observed_cosmic_sed(cosmo=cosmo, label="sum")
+        sum_pipeline.run()
+
+        avg_pipeline.get_spectra()
+        avg_pipeline.get_observed_spectra(cosmo=cosmo)
+        avg_pipeline.get_cosmic_sed(
+            label="avg",
+            average=True,
+            volume=volume,
+        )
+        avg_pipeline.get_observed_cosmic_sed(
+            cosmo=cosmo,
+            label="avg",
+            average=True,
+            volume=volume,
+        )
+        avg_pipeline.run()
+
+        assert any(sum_pipeline.cosmic_lnus.values())
+        assert any(sum_pipeline.cosmic_fnus.values())
+        assert any(avg_pipeline.cosmic_lnus.values())
+        assert any(avg_pipeline.cosmic_fnus.values())
+
+        for component in sum_pipeline.cosmic_lnus:
+            if "sum" not in sum_pipeline.cosmic_lnus[component]:
+                continue
+            assert "avg" in avg_pipeline.cosmic_lnus[component]
+            for model_label, spec in sum_pipeline.cosmic_lnus[component][
+                "sum"
+            ].items():
+                expected = spec / n_contributors / volume
+                _assert_nested_allclose(
+                    avg_pipeline.cosmic_lnus[component]["avg"][model_label],
+                    expected,
+                )
+
+        for component in sum_pipeline.cosmic_fnus:
+            if "sum" not in sum_pipeline.cosmic_fnus[component]:
+                continue
+            assert "avg" in avg_pipeline.cosmic_fnus[component]
+            for model_label, spec in sum_pipeline.cosmic_fnus[component][
+                "sum"
+            ].items():
+                expected = spec / n_contributors / volume
+                _assert_nested_allclose(
+                    avg_pipeline.cosmic_fnus[component]["avg"][model_label],
+                    expected,
+                )
+
     def test_split_matches_unsplit_resolved_outputs(
         self,
         random_particle_galaxy,


### PR DESCRIPTION
Since we may not always want to save spectra to calculate the Cosmic SED when running a ``Pipeline`` it seems worthwhile that we introduce a baked-in accumulation to collect the spectra as we go through the ``Pipeline``. 

This new method (and the observer frame equivalent) supports arbitrary galaxy attribute filters with an upper or lower bound (and the option to associate a custom label) to enable simple binning of the Cosmic SED. 

I have run this with the COLIBRE pipeline and got a bunch of Cosmic SEDs out comparing different things:
<img width="1682" height="1379" alt="cosmic_sed_chabrier_los_sps_comparison_cosmic_sed_luminosity" src="https://github.com/user-attachments/assets/1aeb7da4-6ec0-4957-9623-2effe00acc6a" />
<img width="1680" height="1379" alt="cosmic_sed_chabrier_los_model_comparison_cosmic_sed_luminosity" src="https://github.com/user-attachments/assets/29330c27-8885-41fd-99a2-543463d6ef53" />
<img width="1680" height="1380" alt="cosmic_sed_chabrier_colibreLOS_intrinsic_attenuated_cosmic_sed_luminosity" src="https://github.com/user-attachments/assets/203d142f-2e3c-458d-8962-70aaa0a51e9c" />

And here using the binning functionality:
<img width="1679" height="1378" alt="cosmic_sed_chabrier_colibreLOS_attenuated_by_mass_cosmic_sed_luminosity" src="https://github.com/user-attachments/assets/b1ab68b1-5dd7-4cc3-ae7a-3167292078e6" />


## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cosmic SED aggregation across galaxy samples (rest-frame Lnu and observer-frame Fnu) with optional attribute filtering, averaging, volume normalization, labeled outputs, and writable outputs.

* **Documentation**
  * Added notebook example demonstrating cosmic SED and observed cosmic SED usage and integration into the workflow.

* **Tests**
  * Added and extended tests verifying cosmic SED sum/average behavior, volume normalization, error handling, and split/unsplit consistency.

* **Bug Fixes**
  * Minor docstring typo corrected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->