### PR TITLE
Version string printed by report and None `weight_var`

### DIFF
--- a/src/synthesizer/data/initialise.py
+++ b/src/synthesizer/data/initialise.py
@@ -18,6 +18,7 @@ import yaml
 from platformdirs import user_data_dir
 
 from synthesizer import exceptions
+from synthesizer._version import __version__
 
 # ASCII art mirror of the galaxy logo (cannot import directly)
 galaxy = (
@@ -418,8 +419,14 @@ class SynthesizerInitializer:
         elif default_units_needs_update():
             self._copy_units()
 
-    def report(self) -> None:
-        """Print a report of the initialisation."""
+    def report(self, initialising: bool = False) -> None:
+        """Print a report of the initialisation or configuration.
+
+        Args:
+            initialising (bool):
+                Whether this report is being printed as part of an actual
+                initialisation run.
+        """
         # ANSI escape codes for styling
         yellow = "\033[93m"
         green = "\033[92m"
@@ -469,8 +476,12 @@ class SynthesizerInitializer:
         galaxy_lines = galaxy.splitlines()
         centered = "\n".join(line.center(100) for line in galaxy_lines)
 
-        # Print the initialisation header with centered galaxy art
-        print(f"{yellow}Synthesizer initialising...{reset}\n\n{centered}\n")
+        # Print the report header with centered galaxy art.
+        if initialising:
+            print(f"{yellow}Synthesizer initialising...{reset}")
+
+        print(f"\n{centered}\n")
+        print(f"  {cyan}Version: {__version__}{reset}\n")
 
         # Print the status of directories and files
         print("  Initialised Synthesizer directories:")
@@ -503,7 +514,8 @@ class SynthesizerInitializer:
                 print(f"    {magenta}export {var}='{default}'{reset}")
         print()
 
-        print(f"{green}Synthesizer initialisation complete!{reset}\n")
+        if initialising:
+            print(f"{green}Synthesizer initialisation complete!{reset}\n")
 
 
 def synth_initialise(verbose=True) -> None:
@@ -544,7 +556,7 @@ def synth_initialise(verbose=True) -> None:
     # what is necessary
     initializer = SynthesizerInitializer()
     initializer.initialize()
-    initializer.report()
+    initializer.report(initialising=True)
 
 
 def synth_report_config() -> None:

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -288,6 +288,8 @@ class Grid:
             # What component variable do we need to weight by for the
             # emission in the grid?
             self._weight_var = hf.attrs.get("WeightVariable")
+            if self._weight_var == "None":
+                self._weight_var = None
 
             # Loop over the Model metadata stored in the Model group
             # and store it in the Grid object

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -40,6 +40,29 @@ class TestGridInitialization:
         assert len(test_grid.axes) == test_grid.naxes
         assert test_grid.has_spectra or test_grid.has_lines
 
+    def test_string_none_weight_var_is_normalised(self, tmp_path, test_grid):
+        """Test WeightVariable='None' is normalised on read."""
+        from pathlib import Path
+
+        import h5py
+
+        grid_path = Path(tmp_path) / "normalised_none_weight_grid.hdf5"
+
+        with (
+            h5py.File(test_grid.grid_filename, "r") as src,
+            h5py.File(grid_path, "w") as dst,
+        ):
+            for key, value in src.attrs.items():
+                dst.attrs[key] = value
+            dst.attrs["WeightVariable"] = "None"
+
+            for key in src.keys():
+                src.copy(key, dst)
+
+        grid = Grid(grid_path.name, grid_dir=grid_path.parent)
+
+        assert grid._weight_var is None
+
     def test_grid_shape_properties(self, test_grid):
         """Test Grid shape and dimension properties."""
         shape = test_grid.shape

--- a/tests/test_initialisation.py
+++ b/tests/test_initialisation.py
@@ -22,6 +22,7 @@ from synthesizer.data.initialise import (
     instrument_cache_exists,
     synth_clear_data,
     synth_initialise,
+    synth_report_config,
 )
 
 
@@ -289,9 +290,9 @@ class TestInitializerMethods:
             p.mkdir(parents=True, exist_ok=True)
         init.report()
         out = capsys.readouterr().out
-        assert "Synthesizer initialising" in out
+        assert "Version:" in out
         assert "Initialised Synthesizer directories" in out
-        assert "Synthesizer initialisation complete" in out
+        assert "Synthesizer initialising" not in out
 
 
 class TestUnitsFileHandling:
@@ -511,7 +512,33 @@ class TestTopLevelFlows:
         synth_initialise()
         out = capsys.readouterr().out
         assert "Synthesizer initialising" in out
+        assert "Version:" in out
         assert (tmp_path / "base").exists()
+
+    def test_synth_report_config_does_not_claim_initialising(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        """Test synth_report_config prints config details without init text."""
+        monkeypatch.setenv("SYNTHESIZER_DIR", str(tmp_path / "base"))
+        monkeypatch.setenv(
+            "SYNTHESIZER_DATA_DIR", str(tmp_path / "base" / "data")
+        )
+        monkeypatch.setenv(
+            "SYNTHESIZER_GRID_DIR", str(tmp_path / "base" / "grids")
+        )
+        monkeypatch.setenv(
+            "SYNTHESIZER_TEST_DATA_DIR",
+            str(tmp_path / "base" / "data" / "test"),
+        )
+        monkeypatch.setenv(
+            "SYNTHESIZER_INSTRUMENT_CACHE", str(tmp_path / "base" / "inst")
+        )
+
+        synth_report_config()
+
+        out = capsys.readouterr().out
+        assert "Synthesizer initialising" not in out
+        assert "Version:" in out
 
     def test_synth_clear_data_removes_all(self, monkeypatch, tmp_path):
         """Test synth_clear_data removes all Synthesizer dirs."""

--- a/tests/test_unified_agn.py
+++ b/tests/test_unified_agn.py
@@ -1,14 +1,19 @@
 """Test suite for the UnifiedAGN emission model."""
 
+from pathlib import Path
+
+import h5py
 import numpy as np
 import pytest
 from unyt import K, Mpc, Msun, deg, yr
 
 from synthesizer.emission_models.agn.unified_agn import UnifiedAGN
+from synthesizer.emission_models.base_model import BlackHoleEmissionModel
 from synthesizer.emission_models.generators.dust.greybody import Greybody
 from synthesizer.emission_models.transformers.dust_attenuation import PowerLaw
 from synthesizer.emission_models.utils import get_param
 from synthesizer.exceptions import InconsistentParameter
+from synthesizer.grid import Grid
 from synthesizer.particle.blackholes import BlackHoles
 
 
@@ -55,6 +60,57 @@ def make_unified_agn(
 def get_intrinsic_model(model):
     """Return the intrinsic UnifiedAGN model carrying transmission branches."""
     return model if hasattr(model, "disc_escaped") else model.intrinsic
+
+
+def make_no_weight_bh_grid(tmp_path: Path):
+    """Write a minimal BH-compatible grid with WeightVariable='None'."""
+    grid_path = tmp_path / "bh_no_weight_grid.hdf5"
+
+    with h5py.File(grid_path, "w") as hdf:
+        hdf.attrs["axes"] = np.array(
+            ["mass", "accretion_rate"],
+            dtype=object,
+        )
+        hdf.attrs["WeightVariable"] = "None"
+
+        axes = hdf.create_group("axes")
+
+        mass = axes.create_dataset(
+            "mass",
+            data=np.array([1.0e6, 2.0e6, 3.0e6]),
+        )
+        mass.attrs["Units"] = "Msun"
+        mass.attrs["log_on_read"] = False
+
+        accretion_rate = axes.create_dataset(
+            "accretion_rate",
+            data=np.array([0.5, 1.0, 2.0]),
+        )
+        accretion_rate.attrs["Units"] = "Msun/yr"
+        accretion_rate.attrs["log_on_read"] = False
+
+        spectra = hdf.create_group("spectra")
+        wavelength = spectra.create_dataset(
+            "wavelength",
+            data=np.array([1000.0, 1500.0, 2000.0]),
+        )
+        wavelength.attrs["Units"] = "angstrom"
+
+        spectra.create_dataset("incident", data=np.ones((3, 3, 3)))
+        spectra.create_dataset(
+            "transmitted",
+            data=np.full((3, 3, 3), 0.5),
+        )
+        spectra.create_dataset(
+            "nebular",
+            data=np.full((3, 3, 3), 0.25),
+        )
+        spectra.create_dataset(
+            "nebular_continuum",
+            data=np.full((3, 3, 3), 0.1),
+        )
+
+    return Grid(grid_path.name, grid_dir=grid_path.parent, ignore_lines=True)
 
 
 class TestUnifiedAGN:
@@ -307,3 +363,30 @@ class TestUnifiedAGN:
         """Test invalid transmission options are rejected."""
         with pytest.raises(InconsistentParameter):
             make_unified_agn(test_grid, disc_transmission="definitely_wrong")
+
+    def test_spectra_generation_with_string_none_weight_var(
+        self,
+        tmp_path,
+    ):
+        """BH extraction should work when grid metadata stores 'None'."""
+        no_weight_grid = make_no_weight_bh_grid(tmp_path)
+        black_holes = make_black_holes(
+            covering_fraction_blr=np.array([0.2, 0.3]),
+            covering_fraction_nlr=np.array([0.1, 0.4]),
+        )
+        model = BlackHoleEmissionModel(
+            grid=no_weight_grid,
+            label="disc_incident_isotropic",
+            extract="incident",
+            cosine_inclination=0.5,
+            hydrogen_density="hydrogen_density_blr",
+            ionisation_parameter="ionisation_parameter_blr",
+        )
+
+        assert no_weight_grid._weight_var is None
+
+        spectra = black_holes.get_spectra(model)
+
+        assert spectra is not None
+        assert model.label in black_holes.spectra
+        assert black_holes.spectra[model.label].shape[-1] == len(model.lam)


### PR DESCRIPTION
This PR simply replaces "None" with None for `_weight_var` to help the behind-the-scenes machinery properly handle Nonetype weight variables from grids. This is not a "it didn't work before" issue; this change just means there are few options to check moving forward when this sort of machinery needs investigating. 

In addition to this, to make it easier for people to quickly get the version string, `synthesizer-report` will now print the version string. 

Finally, a few extra tests have been added.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grid metadata loading to properly handle weight variable attributes, converting string representations to actual values.

* **New Features**
  * Added version information to initializer reports.
  * Improved contextual reporting during initialization process.

* **Tests**
  * Expanded test coverage for grid metadata handling and black hole emission model functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->