### PR TITLE
Adding doppler and thermal broadening transformers

### DIFF
--- a/examples/blackholes/plot_unified_agn_broadening.py
+++ b/examples/blackholes/plot_unified_agn_broadening.py
@@ -7,6 +7,7 @@ the optional Doppler broadening applied by ``velocity_dispersion_blr`` and
 ``velocity_dispersion_nlr``.
 """
 
+import matplotlib.pyplot as plt
 from unyt import Msun, deg, kelvin, km, s, yr
 
 from synthesizer.emission_models import Greybody, UnifiedAGN
@@ -71,4 +72,5 @@ for component in ("blr", "nlr"):
     )
     spectra_ax.loglog()
     spectra_ax.set_xlim(800, None)
-    spectra_ax.figure.show()
+
+plt.show()

--- a/examples/blackholes/plot_unified_agn_broadening.py
+++ b/examples/blackholes/plot_unified_agn_broadening.py
@@ -7,10 +7,10 @@ the optional Doppler broadening applied by ``velocity_dispersion_blr`` and
 ``velocity_dispersion_nlr``.
 """
 
-import matplotlib.pyplot as plt
 from unyt import Msun, deg, kelvin, km, s, yr
 
 from synthesizer.emission_models import Greybody, UnifiedAGN
+from synthesizer.emissions import plot_spectra
 from synthesizer.grid import Grid
 from synthesizer.parametric import BlackHole
 
@@ -58,21 +58,14 @@ broadened_bh.get_spectra(broadened_model)
 
 # Plot the final BLR and NLR model outputs. In the broadened model these are
 # transformations of the internal unbroadened_blr/unbroadened_nlr components.
-fig, axes = plt.subplots(2, 1, sharex=True, figsize=(7, 6))
-for ax, component in zip(axes, ("blr", "nlr")):
-    ax.plot(
-        unbroadened_bh.spectra[component].lam,
-        unbroadened_bh.spectra[component].lnu,
-        label="Unbroadened",
+for component in ("blr", "nlr"):
+    plot_spectra(
+        spectra={
+            f"Unbroadened {component.upper()}": unbroadened_bh.spectra[
+                component
+            ],
+            f"Broadened {component.upper()}": broadened_bh.spectra[component],
+        },
+        quantity_to_plot="luminosity",
+        show=True,
     )
-    ax.plot(
-        broadened_bh.spectra[component].lam,
-        broadened_bh.spectra[component].lnu,
-        label="Broadened",
-    )
-    ax.set_ylabel(f"{component.upper()} $L_\\nu$")
-    ax.legend()
-
-axes[-1].set_xlabel("Rest-frame wavelength")
-fig.tight_layout()
-plt.show()

--- a/examples/blackholes/plot_unified_agn_broadening.py
+++ b/examples/blackholes/plot_unified_agn_broadening.py
@@ -82,6 +82,7 @@ for component in ("blr", "nlr"):
         show=False,
     )
     spectra_ax.loglog()
+    spectra_ax.set_xlim(800, None)
     spectra_ax.set_xlabel("")
 
     # Plot the absolute fractional residual where the unbroadened model is

--- a/examples/blackholes/plot_unified_agn_broadening.py
+++ b/examples/blackholes/plot_unified_agn_broadening.py
@@ -7,8 +7,6 @@ the optional Doppler broadening applied by ``velocity_dispersion_blr`` and
 ``velocity_dispersion_nlr``.
 """
 
-import matplotlib.pyplot as plt
-import numpy as np
 from unyt import Msun, deg, kelvin, km, s, yr
 
 from synthesizer.emission_models import Greybody, UnifiedAGN
@@ -61,45 +59,16 @@ broadened_bh.get_spectra(broadened_model)
 # Plot the final BLR and NLR model outputs. In the broadened model these are
 # transformations of the internal unbroadened_blr/unbroadened_nlr components.
 for component in ("blr", "nlr"):
-    fig, (spectra_ax, residual_ax) = plt.subplots(
-        2,
-        1,
-        figsize=(7, 6),
-        gridspec_kw={"height_ratios": (3, 1), "hspace": 0.05},
-        sharex=True,
-    )
-
-    unbroadened_sed = unbroadened_bh.spectra[component]
-    broadened_sed = broadened_bh.spectra[component]
-    plot_spectra(
+    _, spectra_ax = plot_spectra(
         spectra={
-            f"Unbroadened {component.upper()}": unbroadened_sed,
-            f"Broadened {component.upper()}": broadened_sed,
+            f"Unbroadened {component.upper()}": unbroadened_bh.spectra[
+                component
+            ],
+            f"Broadened {component.upper()}": broadened_bh.spectra[component],
         },
-        fig=fig,
-        ax=spectra_ax,
         quantity_to_plot="luminosity",
         show=False,
     )
     spectra_ax.loglog()
     spectra_ax.set_xlim(800, None)
-    spectra_ax.set_xlabel("")
-
-    # Plot the absolute fractional residual where the unbroadened model is
-    # non-zero. This is positive definite, so it can be shown on a log y-axis.
-    ok = unbroadened_sed.luminosity > 0
-    residual = np.zeros_like(unbroadened_sed.luminosity.value)
-    residual[ok] = (
-        np.abs(
-            broadened_sed.luminosity[ok] / unbroadened_sed.luminosity[ok] - 1.0
-        )
-    ).value
-    residual[residual <= 0] = np.nan
-
-    residual_ax.plot(unbroadened_sed.lam, residual, color="k", lw=1)
-    residual_ax.set_xscale("log")
-    residual_ax.set_yscale("log")
-    residual_ax.set_ylabel("Abs. frac. residual")
-    residual_ax.set_xlabel("Rest-frame wavelength")
-
-    plt.show()
+    spectra_ax.figure.show()

--- a/examples/blackholes/plot_unified_agn_broadening.py
+++ b/examples/blackholes/plot_unified_agn_broadening.py
@@ -7,6 +7,8 @@ the optional Doppler broadening applied by ``velocity_dispersion_blr`` and
 ``velocity_dispersion_nlr``.
 """
 
+import matplotlib.pyplot as plt
+import numpy as np
 from unyt import Msun, deg, kelvin, km, s, yr
 
 from synthesizer.emission_models import Greybody, UnifiedAGN
@@ -59,13 +61,42 @@ broadened_bh.get_spectra(broadened_model)
 # Plot the final BLR and NLR model outputs. In the broadened model these are
 # transformations of the internal unbroadened_blr/unbroadened_nlr components.
 for component in ("blr", "nlr"):
+    fig, (spectra_ax, residual_ax) = plt.subplots(
+        2,
+        1,
+        figsize=(7, 6),
+        gridspec_kw={"height_ratios": (3, 1), "hspace": 0.05},
+        sharex=True,
+    )
+
+    unbroadened_sed = unbroadened_bh.spectra[component]
+    broadened_sed = broadened_bh.spectra[component]
     plot_spectra(
         spectra={
-            f"Unbroadened {component.upper()}": unbroadened_bh.spectra[
-                component
-            ],
-            f"Broadened {component.upper()}": broadened_bh.spectra[component],
+            f"Unbroadened {component.upper()}": unbroadened_sed,
+            f"Broadened {component.upper()}": broadened_sed,
         },
+        fig=fig,
+        ax=spectra_ax,
         quantity_to_plot="luminosity",
-        show=True,
+        show=False,
     )
+    spectra_ax.loglog()
+    spectra_ax.set_xlabel("")
+
+    # Plot fractional residuals where the unbroadened model is non-zero. The
+    # broadened model conserves integrated luminosity but redistributes it in
+    # wavelength, so the residual panel highlights line-profile changes.
+    ok = unbroadened_sed.luminosity > 0
+    residual = np.zeros_like(unbroadened_sed.luminosity.value)
+    residual[ok] = (
+        broadened_sed.luminosity[ok] / unbroadened_sed.luminosity[ok]
+    ).value - 1.0
+
+    residual_ax.axhline(0.0, color="0.5", lw=1, ls="--")
+    residual_ax.plot(unbroadened_sed.lam, residual, color="k", lw=1)
+    residual_ax.set_xscale("log")
+    residual_ax.set_ylabel("Frac. residual")
+    residual_ax.set_xlabel("Rest-frame wavelength")
+
+    plt.show()

--- a/examples/blackholes/plot_unified_agn_broadening.py
+++ b/examples/blackholes/plot_unified_agn_broadening.py
@@ -1,0 +1,78 @@
+"""
+UnifiedAGN line-region broadening
+=================================
+
+Compare the BLR and NLR spectra from a ``UnifiedAGN`` model with and without
+the optional Doppler broadening applied by ``velocity_dispersion_blr`` and
+``velocity_dispersion_nlr``.
+"""
+
+import matplotlib.pyplot as plt
+from unyt import Msun, deg, kelvin, km, s, yr
+
+from synthesizer.emission_models import Greybody, UnifiedAGN
+from synthesizer.grid import Grid
+from synthesizer.parametric import BlackHole
+
+# Define a single black hole and the grids used by the AGN model.
+black_hole = BlackHole(
+    mass=10**8 * Msun,
+    inclination=45 * deg,
+    accretion_rate=1 * Msun / yr,
+    metallicity=0.01,
+)
+nlr_grid = Grid("test_grid_agn-nlr")
+blr_grid = Grid("test_grid_agn-blr")
+
+# Common model settings. The first model leaves line-region spectra at the grid
+# resolution; the second makes the final BLR/NLR components Doppler broadened.
+common_model_kwargs = {
+    "nlr_grid": nlr_grid,
+    "blr_grid": blr_grid,
+    "torus_emission_model": Greybody(1000 * kelvin, 1.5),
+    "covering_fraction_nlr": 0.1,
+    "covering_fraction_blr": 0.1,
+    "ionisation_parameter_nlr": 1e-2,
+    "ionisation_parameter_blr": 1e-2,
+    "hydrogen_density_nlr": 1e3,
+    "hydrogen_density_blr": 1e3,
+}
+unbroadened_model = UnifiedAGN(**common_model_kwargs)
+broadened_model = UnifiedAGN(
+    **common_model_kwargs,
+    velocity_dispersion_nlr=500 * km / s,
+    velocity_dispersion_blr=2000 * km / s,
+)
+
+# Generate the two spectra independently so the second call does not overwrite
+# the first model outputs on the black hole object.
+unbroadened_bh = black_hole
+broadened_bh = BlackHole(
+    mass=10**8 * Msun,
+    inclination=45 * deg,
+    accretion_rate=1 * Msun / yr,
+    metallicity=0.01,
+)
+unbroadened_bh.get_spectra(unbroadened_model)
+broadened_bh.get_spectra(broadened_model)
+
+# Plot the final BLR and NLR model outputs. In the broadened model these are
+# transformations of the internal unbroadened_blr/unbroadened_nlr components.
+fig, axes = plt.subplots(2, 1, sharex=True, figsize=(7, 6))
+for ax, component in zip(axes, ("blr", "nlr")):
+    ax.plot(
+        unbroadened_bh.spectra[component].lam,
+        unbroadened_bh.spectra[component].lnu,
+        label="Unbroadened",
+    )
+    ax.plot(
+        broadened_bh.spectra[component].lam,
+        broadened_bh.spectra[component].lnu,
+        label="Broadened",
+    )
+    ax.set_ylabel(f"{component.upper()} $L_\\nu$")
+    ax.legend()
+
+axes[-1].set_xlabel("Rest-frame wavelength")
+fig.tight_layout()
+plt.show()

--- a/examples/blackholes/plot_unified_agn_broadening.py
+++ b/examples/blackholes/plot_unified_agn_broadening.py
@@ -84,19 +84,21 @@ for component in ("blr", "nlr"):
     spectra_ax.loglog()
     spectra_ax.set_xlabel("")
 
-    # Plot fractional residuals where the unbroadened model is non-zero. The
-    # broadened model conserves integrated luminosity but redistributes it in
-    # wavelength, so the residual panel highlights line-profile changes.
+    # Plot the absolute fractional residual where the unbroadened model is
+    # non-zero. This is positive definite, so it can be shown on a log y-axis.
     ok = unbroadened_sed.luminosity > 0
     residual = np.zeros_like(unbroadened_sed.luminosity.value)
     residual[ok] = (
-        broadened_sed.luminosity[ok] / unbroadened_sed.luminosity[ok]
-    ).value - 1.0
+        np.abs(
+            broadened_sed.luminosity[ok] / unbroadened_sed.luminosity[ok] - 1.0
+        )
+    ).value
+    residual[residual <= 0] = np.nan
 
-    residual_ax.axhline(0.0, color="0.5", lw=1, ls="--")
     residual_ax.plot(unbroadened_sed.lam, residual, color="k", lw=1)
     residual_ax.set_xscale("log")
-    residual_ax.set_ylabel("Frac. residual")
+    residual_ax.set_yscale("log")
+    residual_ax.set_ylabel("Abs. frac. residual")
     residual_ax.set_xlabel("Rest-frame wavelength")
 
     plt.show()

--- a/src/synthesizer/emission_models/agn/unified_agn.py
+++ b/src/synthesizer/emission_models/agn/unified_agn.py
@@ -30,6 +30,7 @@ from synthesizer.emission_models.models import (
 )
 from synthesizer.emission_models.transformers import (
     CoveringFraction,
+    DopplerBroadening,
     EscapingFraction,
 )
 from synthesizer.emission_models.utils import ParameterFunction
@@ -107,6 +108,8 @@ class UnifiedAGNIntrinsic(BlackHoleEmissionModel):
         blr_grid,
         torus_emission_model,
         disc_transmission="weighted_combination",
+        velocity_dispersion_blr=None,
+        velocity_dispersion_nlr=None,
         label="intrinsic",
         **kwargs,
     ):
@@ -133,6 +136,12 @@ class UnifiedAGNIntrinsic(BlackHoleEmissionModel):
                 ``"nlr"``, which uses only disc emission transmitted through
                 the NLR; and ``"blr"``, which uses only disc emission
                 transmitted through the BLR.
+            velocity_dispersion_blr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final BLR emission. If ``None`` no broadening is applied.
+            velocity_dispersion_nlr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final NLR emission. If ``None`` no broadening is applied.
             label (str):
                 The label for the resulting spectra. Defaults to "intrinsic".
             **kwargs: Any additional keyword arguments to pass to the
@@ -202,6 +211,8 @@ class UnifiedAGNIntrinsic(BlackHoleEmissionModel):
             self._make_line_regions(
                 nlr_grid,
                 blr_grid,
+                velocity_dispersion_blr=velocity_dispersion_blr,
+                velocity_dispersion_nlr=velocity_dispersion_nlr,
                 **kwargs,
             )
         )
@@ -635,6 +646,8 @@ class UnifiedAGNIntrinsic(BlackHoleEmissionModel):
         self,
         nlr_grid,
         blr_grid,
