### PR TITLE
Adds caching machinery for SVO requests

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -50,6 +50,9 @@ jobs:
         run: |
           # Download the data we need
           synthesizer-download --test-grids --dust-grid --all-sim-data --instruments EuclidNISP
+      - name: Download SVO filter cache
+        run: |
+          synthesizer-download --svo-filter-cache
       - name: Test with pytest
         run: |
           pytest -n auto

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           # Download the data we need
           synthesizer-download --test-grids --dust-grid --all-sim-data --instruments EuclidNISP
+      - name: Download SVO filter cache
+        run: |
+          synthesizer-download --svo-filter-cache
       - name: Sphinx Build
         run: |
           cd docs

--- a/package_svo_cache.sh
+++ b/package_svo_cache.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Package the SVO filter cache for CI distribution.
+#
+# After running the full test suite, docs build, and examples locally,
+# this script tars the populated cache directory so it can be uploaded
+# to the data server for CI consumption.
+#
+# Usage:
+#   ./package_svo_cache.sh [output_path]
+#
+# Args:
+#   output_path: Path for the output tarball (default: svo_filter_cache.tar.gz)
+
+set -e
+
+OUTPUT="${1:-svo_filter_cache.tar.gz}"
+
+# Resolve the cache directory from Python
+CACHE_DIR=$(python -c "from synthesizer import SVO_FILTER_CACHE_DIR; print(SVO_FILTER_CACHE_DIR)")
+
+# Count cached filters
+EXISTING=$(ls "$CACHE_DIR"/*.hdf5 2>/dev/null | wc -l)
+
+if [ "$EXISTING" -eq 0 ]; then
+    echo "No cached filters found in $CACHE_DIR"
+    echo "Run the tests, docs build, and examples first to populate the cache."
+    exit 1
+fi
+
+echo "SVO filter cache: $CACHE_DIR ($EXISTING filter files)"
+echo "Packaging into $OUTPUT..."
+tar -czf "$OUTPUT" -C "$CACHE_DIR" .
+echo "Done: $OUTPUT"

--- a/src/synthesizer/__init__.py
+++ b/src/synthesizer/__init__.py
@@ -7,6 +7,7 @@ from synthesizer.data.initialise import (
     get_data_dir,
     get_grids_dir,
     get_instrument_dir,
+    get_svo_filter_cache_dir,
     get_test_data_dir,
     synth_initialise,
 )
@@ -22,6 +23,7 @@ DATA_DIR = get_data_dir()
 GRID_DIR = get_grids_dir()
 TEST_DATA_DIR = get_test_data_dir()
 INSTRUMENT_CACHE_DIR = get_instrument_dir()
+SVO_FILTER_CACHE_DIR = get_svo_filter_cache_dir()
 
 
 # Make a version available at the top level
@@ -62,4 +64,5 @@ __all__ = [
     "GRID_DIR",
     "TEST_DATA_DIR",
     "INSTRUMENT_CACHE_DIR",
+    "SVO_FILTER_CACHE_DIR",
 ]

--- a/src/synthesizer/data/initialise.py
+++ b/src/synthesizer/data/initialise.py
@@ -148,6 +148,30 @@ def get_instrument_dir() -> Path:
     return get_base_dir() / "instrument_cache"
 
 
+def get_svo_filter_cache_dir() -> Path:
+    """Get the Synthesizer SVO filter cache directory path.
+
+    This function returns the path to the Synthesizer SVO filter cache
+    directory, which stores cached SVO filter responses to avoid
+    repeated requests to the SVO database.
+    """
+    # First check if we have an environment variable set
+    if "SYNTHESIZER_SVO_FILTER_CACHE" in os.environ:
+        return Path(os.environ["SYNTHESIZER_SVO_FILTER_CACHE"])
+
+    # Otherwise, use the base directory
+    return get_base_dir() / "svo_filter_cache"
+
+
+def svo_filter_cache_exists() -> bool:
+    """Check if the SVO filter cache directory exists.
+
+    This function checks if the SVO filter cache directory, as defined by
+    get_svo_filter_cache_dir(), exists on the filesystem.
+    """
+    return get_svo_filter_cache_dir().exists()
+
+
 def instrument_cache_exists() -> bool:
     """Check if the Synthesizer instrument cache directory exists.
 
@@ -247,6 +271,7 @@ class SynthesizerInitializer:
         self.grids_dir = get_grids_dir()
         self.test_data_dir = get_test_data_dir()
         self.instrument_cache_dir = get_instrument_dir()
+        self.svo_filter_cache_dir = get_svo_filter_cache_dir()
 
         # Initialize status dictionary for each step
         keys = [
@@ -254,6 +279,7 @@ class SynthesizerInitializer:
             "data_dir",
             "grids",
             "instrument_cache",
+            "svo_filter_cache",
             "test_data",
             "units_file",
             "ids_file",
@@ -404,6 +430,7 @@ class SynthesizerInitializer:
         self._make_dir(self.data_dir, "data_dir")
         self._make_dir(self.grids_dir, "grids")
         self._make_dir(self.instrument_cache_dir, "instrument_cache")
+        self._make_dir(self.svo_filter_cache_dir, "svo_filter_cache")
         self._make_dir(self.test_data_dir, "test_data")
 
         # Copy the default units to their user facing location
@@ -447,6 +474,11 @@ class SynthesizerInitializer:
                 "Instrument cache directory:",
                 self.instrument_cache_dir,
             ),
+            (
+                "svo_filter_cache",
+                "SVO filter cache directory:",
+                self.svo_filter_cache_dir,
+            ),
             ("test_data", "Test data directory:", self.test_data_dir),
         ]
 
@@ -465,6 +497,7 @@ class SynthesizerInitializer:
             ("SYNTHESIZER_DATA_DIR", self.data_dir),
             ("SYNTHESIZER_GRID_DIR", self.grids_dir),
             ("SYNTHESIZER_INSTRUMENT_CACHE", self.instrument_cache_dir),
+            ("SYNTHESIZER_SVO_FILTER_CACHE", self.svo_filter_cache_dir),
             ("SYNTHESIZER_TEST_DATA_DIR", self.test_data_dir),
         ]
 
@@ -531,6 +564,7 @@ def synth_initialise(verbose=True) -> None:
         and grids_dir_exists()
         and testdata_dir_exists()
         and instrument_cache_exists()
+        and svo_filter_cache_exists()
         and default_units_exists()
     )
 
@@ -598,3 +632,7 @@ def synth_clear_data() -> None:
         initializer._remove_dir(initializer.instrument_cache_dir)
     except Exception as e:
         print(f"Failed to clear Synthesizer instrument cache directory: {e}")
+    try:
+        initializer._remove_dir(initializer.svo_filter_cache_dir)
+    except Exception as e:
+        print(f"Failed to clear Synthesizer SVO filter cache directory: {e}")

--- a/src/synthesizer/downloader/_data_ids.yml
+++ b/src/synthesizer/downloader/_data_ids.yml
@@ -693,6 +693,10 @@ ProductionGrids:
   maraston24-Tenc40_kroupa-0.1,100_cloudy-c23.01-sps.hdf5:
     file: maraston24-Tenc40_kroupa-0.1,100_cloudy-c23.01-sps.hdf5
     direct_link: https://sussex.box.com/shared/static/c7s1xxltz5a8fo7gi14howlepbfc3aa1.hdf5
+SVOFilterCache:
+  svo_filter_cache.tar.gz:
+    file: svo_filter_cache.tar.gz
+    direct_link: https://sussex.box.com/shared/static/o29i2nytryj2895pkbe25e9825cf5zc6.gz
 SynferenceData:
   BPASS_DenseBasis_v4_final_nsf_0_params.pkl:
     file: BPASS_DenseBasis_v4_final_nsf_0_params.pkl

--- a/src/synthesizer/downloader/downloader.py
+++ b/src/synthesizer/downloader/downloader.py
@@ -457,11 +457,24 @@ def download_svo_filter_cache(destination):
     """
     import tarfile
 
+    def _safe_extract(tar, path):
+        """Extract a tarball safely, guarding against path traversal."""
+        if hasattr(tarfile, "DATA_FILTER"):
+            tar.extractall(path=path, filter="data")
+        else:
+            for member in tar.getmembers():
+                member_path = os.path.realpath(os.path.join(path, member.name))
+                if not member_path.startswith(os.path.realpath(path)):
+                    raise exceptions.DownloadError(
+                        f"Unsafe tar member: {member.name}"
+                    )
+                tar.extract(member, path=path)
+
     for fname in SVO_FILTER_CACHE_FILES:
         _download(fname, destination)
         tarball_path = os.path.join(destination, fname)
         with tarfile.open(tarball_path, "r:gz") as tar:
-            tar.extractall(path=destination)
+            _safe_extract(tar, destination)
         os.remove(tarball_path)
 
 

--- a/src/synthesizer/downloader/downloader.py
+++ b/src/synthesizer/downloader/downloader.py
@@ -25,6 +25,7 @@ from tqdm import tqdm
 from synthesizer import (
     GRID_DIR,
     INSTRUMENT_CACHE_DIR,
+    SVO_FILTER_CACHE_DIR,
     TEST_DATA_DIR,
     exceptions,
 )
@@ -62,11 +63,17 @@ def load_synference_data_links():
     return load_database_yaml()["SynferenceData"]
 
 
+def load_svo_filter_cache_links():
+    """Load the SVO filter cache links from the yaml file."""
+    return load_database_yaml()["SVOFilterCache"]
+
+
 # Get the dicts contain the locations of the test and dust data
 TEST_FILES = load_test_data_links()
 DUST_FILES = load_dust_data_links()
 INSTRUMENT_FILES = load_instrument_data_links()
 SYNFERENCE_FILES = load_synference_data_links()
+SVO_FILTER_CACHE_FILES = load_svo_filter_cache_links()
 
 # Combine everything into a nice single dict
 AVAILABLE_FILES = {
@@ -74,6 +81,7 @@ AVAILABLE_FILES = {
     **DUST_FILES,
     **INSTRUMENT_FILES,
     **SYNFERENCE_FILES,
+    **SVO_FILTER_CACHE_FILES,
 }
 
 # Define a translation between instrument file names and their class names
@@ -322,6 +330,17 @@ def download():
         help="Download all available instruments",
     )
 
+    # Add a flag to download the SVO filter cache
+    parser.add_argument(
+        "--svo-filter-cache",
+        action="store_true",
+        help=(
+            "Download the SVO filter cache (stored in "
+            f"{SVO_FILTER_CACHE_DIR}). This avoids hitting the SVO database "
+            "during CI runs."
+        ),
+    )
+
     # Add a flag to go ham and download everything
     parser.add_argument(
         "--all",
@@ -353,6 +372,7 @@ def download():
     agn = args.agn_test_grids
     dust_grid = args.dust_grid
     camels = args.camels_data
+    svo_filter_cache = args.svo_filter_cache
     everything = args.all
     dest = args.destination
     scsam = args.scsam_data
@@ -413,10 +433,36 @@ def download():
     if scsam:
         download_sc_sam_test_data(dest if dest is not None else TEST_DATA_DIR)
 
+    # SVO filter cache?
+    if svo_filter_cache:
+        download_svo_filter_cache(SVO_FILTER_CACHE_DIR)
+
     # All simulation data?
     if all_sim_data:
         download_camels_data(dest if dest is not None else TEST_DATA_DIR)
         download_sc_sam_test_data(dest if dest is not None else TEST_DATA_DIR)
+
+
+def download_svo_filter_cache(destination):
+    """Download and extract the SVO filter cache.
+
+    This downloads a tarball of cached SVO filter responses and extracts
+    them into the destination directory, avoiding repeated requests to
+    the SVO database during CI runs.
+
+    Args:
+        destination (str):
+            The path to the destination directory where the cache should
+            be extracted.
+    """
+    import tarfile
+
+    for fname in SVO_FILTER_CACHE_FILES:
+        _download(fname, destination)
+        tarball_path = os.path.join(destination, fname)
+        with tarfile.open(tarball_path, "r:gz") as tar:
+            tar.extractall(path=destination)
+        os.remove(tarball_path)
 
 
 def download_synference_test(destination):

--- a/src/synthesizer/instruments/filters.py
+++ b/src/synthesizer/instruments/filters.py
@@ -38,6 +38,7 @@ from unyt import Hz, angstrom, c, unyt_array, unyt_quantity
 
 from synthesizer import exceptions
 from synthesizer._version import __version__
+from synthesizer.data.initialise import get_svo_filter_cache_dir
 from synthesizer.extensions.photometry import compute_photometry
 from synthesizer.synth_warnings import warn
 from synthesizer.units import Quantity, accepts
@@ -1995,6 +1996,47 @@ class Filter:
             f"{self.instrument}.{self.filter_}"
         )
 
+        # Check the SVO filter cache to avoid unnecessary requests.
+        cache_key = self.filter_code.replace("/", "_")
+        cache_dir = get_svo_filter_cache_dir()
+        cache_file = cache_dir / f"{cache_key}.hdf5"
+        if cache_file.exists():
+            try:
+                with h5py.File(cache_file, "r") as f:
+                    self.original_lam = f["wavelength"][:]
+                    self.original_t = f["transmission"][:]
+                    self.svo_url = f.attrs["svo_url"]
+                if isinstance(self._lam, np.ndarray):
+                    self._interpolate_wavelength()
+                else:
+                    self.lam = self.original_lam
+                    self.t = self.original_t
+                return
+            except Exception:
+                pass  # Corrupt cache; fall through to HTTP request
+
+        # Check the CI HDF5 cache (a single file with all filters).
+        ci_cache_file = cache_dir / "ci_svo_filter_cache.hdf5"
+        if ci_cache_file.exists():
+            try:
+                with h5py.File(ci_cache_file, "r") as f:
+                    grp_key = cache_key
+                    if grp_key in f:
+                        self.original_lam = f[grp_key]["wavelength"][:]
+                        self.original_t = f[grp_key]["transmission"][:]
+                        attr_key = f"{grp_key}_svo_url"
+                        if attr_key in f.attrs:
+                            self.svo_url = f.attrs[attr_key]
+                if self.original_lam is not None:
+                    if isinstance(self._lam, np.ndarray):
+                        self._interpolate_wavelength()
+                    else:
+                        self.lam = self.original_lam
+                        self.t = self.original_t
+                    return
+            except Exception:
+                pass  # Corrupt CI cache; fall through to HTTP request
+
         # Make a request for the data and handle a failure more informatively
         try:
             with urllib.request.urlopen(self.svo_url) as f:
@@ -2050,6 +2092,16 @@ class Filter:
         self.original_t = np.array(
             [float(child.findall("TD")[1].text) for child in data]
         )
+
+        # Cache the response for future use.
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            with h5py.File(cache_file, "w") as f:
+                f.create_dataset("wavelength", data=self.original_lam)
+                f.create_dataset("transmission", data=self.original_t)
+                f.attrs["svo_url"] = self.svo_url
+        except Exception:
+            pass  # Cache write failure is non-fatal
 
         # If a new wavelength grid is provided, interpolate
         # the transmission curve on to that grid

--- a/src/synthesizer/instruments/filters.py
+++ b/src/synthesizer/instruments/filters.py
@@ -2027,13 +2027,12 @@ class Filter:
                         attr_key = f"{grp_key}_svo_url"
                         if attr_key in f.attrs:
                             self.svo_url = f.attrs[attr_key]
-                if self.original_lam is not None:
-                    if isinstance(self._lam, np.ndarray):
-                        self._interpolate_wavelength()
-                    else:
-                        self.lam = self.original_lam
-                        self.t = self.original_t
-                    return
+                        if isinstance(self._lam, np.ndarray):
+                            self._interpolate_wavelength()
+                        else:
+                            self.lam = self.original_lam
+                            self.t = self.original_t
+                        return
             except Exception:
                 pass  # Corrupt CI cache; fall through to HTTP request
 

--- a/tests/test_initialisation.py
+++ b/tests/test_initialisation.py
@@ -261,6 +261,7 @@ class TestInitializerMethods:
             ("data_dir", "data_dir"),
             ("grids_dir", "grids"),
             ("instrument_cache_dir", "instrument_cache"),
+            ("svo_filter_cache_dir", "svo_filter_cache"),
             ("test_data_dir", "test_data"),
         ]:
             path = getattr(init, attr)
@@ -285,6 +286,7 @@ class TestInitializerMethods:
             "grids_dir",
             "test_data_dir",
             "instrument_cache_dir",
+            "svo_filter_cache_dir",
         ):
             p = getattr(init, attr)
             p.mkdir(parents=True, exist_ok=True)

--- a/tests/test_initialisation.py
+++ b/tests/test_initialisation.py
@@ -35,6 +35,7 @@ def clear_env(monkeypatch):
         "SYNTHESIZER_GRID_DIR",
         "SYNTHESIZER_TEST_DATA_DIR",
         "SYNTHESIZER_INSTRUMENT_CACHE",
+        "SYNTHESIZER_SVO_FILTER_CACHE",
     ]:
         monkeypatch.delenv(var, raising=False)
     yield
@@ -44,6 +45,7 @@ def clear_env(monkeypatch):
         "SYNTHESIZER_GRID_DIR",
         "SYNTHESIZER_TEST_DATA_DIR",
         "SYNTHESIZER_INSTRUMENT_CACHE",
+        "SYNTHESIZER_SVO_FILTER_CACHE",
     ]:
         monkeypatch.delenv(var, raising=False)
 


### PR DESCRIPTION
This PR finally adds the machinery needed to cache the SVO requests made by our filter machinery. 

This includes a new directory alongside the rest of the Synthesizer data and also a download to grab all the filters needed for the tests from Box. 

Filters are saved as HDF5 files so they can be read in parallel if needs be (i.e. when running distributed on a HPC) and have been turned into a tarball for upload to box. The cache download then unpacks the tarball ready for use by the CI. 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--svo-filter-cache` option to downloader for downloading and caching SVO filter data locally
  * Filter loading now checks local cache first, reducing repeated network requests

* **Improvements**
  * Faster filter initialization when cached data is available

* **CI/Infrastructure**
  * Updated GitHub Actions workflows to pre-download SVO filter cache during build process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->