### PR TITLE
Adding the ability to measure smoothing lengths from other coordinates

### DIFF
--- a/docs/source/galaxy_components/stars.ipynb
+++ b/docs/source/galaxy_components/stars.ipynb
@@ -165,7 +165,7 @@
     "    num_neighbours=32,\n",
     ")\n",
     "\n",
-    "stars = Stars(\n",
+    "smoothed_stars = Stars(\n",
     "    initial_masses=initial_masses,\n",
     "    ages=ages,\n",
     "    metallicities=metallicities,\n",
@@ -175,7 +175,8 @@
     ")\n",
     "\n",
     "print(stellar_smls[:3])\n",
-    "print(stellar_smls_from_gas[:3])"
+    "print(stellar_smls_from_gas[:3])\n",
+    "print(smoothed_stars.smoothing_lengths[:3])"
    ]
   },
   {

--- a/docs/source/galaxy_components/stars.ipynb
+++ b/docs/source/galaxy_components/stars.ipynb
@@ -140,6 +140,48 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Smoothing lengths\n",
+    "\n",
+    "Smoothed particle imaging and line-of-sight calculations require ``smoothing_lengths`` for each particle. If these are not already present in your input data, you can derive them from the particle coordinates with ``calculate_smoothing_lengths``. By default this performs a self-query, using the stellar coordinates as both the input and source set.\n",
+    "\n",
+    "You can also derive stellar smoothing lengths from a different particle distribution by passing ``source_coords``. This is useful when the stars should inherit their smoothing scale from the gas distribution, for example when preparing stellar line-of-sight calculations based on gas particles. The same interface is available on the particle object itself via ``stars.calculate_smoothing_lengths(source_coords=...)``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from synthesizer.particle.utils import calculate_smoothing_lengths\n",
+    "\n",
+    "star_coords = np.random.normal(50, 0.005, (N, 3)) * Mpc\n",
+    "gas_coords = np.random.normal(50, 0.01, (4 * N, 3)) * Mpc\n",
+    "\n",
+    "stellar_smls = calculate_smoothing_lengths(star_coords)\n",
+    "stellar_smls_from_gas = calculate_smoothing_lengths(\n",
+    "    star_coords,\n",
+    "    source_coords=gas_coords,\n",
+    "    num_neighbours=32,\n",
+    ")\n",
+    "\n",
+    "stars = Stars(\n",
+    "    initial_masses=initial_masses,\n",
+    "    ages=ages,\n",
+    "    metallicities=metallicities,\n",
+    "    coordinates=star_coords,\n",
+    "    current_masses=initial_masses,\n",
+    "    smoothing_lengths=stellar_smls_from_gas,\n",
+    ")\n",
+    "\n",
+    "print(stellar_smls[:3])\n",
+    "print(stellar_smls_from_gas[:3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Computing characteristics radii\n",
     "\n",
     "Characteristic radii can be computed for the stellar particle distribution. We can either calculate the half-mass radius."

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -713,15 +713,25 @@ class Particles:
 
         self.center = com
 
-    def calculate_smoothing_lengths(self, **kwargs):
+    def calculate_smoothing_lengths(self, source_coords=None, **kwargs):
         """Calculate smoothing lengths of particles and assign.
 
         Calls utility function directly, see
         `synthesizer.particle.utils.calculate_smoothing_lengths`
         for a full list of accepted arguments.
+
+        Args:
+            source_coords (unyt_array, optional):
+                Coordinates to query against when calculating smoothing
+                lengths. If None, the particle coordinates are used.
+            **kwargs (dict):
+                Additional keyword arguments passed to
+                `calculate_smoothing_lengths`.
         """
         self.smoothing_lengths = calculate_smoothing_lengths(
-            coordinates=self.coordinates, **kwargs
+            coordinates=self.coordinates,
+            source_coords=source_coords,
+            **kwargs,
         )
 
     def get_radii(self):

--- a/src/synthesizer/particle/utils.py
+++ b/src/synthesizer/particle/utils.py
@@ -118,9 +118,9 @@ def calculate_smoothing_lengths(
     query_coords = coordinates.value
     source_values = source_coords.to(coordinates.units).value
 
+    # Ensure the number of neighbours and speedup factor are valid
     if num_neighbours < 1:
         raise ValueError("num_neighbours must be at least 1.")
-
     if speedup_fac < 1:
         raise ValueError("speedup_fac must be at least 1.")
 
@@ -133,9 +133,12 @@ def calculate_smoothing_lengths(
             source_values, boxsize=boxsize.to(coordinates.units).value
         )
 
+    # Prepare an array to hold the resultant smoothing lengths
     smoothing_lengths: np.ndarray = np.empty(nparts, dtype=np.float32)
 
-    # Include speedup_fac stuff here:
+    # Derive the number of neighbours to search for and the correction factor
+    # to apply to the smoothing lengths based on the speedup factor around
+    # dimension
     neighbours_search: int = max(1, num_neighbours // speedup_fac)
     hsml_correction_fac_speedup: float = (speedup_fac) ** (1 / dimension)
 
@@ -145,7 +148,9 @@ def calculate_smoothing_lengths(
     # testing." - SWIFTsimio (probably Josh)
     block_size: int = 65536
 
+    # Loop through the coordinates in blocks
     for starting_index in range(0, nparts, block_size):
+        # Get the block indices
         ending_index = min(starting_index + block_size, nparts)
 
         # Query the tree for this chunk
@@ -164,4 +169,5 @@ def calculate_smoothing_lengths(
     return unyt_array(
         smoothing_lengths * (hsml_correction_fac_speedup / kernel_gamma),
         units=coordinates.units,
+        bypass_validation=True,
     )

--- a/src/synthesizer/particle/utils.py
+++ b/src/synthesizer/particle/utils.py
@@ -62,14 +62,16 @@ def rotate(
     return np.dot(coordinates, rot_matrix.T)
 
 
-@accepts(coordinates=Mpc, boxsize=Mpc)
+@accepts(coordinates=Mpc, source_coords=Mpc, boxsize=Mpc)
 def calculate_smoothing_lengths(
     coordinates: unyt_array,
+    source_coords: unyt_array = None,
     kernel_gamma: np.float32 = 1.4,
     num_neighbours: int = 32,
     speedup_fac: int = 2,
     dimension: int = 3,
     boxsize: unyt_array = None,
+    workers: int = 1,
 ) -> unyt_array[Mpc]:
     """Calculate smoothing lengths based on the kth nearest neighbour distance.
 
@@ -82,6 +84,9 @@ def calculate_smoothing_lengths(
     Args:
         coordinates (unyt_array):
             The coordinates to calculate the smoothing lengths for.
+        source_coords (unyt_array, optional):
+            The source coordinates to query against. If None, smoothing
+            lengths are calculated from `coordinates` themselves.
         kernel_gamma (float, optional):
             The kernel gamma of the kernel being used. (default: 1.4)
         num_neighbours (int, optional):
@@ -101,26 +106,37 @@ def calculate_smoothing_lengths(
         boxsize (unyt_array, optional):
             The boxsize to use for the periodic boundary conditions. If None,
             no periodic boundary conditions are used
+        workers (int, optional):
+            The number of workers to use in the neighbour search. The default
+            is 1.
 
     Returns:
         unyt_array: An unyt array of smoothing lengths.
     """
     nparts: int = coordinates.shape[0]
+    source_coords = coordinates if source_coords is None else source_coords
+    query_coords = coordinates.value
+    source_values = source_coords.to(coordinates.units).value
+
+    if num_neighbours < 1:
+        raise ValueError("num_neighbours must be at least 1.")
+
+    if speedup_fac < 1:
+        raise ValueError("speedup_fac must be at least 1.")
 
     # Build the tree (with or without periodic boundary conditions)
     tree: cKDTree
     if boxsize is None:
-        tree = cKDTree(coordinates.value)
+        tree = cKDTree(source_values)
     else:
         tree = cKDTree(
-            coordinates.value, boxsize=boxsize.to(coordinates.units).value
+            source_values, boxsize=boxsize.to(coordinates.units).value
         )
 
     smoothing_lengths: np.ndarray = np.empty(nparts, dtype=np.float32)
-    smoothing_lengths[-1] = -0.1
 
     # Include speedup_fac stuff here:
-    neighbours_search: int = num_neighbours // speedup_fac
+    neighbours_search: int = max(1, num_neighbours // speedup_fac)
     hsml_correction_fac_speedup: float = (speedup_fac) ** (1 / dimension)
 
     # We create a lot of data doing this, so we want to do it in small chunks
@@ -128,31 +144,23 @@ def calculate_smoothing_lengths(
     # reasonable chunk size based on previous performance
     # testing." - SWIFTsimio (probably Josh)
     block_size: int = 65536
-    number_of_blocks: int = 1 + nparts // block_size
 
-    d: np.ndarray
-    for block in range(number_of_blocks):
-        starting_index: int = block * block_size
-        ending_index: int = (block + 1) * (block_size)
-
-        # Handles the bounds
-        if ending_index > nparts:
-            ending_index = nparts + 1
-        if starting_index >= ending_index:
-            break
+    for starting_index in range(0, nparts, block_size):
+        ending_index = min(starting_index + block_size, nparts)
 
         # Query the tree for this chunk
         d, _ = tree.query(
-            coordinates[starting_index:ending_index].value,
+            query_coords[starting_index:ending_index],
             k=neighbours_search,
-            workers=-1,
+            workers=workers,
         )
 
         # Store the smoothing lengths
-        smoothing_lengths[starting_index:ending_index] = d[:, -1]
+        if np.ndim(d) == 1:
+            smoothing_lengths[starting_index:ending_index] = d
+        else:
+            smoothing_lengths[starting_index:ending_index] = d[:, -1]
 
-    # Correct the smoothing lengths for the speedup factor and kernel gamma
-    # before returning
     return unyt_array(
         smoothing_lengths * (hsml_correction_fac_speedup / kernel_gamma),
         units=coordinates.units,


### PR DESCRIPTION
For some applications, it's better to have smoothing lengths that are measured from a different set of coordinates (e.g. stars measured from gas). This PR enables that. 

The existing machinery also didn't make the most of the ``scipy`` threading machinery. This is now folded in.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for calculating smoothing lengths from alternative source coordinates, enabling flexible derivation from different particle sets (e.g., deriving star smoothing lengths from gas particle coordinates).
  * Added configurable parallelism control for neighbor searches.

* **Documentation**
  * New "Smoothing lengths" section with practical examples demonstrating direct calculation and source-coordinate-based derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->