+        velocity_dispersion_blr=None,
+        velocity_dispersion_nlr=None,
         **kwargs,
     ):
         """Make the line regions.
@@ -699,8 +712,14 @@ class UnifiedAGNIntrinsic(BlackHoleEmissionModel):
         )
 
         # Now apply the relevant covering fractions to the different spectra
+        nlr_label = (
+            "unbroadened_nlr" if velocity_dispersion_nlr is not None else "nlr"
+        )
+        blr_label = (
+            "unbroadened_blr" if velocity_dispersion_blr is not None else "blr"
+        )
         nlr = BlackHoleEmissionModel(
-            label="nlr",
+            label=nlr_label,
             apply_to=full_nlr,
             transformer=CoveringFraction(
                 covering_attrs=("covering_fraction_nlr",)
@@ -708,7 +727,7 @@ class UnifiedAGNIntrinsic(BlackHoleEmissionModel):
             **kwargs,
         )
         blr = BlackHoleEmissionModel(
-            label="blr",
+            label=blr_label,
             apply_to=full_blr,
             transformer=CoveringFraction(
                 covering_attrs=("covering_fraction_blr",)
@@ -731,6 +750,27 @@ class UnifiedAGNIntrinsic(BlackHoleEmissionModel):
             ),
             **kwargs,
         )
+
+        if velocity_dispersion_nlr is not None:
+            nlr = BlackHoleEmissionModel(
+                label="nlr",
+                apply_to=nlr,
+                transformer=DopplerBroadening(
+                    sigma_v_attr="velocity_dispersion_nlr"
+                ),
+                velocity_dispersion_nlr=velocity_dispersion_nlr,
+                **kwargs,
+            )
+        if velocity_dispersion_blr is not None:
+            blr = BlackHoleEmissionModel(
+                label="blr",
+                apply_to=blr,
+                transformer=DopplerBroadening(
+                    sigma_v_attr="velocity_dispersion_blr"
+                ),
+                velocity_dispersion_blr=velocity_dispersion_blr,
+                **kwargs,
+            )
 
         return nlr, nlr_continuum, blr, blr_continuum
 
@@ -765,6 +805,8 @@ class UnifiedAGNWithDiffuseDustAttenuation(BlackHoleEmissionModel):
         torus_emission_model,
         diffuse_dust_curve,
         disc_transmission="weighted_combination",
+        velocity_dispersion_blr=None,
+        velocity_dispersion_nlr=None,
         label="attenuated",
         tau_v="tau_v",
         **kwargs,
@@ -794,6 +836,12 @@ class UnifiedAGNWithDiffuseDustAttenuation(BlackHoleEmissionModel):
                 the unobscured disc emission; ``"nlr"``, which uses only
                 disc emission transmitted through the NLR; and ``"blr"``,
                 which uses only disc emission transmitted through the BLR.
+            velocity_dispersion_blr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final BLR emission. If ``None`` no broadening is applied.
+            velocity_dispersion_nlr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final NLR emission. If ``None`` no broadening is applied.
             label (str):
                 The label for the resulting spectra. This defaults to
                 "attenuated".
@@ -808,6 +856,8 @@ class UnifiedAGNWithDiffuseDustAttenuation(BlackHoleEmissionModel):
             blr_grid,
             torus_emission_model,
             disc_transmission=disc_transmission,
+            velocity_dispersion_blr=velocity_dispersion_blr,
+            velocity_dispersion_nlr=velocity_dispersion_nlr,
             **kwargs,
         )
 
@@ -848,6 +898,8 @@ class UnifiedAGNWithDiffuseDustAttenuationAndEmission(BlackHoleEmissionModel):
         diffuse_dust_emission_model,
         tau_v="tau_v",
         disc_transmission="weighted_combination",
+        velocity_dispersion_blr=None,
+        velocity_dispersion_nlr=None,
         label="total",
         **kwargs,
     ):
@@ -878,6 +930,12 @@ class UnifiedAGNWithDiffuseDustAttenuationAndEmission(BlackHoleEmissionModel):
                 The dust attenuation curve for diffuse dust.
             diffuse_dust_emission_model:
                 The diffuse dust emission model.
+            velocity_dispersion_blr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final BLR emission. If ``None`` no broadening is applied.
+            velocity_dispersion_nlr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final NLR emission. If ``None`` no broadening is applied.
             tau_v (str):
                 The attribute on the emitter to use for tau_v
             label (str):
@@ -893,6 +951,8 @@ class UnifiedAGNWithDiffuseDustAttenuationAndEmission(BlackHoleEmissionModel):
             blr_grid,
             torus_emission_model,
             disc_transmission=disc_transmission,
+            velocity_dispersion_blr=velocity_dispersion_blr,
+            velocity_dispersion_nlr=velocity_dispersion_nlr,
             **kwargs,
         )
 
@@ -947,6 +1007,8 @@ class UnifiedAGN(BlackHoleEmissionModel):
         disc_transmission="weighted_combination",
         diffuse_dust_curve=None,
         diffuse_dust_emission_model=None,
+        velocity_dispersion_blr=None,
+        velocity_dispersion_nlr=None,
         label=None,
         **kwargs,
     ):
@@ -977,6 +1039,12 @@ class UnifiedAGN(BlackHoleEmissionModel):
                 The dust attenuation curve for diffuse dust.
             diffuse_dust_emission_model:
                 The diffuse dust emission model.
+            velocity_dispersion_blr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final BLR emission. If ``None`` no broadening is applied.
+            velocity_dispersion_nlr (unyt_quantity):
+                The optional velocity dispersion to use when Doppler broadening
+                the final NLR emission. If ``None`` no broadening is applied.
             label (str):
                 The label for the resulting spectra. When dust attenuation and
                 emission is included this defaults to "total" otherwise it
@@ -1003,6 +1071,8 @@ class UnifiedAGN(BlackHoleEmissionModel):
                 diffuse_dust_curve,
                 diffuse_dust_emission_model,
                 disc_transmission=disc_transmission,
+                velocity_dispersion_blr=velocity_dispersion_blr,
+                velocity_dispersion_nlr=velocity_dispersion_nlr,
                 label=label,
                 **kwargs,
             )
@@ -1018,6 +1088,8 @@ class UnifiedAGN(BlackHoleEmissionModel):
                 torus_emission_model,
                 diffuse_dust_curve,
                 disc_transmission=disc_transmission,
+                velocity_dispersion_blr=velocity_dispersion_blr,
+                velocity_dispersion_nlr=velocity_dispersion_nlr,
                 label=label,
                 **kwargs,
             )
@@ -1031,6 +1103,8 @@ class UnifiedAGN(BlackHoleEmissionModel):
                 blr_grid,
                 torus_emission_model,
                 disc_transmission=disc_transmission,
+                velocity_dispersion_blr=velocity_dispersion_blr,
+                velocity_dispersion_nlr=velocity_dispersion_nlr,
                 label=label,
                 **kwargs,
             )

--- a/src/synthesizer/emission_models/transformers/__init__.py
+++ b/src/synthesizer/emission_models/transformers/__init__.py
@@ -1,27 +1,43 @@
-# Import all the transformers here so they can be accessed from the package
-# level.
+"""Transformer classes exposed at package level."""
+
+from synthesizer.emission_models.transformers.broadening import (
+    DopplerBroadening,
+    ThermalBroadening,
+)
 from synthesizer.emission_models.transformers.dust_attenuation import (
     MWN18,
     Calzetti2000,
-    GrainModels,
     DraineLiGrainCurves,
+    GrainModels,
     ParametricLi08,
     PowerLaw,
 )
 from synthesizer.emission_models.transformers.escape_fraction import (
     CoveringFraction,
     EscapedFraction,
-    ProcessedFraction,
     EscapingFraction,
+    ProcessedFraction,
 )
-from synthesizer.emission_models.transformers.igm import Inoue14, Madau96, Asada25
+from synthesizer.emission_models.transformers.igm import (
+    Asada25,
+    Inoue14,
+    Madau96,
+)
 
 __all__ = [
-    "ProcessedFraction",
-    "EscapedFraction",
-    "CoveringFraction",
-    "EscapingFraction",
-    "Madau96",
-    "Inoue14",
     "Asada25",
+    "Calzetti2000",
+    "CoveringFraction",
+    "DopplerBroadening",
+    "DraineLiGrainCurves",
+    "EscapedFraction",
+    "EscapingFraction",
+    "GrainModels",
+    "Inoue14",
+    "MWN18",
+    "Madau96",
+    "ParametricLi08",
+    "PowerLaw",
+    "ProcessedFraction",
+    "ThermalBroadening",
 ]

--- a/src/synthesizer/emission_models/transformers/broadening.py
+++ b/src/synthesizer/emission_models/transformers/broadening.py
@@ -4,7 +4,7 @@ This module contains classes for applying doppler broadening and thermal
 broadening to spectra.
 """
 
-from unyt import K, amu, km, s
+from unyt import amu
 
 from synthesizer import exceptions
 from synthesizer.emission_models.transformers.transformer import Transformer
@@ -14,41 +14,23 @@ from synthesizer.emissions.sed import Sed
 class DopplerBroadening(Transformer):
     """A transformer that applies Doppler broadening to a Sed."""
 
-    def __init__(
-        self,
-        sigma_v_attr="sigma_v",
-        apply_units=True,
-        sigma_v_units=km / s,
-    ):
+    def __init__(self, sigma_v_attr="sigma_v"):
         """Initialise the Doppler broadening transformer.
 
         Args:
             sigma_v_attr (str):
                 The attribute to extract from the model, emission, or emitter
                 to use as the velocity dispersion.
-            apply_units (bool):
-                Whether to apply ``sigma_v_units`` to extracted unitless
-                values. Defaults to True.
-            sigma_v_units (unyt.Unit):
-                The units to apply when the extracted velocity dispersion is
-                unitless.
         """
         # Attach the required parameters
         self.sigma_v_attr = sigma_v_attr
-        self.apply_units = apply_units
-        self.sigma_v_units = sigma_v_units
 
         # Initialize the base class with the required parameters
         Transformer.__init__(self, required_params=(sigma_v_attr,))
 
     def __repr__(self):
         """Return a string representation of the object."""
-        return (
-            "DopplerBroadening("
-            f"sigma_v_attr={self.sigma_v_attr}, "
-            f"apply_units={self.apply_units}, "
-            f"sigma_v_units={self.sigma_v_units})"
-        )
+        return f"DopplerBroadening(sigma_v_attr={self.sigma_v_attr})"
 
     def _transform(self, emission, emitter, model, mask, lam_mask):
         """Apply Doppler broadening to the emission.
@@ -93,11 +75,6 @@ class DopplerBroadening(Transformer):
         # Unpack the velocity dispersion
         sigma_v = params[self.sigma_v_attr]
 
-        # If a plain value was supplied, interpret it in the transformer's
-        # configured velocity units before calling the unit-checked Sed API.
-        if self.apply_units and not hasattr(sigma_v, "units"):
-            sigma_v = sigma_v * self.sigma_v_units
-
         # Apply the Doppler broadening to the emission
         return emission.doppler_broaden(sigma_v, mask=mask)
 
@@ -110,9 +87,6 @@ class ThermalBroadening(Transformer):
         temperature_attr="temperature",
         mu_attr=None,
         mu=1.0 * amu,
-        apply_units=True,
-        temperature_units=K,
-        mu_units=amu,
     ):
         """Initialise the thermal broadening transformer.
 
@@ -125,14 +99,6 @@ class ThermalBroadening(Transformer):
                 emitter to use as the mean molecular weight.
             mu (unyt_quantity):
                 The mean molecular weight to use when ``mu_attr`` is not set.
