### PR TITLE
Timing rotations and protecting when velocities aren't present

### DIFF
--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -1405,6 +1405,7 @@ class Particles:
         return col_den
 
     @accepts(phi=rad, theta=rad)
+    @timed("Particles.rotate_particles")
     def rotate_particles(
         self,
         phi=0 * rad,
@@ -1444,7 +1445,10 @@ class Particles:
         if inplace:
             # Rotate the coordinates
             self.coordinates = rotate(self.coordinates, phi, theta, rot_matrix)
-            self.velocities = rotate(self.velocities, phi, theta, rot_matrix)
+            if self.velocities is not None:
+                self.velocities = rotate(
+                    self.velocities, phi, theta, rot_matrix
+                )
             if self.centre is not None:
                 self.centre = rotate(self.centre, phi, theta, rot_matrix)
 
@@ -1457,9 +1461,10 @@ class Particles:
         new_parts.coordinates = rotate(
             new_parts.coordinates, phi, theta, rot_matrix
         )
-        new_parts.velocities = rotate(
-            new_parts.velocities, phi, theta, rot_matrix
-        )
+        if new_parts.velocities is not None:
+            new_parts.velocities = rotate(
+                new_parts.velocities, phi, theta, rot_matrix
+            )
         if self.centre is not None:
             new_parts.centre = rotate(new_parts.centre, phi, theta, rot_matrix)
 
@@ -1502,6 +1507,7 @@ class Particles:
             axis=0,
         ).to(ang_mom_unit)
 
+    @timed("Particles.rotate_edge_on")
     def rotate_edge_on(self, inplace=True):
         """Rotate the particle distribution to edge-on.
 
@@ -1526,6 +1532,7 @@ class Particles:
         # Call the rotate_particles method with the computed angles
         return self.rotate_particles(rot_matrix=rot_matrix, inplace=inplace)
 
+    @timed("Particles.rotate_face_on")
     def rotate_face_on(self, inplace=True):
         """Rotate the particle distribution to face-on.
 


### PR DESCRIPTION
DWISOTT. Previously, the rotations would fall over if there were no velocities.

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Particle rotation now correctly handles cases where velocity data may not be present, ensuring proper transformations during rotation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/synthesizer-project/synthesizer/pull/1155?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->