### PR TITLE
Fix to_hdf5 crash on plain-float depth and snrs

### DIFF
--- a/src/synthesizer/instruments/instrument.py
+++ b/src/synthesizer/instruments/instrument.py
@@ -627,10 +627,12 @@ class Instrument:
             if isinstance(self.depth, dict):
                 depth_group = group.create_group("Depth")
                 for key, value in self.depth.items():
+                    raw = value.value if hasattr(value, "value") else value
+                    units = str(value.units) if hasattr(value, "units") else "dimensionless"
                     ds = depth_group.create_dataset(
-                        key, data=value.value, dtype=float
+                        key, data=raw, dtype=float
                     )
-                    ds.attrs["units"] = "dimensionless"
+                    ds.attrs["units"] = units
             else:
                 ds = group.create_dataset(
                     "Depth", data=self.depth.value, dtype=float
@@ -641,10 +643,12 @@ class Instrument:
             if isinstance(self.snrs, dict):
                 snrs_group = group.create_group("SNRs")
                 for key, value in self.snrs.items():
+                    raw = value.value if hasattr(value, "value") else value
+                    units = str(value.units) if hasattr(value, "units") else "dimensionless"
                     ds = snrs_group.create_dataset(
-                        key, data=value.value, dtype=float
+                        key, data=raw, dtype=float
                     )
-                    ds.attrs["units"] = "dimensionless"
+                    ds.attrs["units"] = units
             else:
                 ds = group.create_dataset(
                     "SNRs", data=self.snrs.value, dtype=float

--- a/src/synthesizer/instruments/instrument.py
+++ b/src/synthesizer/instruments/instrument.py
@@ -628,7 +628,10 @@ class Instrument:
                 depth_group = group.create_group("Depth")
                 for key, value in self.depth.items():
                     raw = value.value if hasattr(value, "value") else value
-                    units = str(value.units) if hasattr(value, "units") else "dimensionless"
+                    units = (
+                        str(value.units) if hasattr(value, "units") 
+                        else "dimensionless"
+                    )
                     ds = depth_group.create_dataset(
                         key, data=raw, dtype=float
                     )
@@ -644,7 +647,10 @@ class Instrument:
                 snrs_group = group.create_group("SNRs")
                 for key, value in self.snrs.items():
                     raw = value.value if hasattr(value, "value") else value
-                    units = str(value.units) if hasattr(value, "units") else "dimensionless"
+                    units = (
+                        str(value.units) if hasattr(value, "units") 
+                        else "dimensionless"
+                    )
                     ds = snrs_group.create_dataset(
                         key, data=raw, dtype=float
                     )

--- a/src/synthesizer/instruments/instrument.py
+++ b/src/synthesizer/instruments/instrument.py
@@ -629,12 +629,11 @@ class Instrument:
                 for key, value in self.depth.items():
                     raw = value.value if hasattr(value, "value") else value
                     units = (
-                        str(value.units) if hasattr(value, "units") 
+                        str(value.units)
+                        if hasattr(value, "units")
                         else "dimensionless"
                     )
-                    ds = depth_group.create_dataset(
-                        key, data=raw, dtype=float
-                    )
+                    ds = depth_group.create_dataset(key, data=raw, dtype=float)
                     ds.attrs["units"] = units
             else:
                 ds = group.create_dataset(
@@ -648,12 +647,11 @@ class Instrument:
                 for key, value in self.snrs.items():
                     raw = value.value if hasattr(value, "value") else value
                     units = (
-                        str(value.units) if hasattr(value, "units") 
+                        str(value.units)
+                        if hasattr(value, "units")
                         else "dimensionless"
                     )
-                    ds = snrs_group.create_dataset(
-                        key, data=raw, dtype=float
-                    )
+                    ds = snrs_group.create_dataset(key, data=raw, dtype=float)
                     ds.attrs["units"] = units
             else:
                 ds = group.create_dataset(


### PR DESCRIPTION
to_hdf5 called value.value on dict entries for snrs and depths, which fails for instruments constructed directly with plain floats as shown in the example docs. The .value succeeds for instruments loaded through _from_hdf5, where values are wrapped as unyt_array. Added attribute check to check if .value is present and handling of both cases.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [X] I have read the [CONTRIBUTING.md]() -->
- [N/A] I have added docstrings to all methods
- [X] I have added sufficient comments to all lines
- [N/A ] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved the robustness of HDF5 data export to handle different data formats more flexibly. The exporter now properly processes measurement data whether they include unit information or are raw numerical values, ensuring more reliable file creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->