-            apply_units (bool):
-                Whether to apply ``temperature_units`` and ``mu_units`` to
-                extracted unitless values. Defaults to True.
-            temperature_units (unyt.Unit):
-                The units to apply when the extracted temperature is unitless.
-            mu_units (unyt.Unit):
-                The units to apply when the extracted mean molecular weight is
-                unitless.
         """
         required_params = (temperature_attr,)
         if mu_attr is not None:
@@ -141,9 +107,6 @@ class ThermalBroadening(Transformer):
         self.temperature_attr = temperature_attr
         self.mu_attr = mu_attr
         self.mu = mu
-        self.apply_units = apply_units
-        self.temperature_units = temperature_units
-        self.mu_units = mu_units
         Transformer.__init__(self, required_params=required_params)
 
     def __repr__(self):
@@ -152,10 +115,7 @@ class ThermalBroadening(Transformer):
             "ThermalBroadening("
             f"temperature_attr={self.temperature_attr}, "
             f"mu_attr={self.mu_attr}, "
-            f"mu={self.mu}, "
-            f"apply_units={self.apply_units}, "
-            f"temperature_units={self.temperature_units}, "
-            f"mu_units={self.mu_units})"
+            f"mu={self.mu})"
         )
 
     def _transform(self, emission, emitter, model, mask, lam_mask):
@@ -193,12 +153,6 @@ class ThermalBroadening(Transformer):
         )
         mu = self.mu if self.mu_attr is None else params[self.mu_attr]
         temperature = params[self.temperature_attr]
-        # If plain values were supplied, interpret them in the transformer's
-        # configured units before calling the unit-checked Sed API.
-        if self.apply_units and not hasattr(temperature, "units"):
-            temperature = temperature * self.temperature_units
-        if self.apply_units and not hasattr(mu, "units"):
-            mu = mu * self.mu_units
 
         return emission.thermally_broaden(
             temperature,

--- a/src/synthesizer/emission_models/transformers/broadening.py
+++ b/src/synthesizer/emission_models/transformers/broadening.py
@@ -1,0 +1,140 @@
+"""A module containing transformers for applying broadening to spectra.
+
+This module contains classes for applying doppler broadening and thermal
+broadening to spectra.
+"""
+
+from unyt import amu
+
+from synthesizer import exceptions
+from synthesizer.emission_models.transformers.transformer import Transformer
+from synthesizer.emissions.sed import Sed
+
+
+class DopplerBroadening(Transformer):
+    """A transformer that applies Doppler broadening to a Sed."""
+
+    def __init__(self, sigma_v_attr="sigma_v"):
+        """Initialise the Doppler broadening transformer.
+
+        Args:
+            sigma_v_attr (str):
+                The attribute to extract from the model, emission, or emitter
+                to use as the velocity dispersion.
+        """
+        self.sigma_v_attr = sigma_v_attr
+        Transformer.__init__(self, required_params=(sigma_v_attr,))
+
+    def __repr__(self):
+        """Return a string representation of the object."""
+        return f"DopplerBroadening(sigma_v_attr={self.sigma_v_attr})"
+
+    def _transform(self, emission, emitter, model, mask, lam_mask):
+        """Apply Doppler broadening to the emission.
+
+        Args:
+            emission (Sed):
+                The emission to transform.
+            emitter (Stars/Gas/BlackHole/Galaxy):
+                The object emitting the emission.
+            model (EmissionModel):
+                The emission model generating the emission.
+            mask (np.ndarray):
+                The mask to apply to the emission.
+            lam_mask (np.ndarray):
+                The wavelength mask to apply to the emission.
+
+        Returns:
+            Sed: The broadened emission.
+        """
+        if not isinstance(emission, Sed):
+            raise exceptions.InconsistentArguments(
+                "DopplerBroadening can only be applied to Sed objects."
+            )
+        if lam_mask is not None:
+            raise exceptions.InconsistentArguments(
+                "Wavelength masks are not supported for Doppler broadening."
+            )
+
+        params = self._extract_params(model, emission, emitter)
+
+        return emission.doppler_broaden(
+            params[self.sigma_v_attr],
+            mask=mask,
+        )
+
+
+class ThermalBroadening(Transformer):
+    """A transformer that applies thermal broadening to a Sed."""
+
+    def __init__(
+        self,
+        temperature_attr="temperature",
+        mu_attr=None,
+        mu=1.0 * amu,
+    ):
+        """Initialise the thermal broadening transformer.
+
+        Args:
+            temperature_attr (str):
+                The attribute to extract from the model, emission, or emitter
+                to use as the temperature.
+            mu_attr (str):
+                The optional attribute to extract from the model, emission, or
+                emitter to use as the mean molecular weight.
+            mu (unyt_quantity):
+                The mean molecular weight to use when ``mu_attr`` is not set.
+        """
+        required_params = (temperature_attr,)
+        if mu_attr is not None:
+            required_params = (*required_params, mu_attr)
+
+        self.temperature_attr = temperature_attr
+        self.mu_attr = mu_attr
+        self.mu = mu
+        Transformer.__init__(self, required_params=required_params)
+
+    def __repr__(self):
+        """Return a string representation of the object."""
+        return (
+            "ThermalBroadening("
+            f"temperature_attr={self.temperature_attr}, "
+            f"mu_attr={self.mu_attr}, "
+            f"mu={self.mu})"
+        )
+
+    def _transform(self, emission, emitter, model, mask, lam_mask):
+        """Apply thermal broadening to the emission.
+
+        Args:
+            emission (Sed):
+                The emission to transform.
+            emitter (Stars/Gas/BlackHole/Galaxy):
+                The object emitting the emission.
+            model (EmissionModel):
+                The emission model generating the emission.
+            mask (np.ndarray):
+                The mask to apply to the emission.
+            lam_mask (np.ndarray):
+                The wavelength mask to apply to the emission.
+
+        Returns:
+            Sed: The broadened emission.
+        """
+        if not isinstance(emission, Sed):
+            raise exceptions.InconsistentArguments(
+                "ThermalBroadening can only be applied to Sed objects."
+            )
+        if lam_mask is not None:
+            raise exceptions.InconsistentArguments(
+                "Wavelength masks are not supported for thermal broadening."
+            )
+
+        params = self._extract_params(model, emission, emitter)
+        mu = self.mu if self.mu_attr is None else params[self.mu_attr]
+
+        return emission.thermally_broaden(
+            params[self.temperature_attr],
+            mu=mu,
+            mask=mask,
+        )

--- a/src/synthesizer/emission_models/transformers/broadening.py
+++ b/src/synthesizer/emission_models/transformers/broadening.py
@@ -9,6 +9,7 @@ from unyt import amu
 from synthesizer import exceptions
 from synthesizer.emission_models.transformers.transformer import Transformer
 from synthesizer.emissions.sed import Sed
+from synthesizer.utils.operation_timers import timed
 
 
 class DopplerBroadening(Transformer):
@@ -22,7 +23,7 @@ class DopplerBroadening(Transformer):
                 The attribute to extract from the model, emission, or emitter
                 to use as the velocity dispersion.
         """
-        # Attach the required parameters
+        # Attach the required parameter
         self.sigma_v_attr = sigma_v_attr
 
         # Initialize the base class with the required parameters
@@ -32,6 +33,7 @@ class DopplerBroadening(Transformer):
         """Return a string representation of the object."""
         return f"DopplerBroadening(sigma_v_attr={self.sigma_v_attr})"
 
+    @timed("DopplerBroadening._transform")
     def _transform(self, emission, emitter, model, mask, lam_mask):
         """Apply Doppler broadening to the emission.
 
@@ -100,13 +102,19 @@ class ThermalBroadening(Transformer):
             mu (unyt_quantity):
                 The mean molecular weight to use when ``mu_attr`` is not set.
         """
+        # Resolve the required parameters, this will always include the
+        # temperature, but may also include the mean molecular weight if
+        # mu_attr is set
         required_params = (temperature_attr,)
         if mu_attr is not None:
             required_params = (*required_params, mu_attr)
 
+        # Attach the required parameters
         self.temperature_attr = temperature_attr
         self.mu_attr = mu_attr
         self.mu = mu
+
+        # Initialize the base class with the required parameters
         Transformer.__init__(self, required_params=required_params)
 
     def __repr__(self):
@@ -118,6 +126,7 @@ class ThermalBroadening(Transformer):
             f"mu={self.mu})"
         )
 
+    @timed("ThermalBroadening._transform")
     def _transform(self, emission, emitter, model, mask, lam_mask):
         """Apply thermal broadening to the emission.
 
@@ -136,24 +145,32 @@ class ThermalBroadening(Transformer):
         Returns:
             Sed: The broadened emission.
         """
+        # Ensure we have an Sed to work on (this transformation is not defined
+        # for other emission types)
         if not isinstance(emission, Sed):
             raise exceptions.InconsistentArguments(
                 "ThermalBroadening can only be applied to Sed objects."
             )
+
+        # Ensure no wavelength mask is provided, this is unsupported for
+        # broadening transformations as it stands
         if lam_mask is not None:
-            raise exceptions.InconsistentArguments(
+            raise exceptions.UnimplementedFunctionality(
                 "Wavelength masks are not supported for thermal broadening."
             )
 
+        # Get the temperature and mean molecular weight we need
         params = self._extract_params(
             model,
             emission,
             emitter,
             preserve_units=True,
         )
+        # Unpack the temperature and mean molecular weight (if required)
         mu = self.mu if self.mu_attr is None else params[self.mu_attr]
         temperature = params[self.temperature_attr]
 
+        # Apply the thermal broadening to the emission
         return emission.thermally_broaden(
             temperature,
             mu=mu,

--- a/src/synthesizer/emission_models/transformers/broadening.py
+++ b/src/synthesizer/emission_models/transformers/broadening.py
@@ -11,28 +11,30 @@ from synthesizer.emission_models.transformers.transformer import Transformer
 from synthesizer.emissions.sed import Sed
 
 
-def _ensure_units(value, units):
-    """Attach units to extracted unitless values."""
-    if hasattr(value, "units"):
-        return value
-    return value * units
-
-
 class DopplerBroadening(Transformer):
     """A transformer that applies Doppler broadening to a Sed."""
 
-    def __init__(self, sigma_v_attr="sigma_v", sigma_v_units=km / s):
+    def __init__(
+        self,
+        sigma_v_attr="sigma_v",
+        apply_units=True,
+        sigma_v_units=km / s,
+    ):
         """Initialise the Doppler broadening transformer.
 
         Args:
             sigma_v_attr (str):
                 The attribute to extract from the model, emission, or emitter
                 to use as the velocity dispersion.
+            apply_units (bool):
+                Whether to apply ``sigma_v_units`` to extracted unitless
+                values. Defaults to True.
             sigma_v_units (unyt.Unit):
                 The units to apply when the extracted velocity dispersion is
                 unitless.
         """
         self.sigma_v_attr = sigma_v_attr
+        self.apply_units = apply_units
         self.sigma_v_units = sigma_v_units
         Transformer.__init__(self, required_params=(sigma_v_attr,))
 
@@ -41,6 +43,7 @@ class DopplerBroadening(Transformer):
         return (
             "DopplerBroadening("
             f"sigma_v_attr={self.sigma_v_attr}, "
+            f"apply_units={self.apply_units}, "
             f"sigma_v_units={self.sigma_v_units})"
         )
 
@@ -73,10 +76,12 @@ class DopplerBroadening(Transformer):
 
         params = self._extract_params(model, emission, emitter)
 
-        sigma_v = _ensure_units(
-            params[self.sigma_v_attr],
-            self.sigma_v_units,
-        )
+        sigma_v = params[self.sigma_v_attr]
+        # Parameter extraction normalises fixed parameters for the C backends,
+        # which strips unyt units. Reattach the transformer's default units so
+        # the unit-checked Sed API still receives a physical velocity.
+        if self.apply_units and not hasattr(sigma_v, "units"):
+            sigma_v = sigma_v * self.sigma_v_units
 
         return emission.doppler_broaden(sigma_v, mask=mask)
 
@@ -89,6 +94,7 @@ class ThermalBroadening(Transformer):
         temperature_attr="temperature",
         mu_attr=None,
         mu=1.0 * amu,
+        apply_units=True,
         temperature_units=K,
         mu_units=amu,
     ):
@@ -103,6 +109,9 @@ class ThermalBroadening(Transformer):
                 emitter to use as the mean molecular weight.
             mu (unyt_quantity):
                 The mean molecular weight to use when ``mu_attr`` is not set.
+            apply_units (bool):
+                Whether to apply ``temperature_units`` and ``mu_units`` to
+                extracted unitless values. Defaults to True.
             temperature_units (unyt.Unit):
                 The units to apply when the extracted temperature is unitless.
             mu_units (unyt.Unit):
@@ -116,6 +125,7 @@ class ThermalBroadening(Transformer):
         self.temperature_attr = temperature_attr
         self.mu_attr = mu_attr
         self.mu = mu
+        self.apply_units = apply_units
         self.temperature_units = temperature_units
         self.mu_units = mu_units
         Transformer.__init__(self, required_params=required_params)
@@ -127,6 +137,7 @@ class ThermalBroadening(Transformer):
             f"temperature_attr={self.temperature_attr}, "
             f"mu_attr={self.mu_attr}, "
             f"mu={self.mu}, "
+            f"apply_units={self.apply_units}, "
             f"temperature_units={self.temperature_units}, "
             f"mu_units={self.mu_units})"
         )
@@ -160,11 +171,15 @@ class ThermalBroadening(Transformer):
 
         params = self._extract_params(model, emission, emitter)
         mu = self.mu if self.mu_attr is None else params[self.mu_attr]
-        temperature = _ensure_units(
-            params[self.temperature_attr],
-            self.temperature_units,
-        )
-        mu = _ensure_units(mu, self.mu_units)
+        temperature = params[self.temperature_attr]
+        # As above, extracted fixed parameters may be plain ndarrays. Keep the
+        # transformer responsible for restoring the physical units expected by
+        # Sed.thermally_broaden, while allowing callers to disable this for
+        # already-normalised custom inputs.
+        if self.apply_units and not hasattr(temperature, "units"):
+            temperature = temperature * self.temperature_units
+        if self.apply_units and not hasattr(mu, "units"):
+            mu = mu * self.mu_units
 
         return emission.thermally_broaden(
             temperature,

--- a/src/synthesizer/emission_models/transformers/broadening.py
+++ b/src/synthesizer/emission_models/transformers/broadening.py
@@ -33,9 +33,12 @@ class DopplerBroadening(Transformer):
                 The units to apply when the extracted velocity dispersion is
                 unitless.
         """
+        # Attach the required parameters
         self.sigma_v_attr = sigma_v_attr
         self.apply_units = apply_units
         self.sigma_v_units = sigma_v_units
+
+        # Initialize the base class with the required parameters
         Transformer.__init__(self, required_params=(sigma_v_attr,))
 
     def __repr__(self):
@@ -65,24 +68,37 @@ class DopplerBroadening(Transformer):
         Returns:
             Sed: The broadened emission.
         """
+        # Ensure we have an Sed to work on (this transformation is not defined
+        # for other emission types)
         if not isinstance(emission, Sed):
             raise exceptions.InconsistentArguments(
                 "DopplerBroadening can only be applied to Sed objects."
             )
+
+        # Ensure no wavelength mask is provided, this is unsupported for
+        # broadening transformations as it stands
         if lam_mask is not None:
-            raise exceptions.InconsistentArguments(
+            raise exceptions.UnimplementedFunctionality(
                 "Wavelength masks are not supported for Doppler broadening."
             )
 
-        params = self._extract_params(model, emission, emitter)
+        # Get the velocity dispersion we need
+        params = self._extract_params(
+            model,
+            emission,
+            emitter,
+            preserve_units=True,
+        )
 
+        # Unpack the velocity dispersion
         sigma_v = params[self.sigma_v_attr]
-        # Parameter extraction normalises fixed parameters for the C backends,
-        # which strips unyt units. Reattach the transformer's default units so
-        # the unit-checked Sed API still receives a physical velocity.
+
+        # If a plain value was supplied, interpret it in the transformer's
+        # configured velocity units before calling the unit-checked Sed API.
         if self.apply_units and not hasattr(sigma_v, "units"):
             sigma_v = sigma_v * self.sigma_v_units
 
+        # Apply the Doppler broadening to the emission
         return emission.doppler_broaden(sigma_v, mask=mask)
 
 
@@ -169,13 +185,16 @@ class ThermalBroadening(Transformer):
                 "Wavelength masks are not supported for thermal broadening."
             )
 
-        params = self._extract_params(model, emission, emitter)
+        params = self._extract_params(
+            model,
+            emission,
+            emitter,
+            preserve_units=True,
+        )
         mu = self.mu if self.mu_attr is None else params[self.mu_attr]
         temperature = params[self.temperature_attr]
-        # As above, extracted fixed parameters may be plain ndarrays. Keep the
-        # transformer responsible for restoring the physical units expected by
-        # Sed.thermally_broaden, while allowing callers to disable this for
-        # already-normalised custom inputs.
+        # If plain values were supplied, interpret them in the transformer's
+        # configured units before calling the unit-checked Sed API.
         if self.apply_units and not hasattr(temperature, "units"):
             temperature = temperature * self.temperature_units
         if self.apply_units and not hasattr(mu, "units"):

--- a/src/synthesizer/emission_models/transformers/broadening.py
+++ b/src/synthesizer/emission_models/transformers/broadening.py
@@ -4,30 +4,45 @@ This module contains classes for applying doppler broadening and thermal
 broadening to spectra.
 """
 
-from unyt import amu
+from unyt import K, amu, km, s
 
 from synthesizer import exceptions
 from synthesizer.emission_models.transformers.transformer import Transformer
 from synthesizer.emissions.sed import Sed
 
 
+def _ensure_units(value, units):
+    """Attach units to extracted unitless values."""
+    if hasattr(value, "units"):
+        return value
+    return value * units
+
+
 class DopplerBroadening(Transformer):
     """A transformer that applies Doppler broadening to a Sed."""
 
-    def __init__(self, sigma_v_attr="sigma_v"):
+    def __init__(self, sigma_v_attr="sigma_v", sigma_v_units=km / s):
         """Initialise the Doppler broadening transformer.
 
         Args:
             sigma_v_attr (str):
                 The attribute to extract from the model, emission, or emitter
                 to use as the velocity dispersion.
+            sigma_v_units (unyt.Unit):
+                The units to apply when the extracted velocity dispersion is
+                unitless.
         """
         self.sigma_v_attr = sigma_v_attr
+        self.sigma_v_units = sigma_v_units
         Transformer.__init__(self, required_params=(sigma_v_attr,))
 
     def __repr__(self):
         """Return a string representation of the object."""
-        return f"DopplerBroadening(sigma_v_attr={self.sigma_v_attr})"
+        return (
+            "DopplerBroadening("
+            f"sigma_v_attr={self.sigma_v_attr}, "
+            f"sigma_v_units={self.sigma_v_units})"
+        )
 
     def _transform(self, emission, emitter, model, mask, lam_mask):
         """Apply Doppler broadening to the emission.
@@ -58,10 +73,12 @@ class DopplerBroadening(Transformer):
 
         params = self._extract_params(model, emission, emitter)
 
-        return emission.doppler_broaden(
+        sigma_v = _ensure_units(
             params[self.sigma_v_attr],
-            mask=mask,
+            self.sigma_v_units,
         )
+
+        return emission.doppler_broaden(sigma_v, mask=mask)
 
 
 class ThermalBroadening(Transformer):
@@ -72,6 +89,8 @@ class ThermalBroadening(Transformer):
         temperature_attr="temperature",
         mu_attr=None,
         mu=1.0 * amu,
+        temperature_units=K,
+        mu_units=amu,
     ):
         """Initialise the thermal broadening transformer.
 
@@ -84,6 +103,11 @@ class ThermalBroadening(Transformer):
                 emitter to use as the mean molecular weight.
             mu (unyt_quantity):
                 The mean molecular weight to use when ``mu_attr`` is not set.
+            temperature_units (unyt.Unit):
+                The units to apply when the extracted temperature is unitless.
+            mu_units (unyt.Unit):
+                The units to apply when the extracted mean molecular weight is
+                unitless.
         """
         required_params = (temperature_attr,)
         if mu_attr is not None:
@@ -92,6 +116,8 @@ class ThermalBroadening(Transformer):
         self.temperature_attr = temperature_attr
         self.mu_attr = mu_attr
         self.mu = mu
+        self.temperature_units = temperature_units
+        self.mu_units = mu_units
         Transformer.__init__(self, required_params=required_params)
 
     def __repr__(self):
@@ -100,7 +126,9 @@ class ThermalBroadening(Transformer):
             "ThermalBroadening("
             f"temperature_attr={self.temperature_attr}, "
             f"mu_attr={self.mu_attr}, "
-            f"mu={self.mu})"
+            f"mu={self.mu}, "
+            f"temperature_units={self.temperature_units}, "
+            f"mu_units={self.mu_units})"
         )
 
     def _transform(self, emission, emitter, model, mask, lam_mask):
