### PR TITLE
Add FAQ page to documentation

### DIFF
--- a/docs/source/faq/faq.rst
+++ b/docs/source/faq/faq.rst
@@ -1,0 +1,11 @@
+FAQ
+===
+
+A collection of frequently asked questions about Synthesizer.
+
+Why do I get an SVO inaccessible warning on a HPC but it works locally?
+-----------------------------------------------------------------------
+
+Your compute node doesn't have internet access. Use the ``write`` method to
+save your instruments or filters locally, then use the ``load`` method to read
+them back in on the HPC.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ Contents
    advanced/advanced
    notebook_examples/cookbook
    auto_examples/index
+   faq/faq
    publications/publications
    API
 


### PR DESCRIPTION
Add a FAQ page positioned between examples and publications in the toctree, with an initial entry on the SVO inaccessible warning on HPC systems without internet access.

## Issue Type
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ addressing "SVO inaccessible" warnings on HPC systems, explaining how to save instruments and filters locally and load them on compute nodes without internet access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->