### PR TITLE
(actually) fix PhotometryCollection unit issue

### DIFF
--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -85,7 +85,7 @@ class PhotometryCollection:
 
         # Keep raw ndarray storage and rely on Quantity descriptors for
         # units.
-        self._photometry_data = photometry.ndview
+        self._photometry_data = photometry.to_value(fnu_unit)
 
         if is_flux:
             self.photo_fnu = self._photometry_data

--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -14,7 +14,7 @@ import numpy as np
 from unyt import Hz, cm, erg, s
 
 from synthesizer import exceptions
-from synthesizer.units import Quantity, accepts
+from synthesizer.units import Quantity, accepts, unyt_to_ndview
 from synthesizer.utils.operation_timers import timed
 
 
@@ -84,12 +84,12 @@ class PhotometryCollection:
         is_flux = photometry.units.same_dimensions_as(fnu_unit)
 
         if is_flux:
-            self._photometry_data = photometry.to_value(fnu_unit)
+            self._photometry_data = unyt_to_ndview(photometry, fnu_unit)
             self.photo_fnu = self._photometry_data
             self.photo_lnu = None
         else:
             lnu_unit = self.__class__.__dict__["photo_lnu"].unit
-            self._photometry_data = photometry.to_value(lnu_unit)
+            self._photometry_data = unyt_to_ndview(photometry, lnu_unit)
             self.photo_lnu = self._photometry_data
             self.photo_fnu = None
 

--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -83,14 +83,13 @@ class PhotometryCollection:
         fnu_unit = self.__class__.__dict__["photo_fnu"].unit
         is_flux = photometry.units.same_dimensions_as(fnu_unit)
 
-        # Keep raw ndarray storage and rely on Quantity descriptors for
-        # units.
-        self._photometry_data = photometry.to_value(fnu_unit)
-
         if is_flux:
+            self._photometry_data = photometry.to_value(fnu_unit)
             self.photo_fnu = self._photometry_data
             self.photo_lnu = None
         else:
+            lnu_unit = self.__class__.__dict__["photo_lnu"].unit
+            self._photometry_data = photometry.to_value(lnu_unit)
             self.photo_lnu = self._photometry_data
             self.photo_fnu = None
 

--- a/tests/test_photometry.py
+++ b/tests/test_photometry.py
@@ -68,6 +68,11 @@ def test_photometry_collection_preserves_units_on_input_array():
     assert pc.photometry.units.same_dimensions_as(erg / s / Hz)
     assert pc.photo_lnu.units.same_dimensions_as(erg / s / Hz)
 
+    assert np.allclose(
+        pc.photometry.to(erg / s / Hz).value,
+        arr.to(erg / s / Hz).value,
+    )
+
     arr = np.array([[1.0, 0.5], [2.0, 1.5], [3.0, 2.5]]) * nJy
     pc = PhotometryCollection(
         filters,
@@ -79,6 +84,11 @@ def test_photometry_collection_preserves_units_on_input_array():
     assert pc.photo_fnu is not None
     assert pc.photometry.units.same_dimensions_as(nJy)
     assert pc.photo_fnu.units.same_dimensions_as(nJy)
+
+    assert np.allclose(
+        pc.photometry.to(nJy).value,
+        arr.to(nJy).value,
+    )
 
 
 def test_photometry_collection_select_preserves_lookup():


### PR DESCRIPTION
TLDR: All photometry is ~e32 too small at the moment -- see [here](https://synthesizer-project.github.io/synthesizer/auto_examples/parametric/plot_observed_sed.html) for an example.

The issue is in PhotometryCollection - #1136 fixed an issue with flux being stored as luminosity and vice-versa, but there was no unit conversion if we are passed a non-nJy flux unit. The C++ typically returns erg/(Hz*cm**2*s) and we strip the unit, whilst leaving the unit attached to the collection as nJy. This results in all the photometry being completely wrong.

I've switched to using unyt's inbuilt .to_value converter, but you may want to handle this slightly differently. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal handling of photometry data was changed to standardize unit conversion at construction; behavior for flux vs luminosity selection is unchanged and no user-facing API changes.

* **Tests**
  * Unit tests updated to compare numeric values after converting to expected units rather than asserting unit objects directly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->