@@ -132,9 +160,14 @@ class ThermalBroadening(Transformer):
 
         params = self._extract_params(model, emission, emitter)
         mu = self.mu if self.mu_attr is None else params[self.mu_attr]
+        temperature = _ensure_units(
+            params[self.temperature_attr],
+            self.temperature_units,
+        )
+        mu = _ensure_units(mu, self.mu_units)
 
         return emission.thermally_broaden(
-            params[self.temperature_attr],
+            temperature,
             mu=mu,
             mask=mask,
         )

--- a/src/synthesizer/emission_models/transformers/transformer.py
+++ b/src/synthesizer/emission_models/transformers/transformer.py
@@ -90,7 +90,7 @@ class Transformer(ABC):
         """
         pass
 
-    def _extract_params(self, model, emission, emitter):
+    def _extract_params(self, model, emission, emitter, preserve_units=False):
         """Extract the required parameters for the transformation.
 
         This method should look for the required parameters in
@@ -105,13 +105,22 @@ class Transformer(ABC):
                 The emission to transform.
             emitter (Stars/Gas/BlackHole/Galaxy):
                 The object emitting the emission.
+            preserve_units (bool, optional):
+                If True, preserve units on extracted parameter values.
+                Defaults to False.
 
         Returns:
             dict
                 A dictionary containing the required parameters.
         """
         # Extract the parameters (Missing parameters will return None)
-        params = get_params(self._required_params, model, emission, emitter)
+        params = get_params(
+            self._required_params,
+            model,
+            emission,
+            emitter,
+            preserve_units=preserve_units,
+        )
 
         # Check if any of the required parameters are missing
         missing_params = [

--- a/src/synthesizer/emission_models/utils.py
+++ b/src/synthesizer/emission_models/utils.py
@@ -144,6 +144,7 @@ def get_param(
     emitter,
     obj=None,
     default=_NO_DEFAULT,
+    preserve_units=False,
     _singular_attempted=False,
     _plural_attempted=False,
     _visited=None,
@@ -172,6 +173,10 @@ def get_param(
             An optional additional object to look for the parameter on last.
         default (object, optional):
             The default value to return if the parameter is not found.
+        preserve_units (bool, optional):
+            If True, return raw parameter values with any attached units
+            preserved. If False, array-like values are normalised for C-backed
+            calculations where appropriate. Defaults to False.
         _singular_attempted (bool, optional):
             Internal flag to track if singular version has been attempted.
         _plural_attempted (bool, optional):
@@ -206,23 +211,35 @@ def get_param(
             model.fixed_parameters[param],
             ParameterFunction,
         ):
-            value = ensure_array_c_compatible_double(
-                model.fixed_parameters[param]
-            )
+            value = model.fixed_parameters[param]
+            if not preserve_units:
+                value = ensure_array_c_compatible_double(value)
         else:
             value = model.fixed_parameters[param]
 
     # Check the emission next
     elif emission is not None and hasattr(emission, param):
-        value = get_attr_c_compatible_double(emission, param)
+        value = (
+            getattr(emission, param)
+            if preserve_units
+            else get_attr_c_compatible_double(emission, param)
+        )
 
     # Check the emitter
     elif emitter is not None and hasattr(emitter, param):
-        value = get_attr_c_compatible_double(emitter, param)
+        value = (
+            getattr(emitter, param)
+            if preserve_units
+            else get_attr_c_compatible_double(emitter, param)
+        )
 
     # Finally, if we have an additional object, check that
     elif obj is not None and hasattr(obj, param):
-        value = get_attr_c_compatible_double(obj, param)
+        value = (
+            getattr(obj, param)
+            if preserve_units
+            else get_attr_c_compatible_double(obj, param)
+        )
 
     # Do we need to recursively look for the parameter? (We know we're only
     # looking on the emitter at this point)
@@ -244,6 +261,7 @@ def get_param(
             None,
             emitter,
             default=default,
+            preserve_units=preserve_units,
             _visited=new_visited,
         )
 
@@ -275,6 +293,7 @@ def get_param(
             emitter,
             obj,
             default=default,
+            preserve_units=preserve_units,
             _visited=_visited,
         )
         if value is not None:
@@ -294,6 +313,7 @@ def get_param(
                 emitter,
                 obj,
                 default=None,
+                preserve_units=preserve_units,
                 _singular_attempted=True,
                 _plural_attempted=_plural_attempted,
                 _visited=_visited,
@@ -308,6 +328,7 @@ def get_param(
                 emitter,
                 obj,
                 default=None,
+                preserve_units=preserve_units,
                 _singular_attempted=_singular_attempted,
                 _plural_attempted=True,
                 _visited=_visited,
@@ -344,7 +365,14 @@ def get_param(
         )
 
 
-def get_params(params, model, emission, emitter, obj=None):
+def get_params(
+    params,
+    model,
+    emission,
+    emitter,
+    obj=None,
+    preserve_units=False,
+):
     """Extract a list of parameters from a model, emission, emitter, or object.
 
     The priority of extraction is:
@@ -364,6 +392,10 @@ def get_params(params, model, emission, emitter, obj=None):
             The emitter object.
         obj (object, optional):
             An optional additional object to look for parameters on last.
+        preserve_units (bool, optional):
+            If True, return raw parameter values with any attached units
+            preserved. If False, array-like values are normalised for C-backed
+            calculations where appropriate. Defaults to False.
 
     Returns:
         values (dict):
@@ -378,6 +410,7 @@ def get_params(params, model, emission, emitter, obj=None):
             emission,
             emitter,
             obj,
+            preserve_units=preserve_units,
         )
 
     return values

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1677,20 +1677,14 @@ class Sed:
         half = n_uniform // 2
         kernel_x = (np.arange(n_uniform) - half) * dx
 
-        def broaden_spectrum(lnu, this_sigma_v):
-            """Broaden one spectrum by one velocity dispersion."""
-            # The convolution kernel has constant width in velocity, so the
-            # spectrum must be sampled uniformly in log(lambda), not lambda.
-            lnu_uniform = spectres(x_uniform, x, lnu, fill=0.0, verbose=False)
-
+        def get_kernel(this_sigma_v):
+            """Get the log-lambda broadening kernel."""
             # Convert velocity sigma to log-lambda sigma. Delta x = ln(lambda)
             # gives Delta v = c * Delta x.
             sigma_x = (this_sigma_v / c).to_value("")
             kernel = np.exp(-(kernel_x**2) / (2 * sigma_x**2))
             kernel /= kernel.sum()
-
-            lnu_broad = fftconvolve(lnu_uniform, kernel, mode="same")
-            return spectres(x, x_uniform, lnu_broad, fill=0.0, verbose=False)
+            return kernel
 
         # Flatten all non-wavelength dimensions so array-valued sigma_v can be
         # applied independently to each spectrum.
@@ -1714,12 +1708,50 @@ class Sed:
                 )
             flat_sigma_v = sigma_v.reshape(-1)
 
-        for ind in np.where(flat_mask)[0]:
-            flat_lnu[ind] = broaden_spectrum(flat_lnu[ind], flat_sigma_v[ind])
+        # The convolution kernel has constant width in velocity, so all spectra
+        # are first sampled on the same uniform log(lambda) grid. Do this once
+        # for the whole SED rather than once per spectrum.
+        flat_lnu_uniform = spectres(
+            x_uniform,
+            x,
+            flat_lnu,
+            fill=0.0,
+            verbose=False,
+        )
 
-        # Reshape back to the original Sed layout after applying the flattened
-        # per-spectrum operation.
-        new_lnu = flat_lnu.reshape(self._lnu.shape) * self.lnu.units
+        if getattr(sigma_v, "shape", ()) == ():
+            # A scalar velocity dispersion uses one kernel for every selected
+            # spectrum, so the convolution can also be vectorised.
+            kernel = get_kernel(sigma_v)
+            flat_lnu_uniform[flat_mask] = fftconvolve(
+                flat_lnu_uniform[flat_mask],
+                kernel[np.newaxis, :],
+                axes=-1,
+                mode="same",
+            )
+        else:
+            # Array-valued velocity dispersions need a different kernel per
+            # selected spectrum. The spectra are already on the uniform grid,
+            # so this loop only performs the unavoidable per-spectrum
+            # convolution.
+            for ind in np.where(flat_mask)[0]:
+                flat_lnu_uniform[ind] = fftconvolve(
+                    flat_lnu_uniform[ind],
+                    get_kernel(flat_sigma_v[ind]),
+                    mode="same",
+                )
+
+        # Interpolate every broadened spectrum back to the original wavelength
+        # grid in one call, then restore the original Sed layout.
+        new_flat_lnu = spectres(
+            x,
+            x_uniform,
+            flat_lnu_uniform,
+            fill=0.0,
+            verbose=False,
+        )
+        new_flat_lnu[~flat_mask] = flat_lnu[~flat_mask]
+        new_lnu = new_flat_lnu.reshape(self._lnu.shape) * self.lnu.units
 
         # Return new Sed or modify in place
         if inplace:

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1630,7 +1630,7 @@ class Sed:
         return ion_photon_prod_rate
 
     @accepts(sigma_v=km / s)
-    def doppler_broaden(self, sigma_v, inplace=False):
+    def doppler_broaden(self, sigma_v, inplace=False, mask=None):
         """Doppler broaden the spectra.
 
         Doppler broadens the spectra either in place or returning a new Sed.
@@ -1640,6 +1640,11 @@ class Sed:
                 The velocity dispersion to broaden the spectra by.
             inplace (bool):
                 Flag for whether to modify self or return a new Sed.
+            mask (array-like, bool):
+                A mask for the spectra to broaden. This must match the shape of
+                the lnu array excluding the wavelength axis. Unmasked spectra
+                are left unchanged. Only applicable for Sed's holding multiple
+                spectra.
 
         Returns:
             Sed:
@@ -1647,35 +1652,69 @@ class Sed:
                 by the provided velocity dispersion. Only returned if
                 in_place is False.
         """
