### PR TITLE
Fix issue with PhotometryCollection units

### DIFF
--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -80,7 +80,8 @@ class PhotometryCollection:
                 f"{len(self.filter_codes)})."
             )
 
-        is_flux = photometry.units == self.__class__.__dict__["photo_fnu"].unit
+        fnu_unit = self.__class__.__dict__["photo_fnu"].unit
+        is_flux = photometry.units.same_dimensions_as(fnu_unit)
 
         # Keep raw ndarray storage and rely on Quantity descriptors for
         # units.

--- a/tests/test_photometry.py
+++ b/tests/test_photometry.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pytest
-from unyt import Hz, angstrom, c, erg, s
+from unyt import Hz, angstrom, c, erg, nJy, s
 
 from synthesizer import exceptions
 from synthesizer.instruments import FilterCollection
@@ -48,6 +48,37 @@ def test_photometry_collection_requires_units_on_input_array():
             filters,
             photometry=arr,
         )
+
+
+def test_photometry_collection_preserves_units_on_input_array():
+    """Constructor should preserve units on input array."""
+    lam = np.linspace(1000, 5000, 500) * angstrom
+    filters = _make_filters(lam)
+
+    arr = np.array([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]]) * erg / s / Hz
+    pc = PhotometryCollection(
+        filters,
+        photometry=arr,
+    )
+
+    assert pc.photometry is not None
+    assert pc.photo_lnu is not None
+    assert pc.photo_fnu is None
+
+    assert pc.photometry.units.same_dimensions_as(erg / s / Hz)
+    assert pc.photo_lnu.units.same_dimensions_as(erg / s / Hz)
+
+    arr = np.array([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]]) * nJy
+    pc = PhotometryCollection(
+        filters,
+        photometry=arr,
+    )
+
+    assert pc.photometry is not None
+    assert pc.photo_lnu is None
+    assert pc.photo_fnu is not None
+    assert pc.photometry.units.same_dimensions_as(nJy)
+    assert pc.photo_fnu.units.same_dimensions_as(nJy)
 
 
 def test_photometry_collection_select_preserves_lookup():


### PR DESCRIPTION
## Issue Type
- Bug

`PhotometryCollection - get_photo_fnu` appears to be storing fluxes as luminosities (.photo_lnu) not flux density (.photo_fnu) because the is_flux check doesn't work

For context it does this -`
is_flux = photometry.units == self.__class__.__dict__["photo_fnu"].unit
`
`photometry.units` is  `erg/(Hz*cm**2*s)` (due to the @accepts decorator) but `self.__class__.__dict__["photo_fnu"].unit`  is nJy. The == check doesn't check for dimensional equivalence, so despite nJy and `erg/(Hz*cm**2*s)`  being dimensionally equivalent the is_flux  evaluates to False, so the input photometry is stored as a luminosity and not a flux.

I've replaced it with this check (but split into two lines).

`is_flux = photometry.units.same_dimensions_as(self.__class__.__dict__["photo_fnu"].unit)`

I've also added a new test in the photometry test suite which tests that flux/luminosity units are preserved properly, which should catch issues like this in the future. 

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes