### PR TITLE
Add label validation in _get_images to raise on unrecognised labels

### DIFF
--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -1380,14 +1380,19 @@ class BaseGalaxy:
                 otherwise a dict of ImageCollections keyed by label.
 
         """
+
+
         # Convert labels tuple to a list and validate they are strings
         labels = list(labels)
+
         for label in labels:
             if not isinstance(label, str):
                 raise exceptions.InconsistentArguments(
                     f"All labels must be strings, got {type(label).__name__}. "
                     "If passing an EmissionModel, use model.label instead."
                 )
+
+
 
         _labels = []
         while len(labels) > 0:
@@ -1429,6 +1434,8 @@ class BaseGalaxy:
         if self.gas is not None and hasattr(self.gas, "model_param_cache"):
             combined_cache.update(self.gas.model_param_cache)
 
+
+
         # Prepare galaxy-level image generation, routing to components
         galaxy_combine_labels, component_labels_by_emitter = (
             _prepare_galaxy_image_labels(
@@ -1436,6 +1443,17 @@ class BaseGalaxy:
                 combined_cache,
             )
         )
+        
+        # Validate all requested labels were routed to an emitter or a combine step
+        routed_labels = set(galaxy_combine_labels)
+        for emitter_labels in component_labels_by_emitter.values():
+            routed_labels.update(emitter_labels)
+        missing = set(labels) - routed_labels
+        if missing:
+            raise exceptions.InconsistentArguments(
+                f"The following labels were not found in any emitter: "
+                f"{missing}."
+            )
 
         # Container for images we will make
         out_images = {}

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -1381,7 +1381,6 @@ class BaseGalaxy:
 
         """
 
-
         # Convert labels tuple to a list and validate they are strings
         labels = list(labels)
 
@@ -1391,8 +1390,6 @@ class BaseGalaxy:
                     f"All labels must be strings, got {type(label).__name__}. "
                     "If passing an EmissionModel, use model.label instead."
                 )
-
-
 
         _labels = []
         while len(labels) > 0:
@@ -1434,8 +1431,6 @@ class BaseGalaxy:
         if self.gas is not None and hasattr(self.gas, "model_param_cache"):
             combined_cache.update(self.gas.model_param_cache)
 
-
-
         # Prepare galaxy-level image generation, routing to components
         galaxy_combine_labels, component_labels_by_emitter = (
             _prepare_galaxy_image_labels(
@@ -1443,7 +1438,7 @@ class BaseGalaxy:
                 combined_cache,
             )
         )
-        
+
         # Validate all requested labels were routed to an emitter or a combine step
         routed_labels = set(galaxy_combine_labels)
         for emitter_labels in component_labels_by_emitter.values():

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -1452,7 +1452,7 @@ class BaseGalaxy:
         if missing:
             raise exceptions.InconsistentArguments(
                 f"The following labels were not found in any emitter: "
-                f"{missing}."
+                f"{missing}. Available labels are: {list(combined_cache.keys())}"
             )
 
         # Container for images we will make


### PR DESCRIPTION
## Issue Type
- Enhancement (easier debug for image generation)

Add validation in BaseGalaxy._get_images to raise an InconsistentArguments error if any labels passed by the user for emission models are invalid / not run yet in any models. Previously, unrecognised labels would silently be dropped with no feedback to the user, and the final image dictionary would be empty without giving the reason. This might be supposed to be caught in lines #1502-1508 but hasn't been. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for image label requests to provide clearer error feedback when requested labels are not found in available resources.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/synthesizer-project/synthesizer/pull/1148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->