-        # Convert wavelength grid to log-lambda space
+        # Ensure the mask is compatible with the spectra
+        leading_shape = self._lnu.shape[:-1]
+        if mask is not None:
+            if self._lnu.ndim < 2:
+                raise exceptions.InconsistentArguments(
+                    "Masks are only applicable for Seds containing "
+                    "multiple spectra"
+                )
+            mask = np.asarray(mask, dtype=bool)
+            if mask.shape != leading_shape:
+                raise exceptions.InconsistentArguments(
+                    "Mask and spectra are incompatible shapes "
+                    f"({mask.shape}, {self._lnu.shape})"
+                )
+
+        # Convert wavelength grid to log-lambda space and regrid to uniform
+        # log-lambda spacing for velocity-space convolution.
         x = np.log(self.lam)
-
-        # Regrid to uniform log-lambda spacing, using a very fine grid
         x_uniform = np.linspace(x.min(), x.max(), 100000)
-        lnu_uniform = spectres(x_uniform, x, self.lnu, fill=0.0, verbose=False)
-
-        # Convert velocity sigma to log-lambda sigma
-        # Δx = ln(λ) gives Δv = c*Δx
-        sigma_x = sigma_v / c
-
-        # Gaussian kernel in log-lambda
         dx = x_uniform[1] - x_uniform[0]
-        N = len(x_uniform)
-        half = N // 2
+        n_uniform = len(x_uniform)
+        half = n_uniform // 2
+        kernel_x = (np.arange(n_uniform) - half) * dx
 
-        # Define and normalise the broadening kernel
-        kernel_x = (np.arange(N) - half) * dx
-        kernel = np.exp(-(kernel_x**2) / (2 * sigma_x**2))
-        kernel /= kernel.sum()
+        def broaden_spectrum(lnu, this_sigma_v):
+            """Broaden one spectrum by one velocity dispersion."""
+            lnu_uniform = spectres(x_uniform, x, lnu, fill=0.0, verbose=False)
 
-        # Convolution in velocity/log-lambda space
-        lnu_broad = fftconvolve(lnu_uniform, kernel, mode="same")
+            # Convert velocity sigma to log-lambda sigma. Delta x = ln(lambda)
+            # gives Delta v = c * Delta x.
+            sigma_x = (this_sigma_v / c).to_value("")
+            kernel = np.exp(-(kernel_x**2) / (2 * sigma_x**2))
+            kernel /= kernel.sum()
 
-        # Re-interpolate back onto original wavelength grid and update the sed
-        new_lnu = (
-            spectres(x, x_uniform, lnu_broad, fill=0.0, verbose=False)
-            * self.lnu.units
+            lnu_broad = fftconvolve(lnu_uniform, kernel, mode="same")
+            return spectres(x, x_uniform, lnu_broad, fill=0.0, verbose=False)
+
+        # Flatten all non-wavelength dimensions so array-valued sigma_v can be
+        # applied independently to each spectrum.
+        lnu = np.array(self._lnu, copy=True)
+        flat_lnu = lnu.reshape(-1, lnu.shape[-1])
+        flat_mask = (
+            np.ones(flat_lnu.shape[0], dtype=bool)
+            if mask is None
+            else mask.reshape(-1)
         )
+
+        # Broadcast scalar sigma_v to all spectra, otherwise validate the array
+        # shape against the spectra dimensions excluding wavelength.
+        if getattr(sigma_v, "shape", ()) == ():
+            flat_sigma_v = np.full(flat_lnu.shape[0], sigma_v) * sigma_v.units
+        else:
+            if sigma_v.shape != leading_shape:
+                raise exceptions.InconsistentArguments(
+                    "sigma_v and spectra are incompatible shapes "
+                    f"({sigma_v.shape}, {self._lnu.shape})"
+                )
+            flat_sigma_v = sigma_v.reshape(-1)
+
+        for ind in np.where(flat_mask)[0]:
+            flat_lnu[ind] = broaden_spectrum(flat_lnu[ind], flat_sigma_v[ind])
+
+        new_lnu = flat_lnu.reshape(self._lnu.shape) * self.lnu.units
 
         # Return new Sed or modify in place
         if inplace:
@@ -1685,7 +1724,9 @@ class Sed:
             return Sed(self.lam, new_lnu)
 
     @accepts(temperature=K, mu=amu)
-    def thermally_broaden(self, temperature, mu=1.0 * amu, inplace=False):
+    def thermally_broaden(
+        self, temperature, mu=1.0 * amu, inplace=False, mask=None
+    ):
         """Create a spectra including the thermal broadening.
 
         This simply calculates the velocity dispersion from the temperature
@@ -1699,6 +1740,11 @@ class Sed:
                 1 amu.
             inplace (bool):
                 Flag for whether to modify self or return a new Sed.
+            mask (array-like, bool):
+                A mask for the spectra to broaden. This must match the shape of
+                the lnu array excluding the wavelength axis. Unmasked spectra
+                are left unchanged. Only applicable for Sed's holding multiple
+                spectra.
 
         Returns:
             Sed:
@@ -1709,7 +1755,7 @@ class Sed:
         # Calculate the velocity dispersion
         sigma_v = np.sqrt(kb * temperature / mu)
 
-        return self.doppler_broaden(sigma_v, inplace=inplace)
+        return self.doppler_broaden(sigma_v, inplace=inplace, mask=mask)
 
     def plot_spectra(self, **kwargs):
         """Plot the spectra.

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1652,7 +1652,8 @@ class Sed:
                 by the provided velocity dispersion. Only returned if
                 in_place is False.
         """
-        # Ensure the mask is compatible with the spectra
+        # The final axis is wavelength; every leading element is an independent
+        # spectrum that can receive its own velocity dispersion and mask value.
         leading_shape = self._lnu.shape[:-1]
         if mask is not None:
             if self._lnu.ndim < 2:
@@ -1678,6 +1679,8 @@ class Sed:
 
         def broaden_spectrum(lnu, this_sigma_v):
             """Broaden one spectrum by one velocity dispersion."""
+            # The convolution kernel has constant width in velocity, so the
+            # spectrum must be sampled uniformly in log(lambda), not lambda.
             lnu_uniform = spectres(x_uniform, x, lnu, fill=0.0, verbose=False)
 
             # Convert velocity sigma to log-lambda sigma. Delta x = ln(lambda)
@@ -1714,6 +1717,8 @@ class Sed:
         for ind in np.where(flat_mask)[0]:
             flat_lnu[ind] = broaden_spectrum(flat_lnu[ind], flat_sigma_v[ind])
 
+        # Reshape back to the original Sed layout after applying the flattened
+        # per-spectrum operation.
         new_lnu = flat_lnu.reshape(self._lnu.shape) * self.lnu.units
 
         # Return new Sed or modify in place

--- a/tests/test_broadening.py
+++ b/tests/test_broadening.py
@@ -1,0 +1,103 @@
+"""Tests for spectral broadening helpers and transformers."""
+
+# ruff: noqa: D101, D103, D107
+
+import numpy as np
+import pytest
+from unyt import Hz, K, amu, angstrom, erg, km, s
+
+from synthesizer import exceptions
+from synthesizer.emission_models.transformers import (
+    DopplerBroadening,
+    ThermalBroadening,
+)
+from synthesizer.emissions.sed import Sed
+
+
+class DummyModel:
+    label = "dummy"
+
+    def __init__(self, **fixed_parameters):
+        self.fixed_parameters = fixed_parameters
+
+
+def make_line_sed(shape=()):
+    lam = np.linspace(1000.0, 2000.0, 200) * angstrom
+    lnu = np.zeros((*shape, lam.size))
+    lnu[..., lam.size // 2] = 1.0
+
+    return Sed(lam, lnu * erg / s / Hz)
+
+
+def test_doppler_broaden_accepts_array_sigma_v():
+    sed = make_line_sed(shape=(2,))
+
+    broadened = sed.doppler_broaden(np.array([100.0, 300.0]) * km / s)
+
+    assert broadened.lnu.shape == sed.lnu.shape
+    assert broadened.lnu[1].max() < broadened.lnu[0].max()
+
+
+def test_doppler_broaden_masks_spectra():
+    sed = make_line_sed(shape=(2,))
+
+    broadened = sed.doppler_broaden(300.0 * km / s, mask=[True, False])
+
+    assert broadened.lnu[0].max() < sed.lnu[0].max()
+    np.testing.assert_allclose(broadened.lnu[1], sed.lnu[1])
+
+
+def test_doppler_broaden_rejects_bad_sigma_v_shape():
+    sed = make_line_sed(shape=(2,))
+
+    with pytest.raises(exceptions.InconsistentArguments):
+        sed.doppler_broaden(np.ones((2, 1)) * km / s)
+
+
+def test_thermally_broaden_accepts_array_temperature():
+    sed = make_line_sed(shape=(2,))
+
+    broadened = sed.thermally_broaden(
+        np.array([1.0e6, 4.0e6]) * K,
+        mu=np.array([1.0, 1.0]) * amu,
+    )
+
+    assert broadened.lnu.shape == sed.lnu.shape
+    assert broadened.lnu[1].max() < broadened.lnu[0].max()
+
+
+def test_doppler_broadening_transformer_uses_fixed_parameter():
+    sed = make_line_sed()
+    model = DummyModel(velocity_dispersion=300.0 * km / s)
+    transformer = DopplerBroadening(sigma_v_attr="velocity_dispersion")
+
+    broadened = transformer._transform(sed, None, model, None, None)
+
+    assert broadened.lnu.max() < sed.lnu.max()
+
+
+def test_thermal_broadening_transformer_uses_fixed_parameters():
+    sed = make_line_sed()
+    model = DummyModel(temperature=1.0e6 * K, mu=1.0 * amu)
+    transformer = ThermalBroadening(mu_attr="mu")
+
+    broadened = transformer._transform(sed, None, model, None, None)
+
+    assert broadened.lnu.max() < sed.lnu.max()
+
+
+def test_broadening_transformer_rejects_lam_mask():
+    sed = make_line_sed()
+    model = DummyModel(sigma_v=300.0 * km / s)
+    transformer = DopplerBroadening()
+
+    with pytest.raises(exceptions.InconsistentArguments):
+        transformer._transform(sed, None, model, None, np.ones(sed.lam.size))
+
+
+def test_broadening_transformer_rejects_non_sed():
+    model = DummyModel(sigma_v=300.0 * km / s)
+    transformer = DopplerBroadening()
+
+    with pytest.raises(exceptions.InconsistentArguments):
+        transformer._transform(object(), None, model, None, None)

--- a/tests/test_broadening.py
+++ b/tests/test_broadening.py
@@ -95,10 +95,7 @@ def test_get_param_preserve_units_keeps_fixed_parameter_units():
 
 def test_broadening_transformer_preserves_fixed_parameter_units():
     model = DummyModel(velocity_dispersion=300.0 * km / s)
-    transformer = DopplerBroadening(
-        sigma_v_attr="velocity_dispersion",
-        apply_units=False,
-    )
+    transformer = DopplerBroadening(sigma_v_attr="velocity_dispersion")
 
     params = transformer._extract_params(
         model,

--- a/tests/test_broadening.py
+++ b/tests/test_broadening.py
@@ -39,6 +39,18 @@ def test_doppler_broaden_accepts_array_sigma_v():
     assert broadened.lnu[1].max() < broadened.lnu[0].max()
 
 
+def test_doppler_broaden_handles_per_particle_spectra():
+    sed = make_line_sed(shape=(3,))
+    sigma_v = np.array([100.0, 300.0, 600.0]) * km / s
+
+    broadened = sed.doppler_broaden(sigma_v)
+
+    assert broadened.lnu.shape == sed.lnu.shape
+    assert broadened.lnu[2].max() < broadened.lnu[1].max()
+    assert broadened.lnu[1].max() < broadened.lnu[0].max()
+    np.testing.assert_allclose(sed.lnu, make_line_sed(shape=(3,)).lnu)
+
+
 def test_doppler_broaden_masks_spectra():
     sed = make_line_sed(shape=(2,))
 

--- a/tests/test_broadening.py
+++ b/tests/test_broadening.py
@@ -11,6 +11,7 @@ from synthesizer.emission_models.transformers import (
     DopplerBroadening,
     ThermalBroadening,
 )
+from synthesizer.emission_models.utils import get_param
 from synthesizer.emissions.sed import Sed
 
 
@@ -76,6 +77,39 @@ def test_doppler_broadening_transformer_uses_fixed_parameter():
     assert broadened.lnu.max() < sed.lnu.max()
 
 
+def test_get_param_preserve_units_keeps_fixed_parameter_units():
+    model = DummyModel(velocity_dispersion=300.0 * km / s)
+
+    default_value = get_param("velocity_dispersion", model, None, None)
+    unit_value = get_param(
+        "velocity_dispersion",
+        model,
+        None,
+        None,
+        preserve_units=True,
+    )
+
+    assert not hasattr(default_value, "units")
+    assert unit_value.units == km / s
+
+
+def test_broadening_transformer_preserves_fixed_parameter_units():
+    model = DummyModel(velocity_dispersion=300.0 * km / s)
+    transformer = DopplerBroadening(
+        sigma_v_attr="velocity_dispersion",
+        apply_units=False,
+    )
+
+    params = transformer._extract_params(
+        model,
+        None,
+        None,
+        preserve_units=True,
+    )
+
+    assert params["velocity_dispersion"].units == km / s
+
+
 def test_thermal_broadening_transformer_uses_fixed_parameters():
     sed = make_line_sed()
     model = DummyModel(temperature=1.0e6 * K, mu=1.0 * amu)
@@ -91,7 +125,7 @@ def test_broadening_transformer_rejects_lam_mask():
     model = DummyModel(sigma_v=300.0 * km / s)
     transformer = DopplerBroadening()
 
-    with pytest.raises(exceptions.InconsistentArguments):
+    with pytest.raises(exceptions.UnimplementedFunctionality):
         transformer._transform(sed, None, model, None, np.ones(sed.lam.size))
 
 

--- a/tests/test_unified_agn.py
+++ b/tests/test_unified_agn.py
@@ -5,11 +5,14 @@ from pathlib import Path
 import h5py
 import numpy as np
 import pytest
-from unyt import K, Mpc, Msun, deg, yr
+from unyt import K, Mpc, Msun, deg, km, s, yr
 
 from synthesizer.emission_models.agn.unified_agn import UnifiedAGN
 from synthesizer.emission_models.base_model import BlackHoleEmissionModel
 from synthesizer.emission_models.generators.dust.greybody import Greybody
+from synthesizer.emission_models.transformers.broadening import (
+    DopplerBroadening,
+)
 from synthesizer.emission_models.transformers.dust_attenuation import PowerLaw
 from synthesizer.emission_models.utils import get_param
 from synthesizer.exceptions import InconsistentParameter
@@ -37,6 +40,7 @@ def make_unified_agn(
     test_grid,
     disc_transmission="weighted_combination",
     variant="intrinsic",
+    **model_kwargs,
 ):
     """Create a UnifiedAGN model for testing."""
     kwargs = {}
@@ -54,12 +58,13 @@ def make_unified_agn(
         torus_emission_model=Greybody(temperature=10**4 * K, emissivity=2),
         disc_transmission=disc_transmission,
         **kwargs,
+        **model_kwargs,
     )
 
 
 def get_intrinsic_model(model):
     """Return the intrinsic UnifiedAGN model carrying transmission branches."""
-    return model if hasattr(model, "disc_escaped") else model.intrinsic
+    return model.intrinsic if hasattr(model, "intrinsic") else model
 
 
 def make_no_weight_bh_grid(tmp_path: Path):
@@ -358,6 +363,55 @@ class TestUnifiedAGN:
         assert escape == 0.0
         assert nlr == 0.75
         assert blr == 0.25
+
+    @pytest.mark.parametrize("variant", ["intrinsic", "attenuated", "total"])
+    def test_line_regions_are_unbroadened_by_default(
+        self,
+        test_grid,
+        variant,
+    ):
+        """Test BLR/NLR labels are unchanged without velocity dispersions."""
+        model = get_intrinsic_model(
+            make_unified_agn(test_grid, variant=variant)
+        )
+
+        assert model.nlr.label == "nlr"
+        assert model.blr.label == "blr"
+        assert model.nlr.transformer._required_params == (
+            "covering_fraction_nlr",
+        )
+        assert model.blr.transformer._required_params == (
+            "covering_fraction_blr",
+        )
+
+    @pytest.mark.parametrize("variant", ["intrinsic", "attenuated", "total"])
+    def test_line_regions_are_broadened_when_velocity_dispersion_is_set(
+        self,
+        test_grid,
+        variant,
+    ):
+        """Test velocity dispersions add final BLR/NLR broadening models."""
+        model = get_intrinsic_model(
+            make_unified_agn(
+                test_grid,
+                variant=variant,
+                velocity_dispersion_blr=2000.0 * km / s,
+                velocity_dispersion_nlr=500.0 * km / s,
+            )
+        )
+
+        assert model.nlr.label == "nlr"
+        assert model.blr.label == "blr"
+        assert model.nlr._apply_to_label == "unbroadened_nlr"
+        assert model.blr._apply_to_label == "unbroadened_blr"
+        assert isinstance(model.nlr.transformer, DopplerBroadening)
+        assert isinstance(model.blr.transformer, DopplerBroadening)
+        assert model.nlr.fixed_parameters["velocity_dispersion_nlr"] == (
+            500.0 * km / s
+        )
+        assert model.blr.fixed_parameters["velocity_dispersion_blr"] == (
+            2000.0 * km / s
+        )
 
     def test_invalid_disc_transmission_raises(self, test_grid):
         """Test invalid transmission options are rejected."""


### PR DESCRIPTION
This PR introduces `Transformer` child classes to handle the broadening of spectra as part of an `EmissionModel`. This functionality has been baked into the `UnifiedAGN` model. This uses the existing `Sed` broadening methods.

This functionality required the expansion of the existing Doppler broadening machinery to work for per-particle spectra. This is done by repeatedly applying the 1D version, which works for now but could certainly be improved.

This also required a slight modification of the `get_param` machinery which used to jetison units wholesale in preparation for passing to C. In this case we want the units and don't want to retroactively assume them and add them back in. I have therefore added an optional flag that will preserve units and folded this in the `Transformer` machinery.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Doppler broadening to the Unified AGN emission model via configurable velocity dispersion parameters for broad and narrow line regions.
  * Introduced new broadening transformers for flexible spectral broadening of emission spectra.
  * Enhanced broadening methods to support selective masking of spectra.

* **Documentation**
  * Added example script demonstrating Unified AGN broadening capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/synthesizer-project/synthesizer/pull/1146?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->