### PR TITLE
Introducing Clang Formatter for C++ formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+ColumnLimit: 79
+KeepEmptyLinesAtTheStartOfBlocks: true
+PenaltyBreakAssignment: 2
+DerivePointerAlignment: false
+PointerAlignment: Right
+...

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,6 +46,11 @@ jobs:
         with:
           version: 0.11.7
           args: "format --check --diff"
+      - name: Check C++ formatting with clang-format
+        run: |
+          pip install "clang-format==22.1.4"
+          ./format_extensions.sh --check
+        shell: bash
       - name: Download test data
         run: |
           # Download the data we need

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,13 @@ repos:
       # Run the formatter.
       - id: ruff-format
 
+  # Formatting for C++ files.
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.4
+    hooks:
+      - id: clang-format
+        types_or: [c, c++]
+
   # Sanitise Jupyter notebooks.
   - repo: https://github.com/srstevenson/nb-clean
     rev: 4.0.1

--- a/format_extensions.sh
+++ b/format_extensions.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+#
+# Format all C/C++ extension source files with clang-format.
+#
+# Usage:
+#   ./format_extensions.sh           # format in-place
+#   ./format_extensions.sh --check   # dry-run, exit 1 if any file would change
+
+set -euo pipefail
+
+REQUIRED_VERSION="22.1.4"
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CLANG_FORMAT="${CLANG_FORMAT:-clang-format}"
+
+if ! command -v "$CLANG_FORMAT" &>/dev/null; then
+  echo "Error: $CLANG_FORMAT not found."
+  echo "Install clang-format $REQUIRED_VERSION with:"
+  echo "  brew install clang-format"
+  echo "  pip install clang-format==$REQUIRED_VERSION"
+  exit 1
+fi
+
+VERSION=$("$CLANG_FORMAT" --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+echo "Using $("$CLANG_FORMAT" --version)"
+
+if [[ "$VERSION" != "$REQUIRED_VERSION" ]]; then
+  echo "Warning: expected clang-format $REQUIRED_VERSION, got $VERSION."
+  echo "Install the correct version with:"
+  echo "  brew install clang-format"
+  echo "  pip install clang-format==$REQUIRED_VERSION"
+  echo "Or set CLANG_FORMAT to point to a specific binary."
+fi
+
+MODE="${1:--i}"
+
+case "$MODE" in
+-i)
+  echo "Formatting all C/C++ files in-place..."
+  ;;
+--check)
+  echo "Checking formatting of all C/C++ files..."
+  ;;
+*)
+  echo "Usage: $0 [-i | --check]"
+  echo "  -i        Format files in-place (default)"
+  echo "  --check   Dry-run; exit 1 if any file would be changed"
+  exit 1
+  ;;
+esac
+
+collect_files() {
+  find "$HERE/src" \( -name '*.cpp' -o -name '*.h' \) -print0
+}
+
+case "$MODE" in
+-i)
+  collect_files | xargs -0 "$CLANG_FORMAT" -i
+  echo "Done."
+  ;;
+--check)
+  errors=0
+  while IFS= read -r -d '' file; do
+    if ! "$CLANG_FORMAT" -n --Werror "$file" 2>/dev/null; then
+      echo "Would reformat: $file"
+      ((errors++))
+    fi
+  done < <(collect_files)
+  if ((errors > 0)); then
+    echo "$errors file(s) would be reformatted."
+    exit 1
+  fi
+  echo "All files are correctly formatted."
+  ;;
+esac

--- a/src/synthesizer/extensions/atomic_timing_check.cpp
+++ b/src/synthesizer/extensions/atomic_timing_check.cpp
@@ -1,5 +1,6 @@
 /******************************************************************************
- * A C module containing a simple function to check if ATOMIC_TIMING is enabled.
+ * A C module containing a simple function to check if ATOMIC_TIMING is
+ * enabled.
  *****************************************************************************/
 #include <Python.h>
 

--- a/src/synthesizer/extensions/column_density.cpp
+++ b/src/synthesizer/extensions/column_density.cpp
@@ -12,8 +12,9 @@
 /* Python headers. */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes. */
 #include "cpp_to_python.h"
@@ -56,10 +57,9 @@
 static void los_loop_serial(const double *pos_i, const double *pos_j,
                             const double *smls, const double *surf_den_vals,
                             const double *kernel,
-                            const double *truncated_kernel,
-                            double *surf_dens, const int npart_i,
-                            const int npart_j, const int kdim,
-                            const int trunc_qdim,
+                            const double *truncated_kernel, double *surf_dens,
+                            const int npart_i, const int npart_j,
+                            const int kdim, const int trunc_qdim,
                             const int zdim, const double threshold) {
 
   /* Loop over particle postions. */
@@ -94,8 +94,7 @@ static void los_loop_serial(const double *pos_i, const double *pos_j,
 
       /* Early skip if the star's line of sight doesn't fall in the gas
        * particles kernel. */
-      if (b > (threshold * sml))
-        continue;
+      if (b > (threshold * sml)) continue;
 
       /* Find fraction of smoothing length. */
       double q = b / sml;
@@ -105,8 +104,8 @@ static void los_loop_serial(const double *pos_i, const double *pos_j,
       double kvalue = 0.0;
       if (z < (zj + threshold * sml)) {
         const double z_trunc = (z - zj) / (threshold * sml);
-        kvalue = get_truncated_kernel_value(
-            truncated_kernel, trunc_qdim, zdim, q / threshold, z_trunc);
+        kvalue = get_truncated_kernel_value(truncated_kernel, trunc_qdim, zdim,
+                                            q / threshold, z_trunc);
       } else {
         kvalue = get_kernel_value(kernel, kdim, q / threshold);
       }
@@ -149,11 +148,10 @@ static void los_loop_serial(const double *pos_i, const double *pos_j,
 #ifdef WITH_OPENMP
 static void los_loop_omp(const double *pos_i, const double *pos_j,
                          const double *smls, const double *surf_den_vals,
-                         const double *kernel,
-                         const double *truncated_kernel, double *surf_dens,
-                         const int npart_i, const int npart_j,
-                         const int kdim, const int trunc_qdim,
-                         const int zdim,
+                         const double *kernel, const double *truncated_kernel,
+                         double *surf_dens, const int npart_i,
+                         const int npart_j, const int kdim,
+                         const int trunc_qdim, const int zdim,
                          const double threshold, const int nthreads) {
 
   /* How many particles should each thread get? */
@@ -207,8 +205,7 @@ static void los_loop_omp(const double *pos_i, const double *pos_j,
 
         /* Early skip if the star's line of sight doesn't fall in the gas
          * particles kernel. */
-        if (b > (threshold * sml))
-          continue;
+        if (b > (threshold * sml)) continue;
 
         /* Find fraction of smoothing length. */
         double q = b / sml;
@@ -218,8 +215,8 @@ static void los_loop_omp(const double *pos_i, const double *pos_j,
         double kvalue = 0.0;
         if (z < (zj + threshold * sml)) {
           const double z_trunc = (z - zj) / (threshold * sml);
-          kvalue = get_truncated_kernel_value(
-              truncated_kernel, trunc_qdim, zdim, q / threshold, z_trunc);
+          kvalue = get_truncated_kernel_value(truncated_kernel, trunc_qdim,
+                                              zdim, q / threshold, z_trunc);
         } else {
           kvalue = get_kernel_value(kernel, kdim, q / threshold);
         }
@@ -248,7 +245,8 @@ static void los_loop_omp(const double *pos_i, const double *pos_j,
  *
  * This is a wrapper function which will call the correct version of the
  * function to compute the line of sight surface densities for each particle
- * based on whether or not OpenMP is available and the number of threads to use.
+ * based on whether or not OpenMP is available and the number of threads to
+ * use.
  *
  * @param pos_i The positions of the star particles.
  * @param pos_j The positions of the gas particles.
@@ -271,9 +269,8 @@ static void los_loop(const double *pos_i, const double *pos_j,
                      const double *smls, const double *surf_den_vals,
                      const double *kernel, const double *truncated_kernel,
                      double *surf_dens, const int npart_i, const int npart_j,
-                     const int kdim, const int trunc_qdim,
-                     const int zdim, const double threshold,
-                     const int nthreads) {
+                     const int kdim, const int trunc_qdim, const int zdim,
+                     const double threshold, const int nthreads) {
 
   tic("los_loop");
 
@@ -282,8 +279,8 @@ static void los_loop(const double *pos_i, const double *pos_j,
   /* If we have multiple threads and OpenMP we can parallelise. */
   if (nthreads > 1) {
     los_loop_omp(pos_i, pos_j, smls, surf_den_vals, kernel, truncated_kernel,
-                 surf_dens, npart_i, npart_j, kdim, trunc_qdim, zdim, threshold,
-                 nthreads);
+                 surf_dens, npart_i, npart_j, kdim, trunc_qdim, zdim,
+                 threshold, nthreads);
   } else {
     los_loop_serial(pos_i, pos_j, smls, surf_den_vals, kernel,
                     truncated_kernel, surf_dens, npart_i, npart_j, kdim,
@@ -295,9 +292,9 @@ static void los_loop(const double *pos_i, const double *pos_j,
   (void)nthreads;
 
   /* If we don't have OpenMP call the serial version. */
-  los_loop_serial(pos_i, pos_j, smls, surf_den_vals, kernel,
-                  truncated_kernel, surf_dens, npart_i, npart_j, kdim,
-                  trunc_qdim, zdim, threshold);
+  los_loop_serial(pos_i, pos_j, smls, surf_den_vals, kernel, truncated_kernel,
+                  surf_dens, npart_i, npart_j, kdim, trunc_qdim, zdim,
+                  threshold);
 
 #endif
   toc("los_loop");
@@ -338,7 +335,8 @@ static double calculate_los_recursive(struct cell *c, const double x,
 
   /* Early exit if the projected distance between cells is more than the
    * maximum smoothing length in the cell. */
-  if (c->max_sml_squ * (threshold * threshold) < min_projected_dist2(c, x, y)) {
+  if (c->max_sml_squ * (threshold * threshold) <
+      min_projected_dist2(c, x, y)) {
     return 0;
   }
 
@@ -358,9 +356,9 @@ static double calculate_los_recursive(struct cell *c, const double x,
       }
 
       /* Recurse... */
-      surf_dens += calculate_los_recursive(
-          cp, x, y, z, threshold, kdim, trunc_qdim, zdim, kernel,
-          truncated_kernel);
+      surf_dens +=
+          calculate_los_recursive(cp, x, y, z, threshold, kdim, trunc_qdim,
+                                  zdim, kernel, truncated_kernel);
     }
 
   } else {
@@ -402,8 +400,8 @@ static double calculate_los_recursive(struct cell *c, const double x,
       double kvalue = 0.0;
       if (z < (part->pos[2] + threshold * part->sml)) {
         const double z_trunc = (z - part->pos[2]) / (threshold * part->sml);
-        kvalue = get_truncated_kernel_value(
-            truncated_kernel, trunc_qdim, zdim, q / threshold, z_trunc);
+        kvalue = get_truncated_kernel_value(truncated_kernel, trunc_qdim, zdim,
+                                            q / threshold, z_trunc);
       } else {
         kvalue = get_kernel_value(kernel, kdim, q / threshold);
       }
@@ -449,8 +447,8 @@ static void los_tree_serial(struct cell *root, const double *pos_i,
   /* Loop over the particles we are calculating the surface density for. */
   for (int i = 0; i < npart_i; i++) {
 
-      /* Start at the root. We'll recurse through the tree to the leaves
-       * skipping all cells out of range of this particle. */
+    /* Start at the root. We'll recurse through the tree to the leaves
+     * skipping all cells out of range of this particle. */
     surf_dens[i] = calculate_los_recursive(
         root, pos_i[i * 3], pos_i[i * 3 + 1], pos_i[i * 3 + 2], threshold,
         kdim, trunc_qdim, zdim, kernel, truncated_kernel);
@@ -483,9 +481,8 @@ static void los_tree_serial(struct cell *root, const double *pos_i,
  */
 #ifdef WITH_OPENMP
 static void los_tree_omp(struct cell *root, const double *pos_i,
-                         const double *kernel,
-                         const double *truncated_kernel, double *surf_dens,
-                         const int npart_i, const int kdim,
+                         const double *kernel, const double *truncated_kernel,
+                         double *surf_dens, const int npart_i, const int kdim,
                          const int trunc_qdim, const int zdim,
                          const double threshold, const int nthreads) {
 
@@ -534,7 +531,8 @@ static void los_tree_omp(struct cell *root, const double *pos_i,
  *
  * This is a wrapper function which will call the correct version of the
  * function to compute the line of sight surface densities for each particle
- * based on whether or not OpenMP is available and the number of threads to use.
+ * based on whether or not OpenMP is available and the number of threads to
+ * use.
  *
  * @param root The root of the tree.
  * @param pos_i The positions of the star particles.
@@ -556,8 +554,7 @@ static void los_tree(struct cell *root, const double *pos_i,
                      const double *kernel, const double *truncated_kernel,
                      double *surf_dens, const int npart_i, const int kdim,
                      const int trunc_qdim, const int zdim,
-                     const double threshold,
-                     const int nthreads) {
+                     const double threshold, const int nthreads) {
 
   tic("los_tree");
 
@@ -613,11 +610,10 @@ PyObject *compute_column_density(PyObject *self, PyObject *args) {
   PyArrayObject *np_kernel, *np_truncated_kernel, *np_pos_i, *np_pos_j,
       *np_smls, *np_surf_den_val;
 
-  if (!PyArg_ParseTuple(args, "OOOOOOiiiiidiii", &np_kernel,
-                         &np_truncated_kernel, &np_pos_i, &np_pos_j, &np_smls,
-                         &np_surf_den_val, &npart_i, &npart_j, &kdim,
-                         &trunc_qdim, &zdim, &threshold, &force_loop,
-                         &min_count, &nthreads))
+  if (!PyArg_ParseTuple(
+          args, "OOOOOOiiiiidiii", &np_kernel, &np_truncated_kernel, &np_pos_i,
+          &np_pos_j, &np_smls, &np_surf_den_val, &npart_i, &npart_j, &kdim,
+          &trunc_qdim, &zdim, &threshold, &force_loop, &min_count, &nthreads))
     return NULL;
 
   tic("compute_column_density");
@@ -722,8 +718,8 @@ PyObject *compute_column_density(PyObject *self, PyObject *args) {
  * Each input/source particle pair is mapped onto the precomputed overlap table
  * `G(q, u, eta)` and contributes exactly once.
  *
- * The runtime pair coordinates are defined using the support radii of the input
- * and source particles:
+ * The runtime pair coordinates are defined using the support radii of the
+ * input and source particles:
  *
  *   q   = b / (R_i + R_j)
  *   u   = (z_i - z_j) / (R_i + R_j)
@@ -898,8 +894,9 @@ static double calculate_los_recursive_smoothed(
 /**
  * @brief Compute smoothed-input LOS surface densities with a loop.
  *
- * For each input particle we loop over source particles, reject non-overlapping
- * pairs, interpolate the overlap table once, and apply the source prefactor.
+ * For each input particle we loop over source particles, reject
+ * non-overlapping pairs, interpolate the overlap table once, and apply the
+ * source prefactor.
  *
  * @param pos_i The positions of the input particles.
  * @param input_smls The smoothing lengths of the input particles.
@@ -988,10 +985,10 @@ static void los_loop_smoothed_omp(
 
     double *surf_dens_thread = new double[end - start]();
 
-    los_loop_smoothed_serial(&pos_i[start * 3], &input_smls[start], pos_j, smls,
-                             surf_den_vals, overlap_kernel, q_grid, u_grid,
-                             eta_grid, surf_dens_thread, end - start, npart_j,
-                             qdim, udim, etadim, threshold);
+    los_loop_smoothed_serial(&pos_i[start * 3], &input_smls[start], pos_j,
+                             smls, surf_den_vals, overlap_kernel, q_grid,
+                             u_grid, eta_grid, surf_dens_thread, end - start,
+                             npart_j, qdim, udim, etadim, threshold);
 
 #pragma omp critical
     {
@@ -1171,9 +1168,9 @@ static void los_tree_smoothed(struct cell *root, const double *pos_i,
                               const double *overlap_kernel,
                               const double *q_grid, const double *u_grid,
                               const double *eta_grid, double *surf_dens,
-                              const int npart_i, const int qdim, const int udim,
-                              const int etadim, const double threshold,
-                              const int nthreads) {
+                              const int npart_i, const int qdim,
+                              const int udim, const int etadim,
+                              const double threshold, const int nthreads) {
 
   tic("Recursive surface density calculation with smoothed inputs");
 
@@ -1289,7 +1286,8 @@ PyObject *compute_column_density_smoothed(PyObject *self, PyObject *args) {
   double *surf_dens = static_cast<double *>(PyArray_DATA(np_surf_dens));
 
   /* No point constructing a source tree if there are too few source particles
-   * to justify it, or if we have explicitly been asked to use the loop path. */
+   * to justify it, or if we have explicitly been asked to use the loop path.
+   */
   if (force_loop || npart_j < min_count) {
 
     /* Use the simple pairwise loop over input and source particles. */
@@ -1320,8 +1318,8 @@ PyObject *compute_column_density_smoothed(PyObject *self, PyObject *args) {
   /* Calculate the smoothed LOS surface densities using the tree. */
   tic("Dispatching smoothed LOS tree path");
   los_tree_smoothed(root, pos_i, input_smls, overlap_kernel, q_grid, u_grid,
-                    eta_grid, surf_dens, npart_i, qdim, udim, etadim, threshold,
-                    nthreads);
+                    eta_grid, surf_dens, npart_i, qdim, udim, etadim,
+                    threshold, nthreads);
   toc("Dispatching smoothed LOS tree path");
 
   /* Clean up the source-particle cell tree. */
@@ -1359,8 +1357,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_column_density(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/cpp_to_python.cpp
+++ b/src/synthesizer/extensions/cpp_to_python.cpp
@@ -2,26 +2,31 @@
 
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
+#include "cpp_to_python.h"
 #include "numpy_init.h"
 
-#include "cpp_to_python.h"
-
 // Map C++ type T to NumPy typenum at compile time
-template <typename T> struct NumpyTypenum;
+template <typename T>
+struct NumpyTypenum;
 
-template <> struct NumpyTypenum<float> {
+template <>
+struct NumpyTypenum<float> {
   static constexpr int typenum = NPY_FLOAT32;
 };
-template <> struct NumpyTypenum<double> {
+template <>
+struct NumpyTypenum<double> {
   static constexpr int typenum = NPY_FLOAT64;
 };
-template <> struct NumpyTypenum<int32_t> {
+template <>
+struct NumpyTypenum<int32_t> {
   static constexpr int typenum = NPY_INT32;
 };
-template <> struct NumpyTypenum<int64_t> {
+template <>
+struct NumpyTypenum<int64_t> {
   static constexpr int typenum = NPY_INT64;
 };
-template <> struct NumpyTypenum<uint8_t> {
+template <>
+struct NumpyTypenum<uint8_t> {
   static constexpr int typenum = NPY_UINT8;
 };
 
@@ -80,7 +85,7 @@ PyArrayObject *wrap_array_to_numpy(int ndim, npy_intp *dims, T *buffer) {
 template <typename T>
 PyArrayObject *wrap_array_to_numpy(int ndim, npy_intp *dims,
                                    std::unique_ptr<T[]> &&ptr) {
-  T *raw = ptr.release(); // transfer ownership
+  T *raw = ptr.release();  // transfer ownership
   return wrap_array_to_numpy<T>(ndim, dims, raw);
 }
 
@@ -91,14 +96,14 @@ template PyArrayObject *wrap_array_to_numpy<int32_t>(int, npy_intp *,
                                                      int32_t *);
 template PyArrayObject *wrap_array_to_numpy<int64_t>(int, npy_intp *,
                                                      int64_t *);
-template PyArrayObject *
-wrap_array_to_numpy<double>(int, npy_intp *, std::unique_ptr<double[]> &&);
-template PyArrayObject *wrap_array_to_numpy<float>(int, npy_intp *,
-                                                   std::unique_ptr<float[]> &&);
-template PyArrayObject *
-wrap_array_to_numpy<int32_t>(int, npy_intp *, std::unique_ptr<int32_t[]> &&);
-template PyArrayObject *
-wrap_array_to_numpy<int64_t>(int, npy_intp *, std::unique_ptr<int64_t[]> &&);
+template PyArrayObject *wrap_array_to_numpy<double>(
+    int, npy_intp *, std::unique_ptr<double[]> &&);
+template PyArrayObject *wrap_array_to_numpy<float>(
+    int, npy_intp *, std::unique_ptr<float[]> &&);
+template PyArrayObject *wrap_array_to_numpy<int32_t>(
+    int, npy_intp *, std::unique_ptr<int32_t[]> &&);
+template PyArrayObject *wrap_array_to_numpy<int64_t>(
+    int, npy_intp *, std::unique_ptr<int64_t[]> &&);
 
 /**
  * @brief Check that the given PyObject* is either None or a NumPy array.

--- a/src/synthesizer/extensions/cpp_to_python.h
+++ b/src/synthesizer/extensions/cpp_to_python.h
@@ -3,13 +3,16 @@
 
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
 #include <cstdint>
 #include <memory>
 
+#include "numpy_init.h"
+
 // Typenum mapping template (declare only)
-template <typename T> struct NumpyTypenum;
+template <typename T>
+struct NumpyTypenum;
 
 // Main wrapper functions (declarations only)
 
@@ -29,10 +32,9 @@ PyArrayObject *wrap_array_to_numpy(int ndim, npy_intp *dims,
 
 PyArrayObject *array_or_none(PyObject *obj, const char *name = "argument");
 
-#define RETURN_IF_PYERR()                                                      \
-  do {                                                                         \
-    if (PyErr_Occurred())                                                      \
-      return nullptr;                                                          \
+#define RETURN_IF_PYERR()                 \
+  do {                                    \
+    if (PyErr_Occurred()) return nullptr; \
   } while (0)
 
-#endif // CPP_TO_PYTHON_H
+#endif  // CPP_TO_PYTHON_H

--- a/src/synthesizer/extensions/doppler_particle_spectra.cpp
+++ b/src/synthesizer/extensions/doppler_particle_spectra.cpp
@@ -3,19 +3,21 @@
  * Calculates weights on an arbitrary dimensional grid given the mass.
  *****************************************************************************/
 /* C includes */
-#include <array>
 #include <math.h>
-#include <new>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <array>
+#include <new>
 #include <vector>
 
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes */
 #include "cpp_to_python.h"
@@ -34,8 +36,8 @@
  * @brief Find nearest wavelength bin for a given lambda, in a given wavelength
  * array. Used by the spectra loop functions when considering doppler shift
  *
- * Note: binary search returns the index of the upper bin of those that straddle
- * the given lambda.
+ * Note: binary search returns the index of the upper bin of those that
+ * straddle the given lambda.
  */
 int get_upper_lam_bin(double lambda, double *grid_wavelengths, int nlam) {
   return binary_search(0, nlam - 1, grid_wavelengths, lambda);
@@ -132,8 +134,7 @@ static void shifted_spectra_loop_cic_serial(GridProps *grid_props,
         frac *= sc.offs[d] ? parts->grid_fracs[p * ndim + d]
                            : (1.0 - parts->grid_fracs[p * ndim + d]);
       }
-      if (frac == 0.0)
-        continue;
+      if (frac == 0.0) continue;
 
       /* Flattened grid index */
       const int grid_i = base_lin + sc.linoff;
@@ -149,8 +150,8 @@ static void shifted_spectra_loop_cic_serial(GridProps *grid_props,
       /* Accumulate the contribution from all valid cells */
       double total = 0.0;
       for (int icell = 0; icell < nvalid_cells; icell++) {
-        total = std::fma(cell_spectra_ptrs[icell][il],
-                         cell_weights[icell], total);
+        total =
+            std::fma(cell_spectra_ptrs[icell][il], cell_weights[icell], total);
       }
 
       const int ils = mapped_indices[il];
@@ -173,7 +174,8 @@ static void shifted_spectra_loop_cic_serial(GridProps *grid_props,
 
 /**
  * @brief This calculates particle spectra using a cloud in cell approach.
- * This is the parallel version of the function that accounts for Doppler shift.
+ * This is the parallel version of the function that accounts for Doppler
+ * shift.
  *
  * Each thread allocates its shift‐mapping buffers once and reuses them for
  * every particle, and all sub‐cell index math is hoisted out of the particle
@@ -193,8 +195,9 @@ static void shifted_spectra_loop_cic_serial(GridProps *grid_props,
  */
 #ifdef WITH_OPENMP
 static void shifted_spectra_loop_cic_omp(GridProps *grid_props,
-                                         Particles *parts, double *part_spectra,
-                                         int nthreads, const double c) {
+                                         Particles *parts,
+                                         double *part_spectra, int nthreads,
+                                         const double c) {
 
   /* Unpack the grid properties. */
   const int ndim = grid_props->ndim;
@@ -287,8 +290,7 @@ static void shifted_spectra_loop_cic_omp(GridProps *grid_props,
           frac *= sc.offs[d] ? parts->grid_fracs[p * ndim + d]
                              : (1.0 - parts->grid_fracs[p * ndim + d]);
         }
-        if (frac == 0.0)
-          continue;
+        if (frac == 0.0) continue;
 
         /* Flattened grid index */
         const int grid_i = base_lin + sc.linoff;
@@ -303,8 +305,8 @@ static void shifted_spectra_loop_cic_omp(GridProps *grid_props,
         /* Accumulate contributions from all valid cells */
         double total = 0.0;
         for (int icell = 0; icell < nvalid_cells; icell++) {
-          total = std::fma(cell_spectra_ptrs[icell][il],
-                           cell_weights[icell], total);
+          total = std::fma(cell_spectra_ptrs[icell][il], cell_weights[icell],
+                           total);
         }
 
         const int ils = mapped_indices[il];
@@ -327,7 +329,8 @@ static void shifted_spectra_loop_cic_omp(GridProps *grid_props,
 
       /* Copy the entire spectrum at once into the output array. */
       for (size_t il = 0; il < nlam; ++il) {
-        local_part_spectra[(p - start_idx) * nlam + il] = this_part_spectra[il];
+        local_part_spectra[(p - start_idx) * nlam + il] =
+            this_part_spectra[il];
       }
 
       /* Reset the local spectra for this particle. */
@@ -485,8 +488,9 @@ static void shifted_spectra_loop_ngp_serial(GridProps *grid_props,
  */
 #ifdef WITH_OPENMP
 static void shifted_spectra_loop_ngp_omp(GridProps *grid_props,
-                                         Particles *parts, double *part_spectra,
-                                         int nthreads, const double c) {
+                                         Particles *parts,
+                                         double *part_spectra, int nthreads,
+                                         const double c) {
 
   /* Unpack the grid properties. */
   size_t nlam = static_cast<size_t>(grid_props->nlam);
@@ -565,7 +569,8 @@ static void shifted_spectra_loop_ngp_omp(GridProps *grid_props,
         /* Compute the fraction of the shifted wavelength between the two
          * closest wavelength elements. */
         double frac_shifted = 0.0;
-        if (ilam_shifted > 0 && static_cast<size_t>(ilam_shifted) <= nlam - 1) {
+        if (ilam_shifted > 0 &&
+            static_cast<size_t>(ilam_shifted) <= nlam - 1) {
           frac_shifted =
               (shifted_lambda - wavelength[ilam_shifted - 1]) /
               (wavelength[ilam_shifted] - wavelength[ilam_shifted - 1]);
@@ -677,8 +682,8 @@ PyObject *compute_part_seds_with_vel_shift(PyObject *self, PyObject *args) {
   PyArrayObject *np_mask, *np_lam_mask;
   char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOOOOiiisiOOO|O", &np_grid_spectra,
-                        &np_lam, &grid_tuple, &part_tuple, &np_part_mass,
+  if (!PyArg_ParseTuple(args, "OOOOOOOiiisiOOO|O", &np_grid_spectra, &np_lam,
+                        &grid_tuple, &part_tuple, &np_part_mass,
                         &np_velocities, &np_ndims, &ndim, &npart, &nlam,
                         &method, &nthreads, &py_c, &np_mask, &np_lam_mask,
                         &prop_names)) {
@@ -692,24 +697,21 @@ PyObject *compute_part_seds_with_vel_shift(PyObject *self, PyObject *args) {
   RETURN_IF_PYERR();
 
   /* Create the object that holds the particle properties. */
-  Particles *part_props =
-      new Particles(np_part_mass, np_velocities, np_mask, part_tuple,
-                    prop_names, npart);
+  Particles *part_props = new Particles(np_part_mass, np_velocities, np_mask,
+                                        part_tuple, prop_names, npart);
   RETURN_IF_PYERR();
 
   /* Allocate the spectra. */
   double *spectra = new (std::nothrow) double[grid_props->nlam]();
-  double *part_spectra =
-      new (std::nothrow) double[npart * grid_props->nlam]();
+  double *part_spectra = new (std::nothrow) double[npart * grid_props->nlam]();
 
   if (spectra == NULL || part_spectra == NULL) {
-    PyErr_SetString(PyExc_MemoryError, "Failed to allocate memory for spectra.");
+    PyErr_SetString(PyExc_MemoryError,
+                    "Failed to allocate memory for spectra.");
     delete part_props;
     delete grid_props;
-    if (spectra)
-      delete[] spectra;
-    if (part_spectra)
-      delete[] part_spectra;
+    if (spectra) delete[] spectra;
+    if (part_spectra) delete[] part_spectra;
     return NULL;
   }
 
@@ -721,13 +723,16 @@ PyObject *compute_part_seds_with_vel_shift(PyObject *self, PyObject *args) {
   /* With everything set up we can compute the spectra for each particle
    * using the requested method. */
   if (strcmp(method, "cic") == 0) {
-    shifted_spectra_loop_cic(grid_props, part_props, part_spectra, nthreads, c);
+    shifted_spectra_loop_cic(grid_props, part_props, part_spectra, nthreads,
+                             c);
   } else if (strcmp(method, "ngp") == 0) {
-    shifted_spectra_loop_ngp(grid_props, part_props, part_spectra, nthreads, c);
+    shifted_spectra_loop_ngp(grid_props, part_props, part_spectra, nthreads,
+                             c);
   } else {
     PyErr_Format(PyExc_ValueError, "Unknown grid assignment method (%s).",
                  method);
-    /* Clean up all allocated memory before returning NULL to propagate the ValueError. */
+    /* Clean up all allocated memory before returning NULL to propagate the
+     * ValueError. */
     delete part_props;
     delete grid_props;
     delete[] spectra;
@@ -785,8 +790,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_doppler_particle_spectra(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/grid_props.cpp
+++ b/src/synthesizer/extensions/grid_props.cpp
@@ -1,15 +1,17 @@
 
 /* Standard includes */
+#include <stdlib.h>
+
 #include <array>
 #include <iostream>
 #include <ostream>
-#include <stdlib.h>
 
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes */
 #include "cpp_to_python.h"
@@ -26,7 +28,8 @@
  * and grid weights.
  *
  * @param np_spectra: The numpy array containing the spectra data.
- * @param axes_tuple: A tuple containing numpy arrays for each axis of the grid.
+ * @param axes_tuple: A tuple containing numpy arrays for each axis of the
+ * grid.
  * @param np_lam: The numpy array containing the wavelength data.
  * @param np_lam_mask: The numpy array containing the wavelength mask.
  * @param nlam: The number of wavelength elements.
@@ -39,8 +42,11 @@ GridProps::GridProps(PyArrayObject *np_spectra, PyObject *axes_tuple,
                      PyArrayObject *np_lam, PyArrayObject *np_lam_mask,
                      const int nlam, PyArrayObject *np_grid_weights,
                      PyObject *axis_names_tuple)
-    : nlam(nlam), np_spectra_(np_spectra), axes_tuple_(axes_tuple),
-      np_lam_(np_lam), np_lam_mask_(np_lam_mask),
+    : nlam(nlam),
+      np_spectra_(np_spectra),
+      axes_tuple_(axes_tuple),
+      np_lam_(np_lam),
+      np_lam_mask_(np_lam_mask),
       np_grid_weights_(np_grid_weights) {
 
   tic("GridProps.__init__");
@@ -166,7 +172,7 @@ int GridProps::ravel_spectra_index(
   for (int i = 0; i < ndim; i++) {
     full_index[i] = multi_index[i];
   }
-  full_index[ndim] = ilam; // Set the wavelength index
+  full_index[ndim] = ilam;  // Set the wavelength index
 
   return get_flat_index(full_index, spectra_dims_.data(), ndim + 1);
 }
@@ -177,11 +183,11 @@ int GridProps::ravel_spectra_index(
  *
  * @param index: The flat index to convert.
  *
- * @return An array of N-dimensional indices corresponding to the flat index and
- * the wavelength index.
+ * @return An array of N-dimensional indices corresponding to the flat index
+ * and the wavelength index.
  */
-std::array<int, MAX_GRID_NDIM + 1>
-GridProps::unravel_spectra_index(int index) const {
+std::array<int, MAX_GRID_NDIM + 1> GridProps::unravel_spectra_index(
+    int index) const {
   std::array<int, MAX_GRID_NDIM + 1> indices = {0};
   get_indices_from_flat(index, ndim + 1, spectra_dims_, indices);
   return indices;
@@ -348,7 +354,7 @@ double *GridProps::get_grid_weights() {
   /* If we already have grid weights, return them. */
   if (has_grid_weights()) {
     grid_weights_ = static_cast<double *>(PyArray_DATA(np_grid_weights_));
-    need_grid_weights_ = false; // We don't need to populate them.
+    need_grid_weights_ = false;  // We don't need to populate them.
     return grid_weights_;
   }
 
@@ -437,8 +443,9 @@ bool GridProps::lam_is_masked(int ind) const {
 bool GridProps::need_grid_weights() const {
   /* Check we have a grid to populate weights for. */
   if (!has_grid_weights()) {
-    PyErr_SetString(PyExc_ValueError, "[GridProps::need_grid_weights]: "
-                                      "Grid weights have not been allocated.");
+    PyErr_SetString(PyExc_ValueError,
+                    "[GridProps::need_grid_weights]: "
+                    "Grid weights have not been allocated.");
     return false;
   }
 

--- a/src/synthesizer/extensions/grid_props.h
+++ b/src/synthesizer/extensions/grid_props.h
@@ -2,15 +2,17 @@
 #define GRID_PROPS_H_
 
 /* Standard includes */
-#include <array>
 #include <stdlib.h>
+
+#include <array>
 #include <string>
 
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes */
 #include "property_funcs.h"
@@ -24,7 +26,7 @@ constexpr int MAX_GRID_NDIM = 10;
 
 class GridProps {
 
-public:
+ public:
   /* The number of dimensions. */
   int ndim;
 
@@ -44,7 +46,8 @@ public:
             PyObject *axis_names_tuple = NULL);
 
   /* Index handlers for indexing the grid properties. */
-  int ravel_grid_index(const std::array<int, MAX_GRID_NDIM> &multi_index) const;
+  int ravel_grid_index(
+      const std::array<int, MAX_GRID_NDIM> &multi_index) const;
   std::array<int, MAX_GRID_NDIM> unravel_grid_index(int index) const;
   int ravel_spectra_index(const std::array<int, MAX_GRID_NDIM> &multi_index,
                           int ilam) const;
@@ -70,7 +73,7 @@ public:
   /* Do we need to populate the grid weights? */
   bool need_grid_weights() const;
 
-private:
+ private:
   /* The spectra array. */
   PyArrayObject *np_spectra_;
 
@@ -103,4 +106,4 @@ private:
 };
 #pragma omp end declare target
 
-#endif // GRID_PROPS_H_
+#endif  // GRID_PROPS_H_

--- a/src/synthesizer/extensions/index_utils.h
+++ b/src/synthesizer/extensions/index_utils.h
@@ -1,9 +1,10 @@
 #ifndef INDEX_UTILS_H_
 #define INDEX_UTILS_H_
 
-#include "grid_props.h"
 #include <array>
 
+#include "grid_props.h"
+
 /**
  * @brief Compute an ndimensional index from a flat index.
  *
@@ -12,10 +13,9 @@
  * @param dims: The size of each dimension.
  * @param indices: The output N-dimensional indices.
  */
-static inline void
-get_indices_from_flat(int flat_ind, int ndim,
-                      std::array<int, MAX_GRID_NDIM> dims,
-                      std::array<int, MAX_GRID_NDIM> &indices) {
+static inline void get_indices_from_flat(
+    int flat_ind, int ndim, std::array<int, MAX_GRID_NDIM> dims,
+    std::array<int, MAX_GRID_NDIM> &indices) {
 
   /* Loop over indices calculating each one. */
   for (int i = ndim - 1; i > -1; i--) {
@@ -35,10 +35,9 @@ get_indices_from_flat(int flat_ind, int ndim,
  * @param dims: The size of each dimension.
  * @param indices: The output N-dimensional indices.
  */
-static inline void
-get_indices_from_flat(int flat_ind, int ndim,
-                      std::array<int, MAX_GRID_NDIM + 1> dims,
-                      std::array<int, MAX_GRID_NDIM + 1> &indices) {
+static inline void get_indices_from_flat(
+    int flat_ind, int ndim, std::array<int, MAX_GRID_NDIM + 1> dims,
+    std::array<int, MAX_GRID_NDIM + 1> &indices) {
 
   /* Loop over indices calculating each one. */
   for (int i = ndim - 1; i > -1; i--) {
@@ -54,9 +53,9 @@ get_indices_from_flat(int flat_ind, int ndim,
  * @param dims: The length of each dimension.
  * @param ndim: The number of dimensions.
  */
-static inline int
-get_flat_index(const std::array<int, MAX_GRID_NDIM> multi_index,
-               const int *dims, const int ndim) {
+static inline int get_flat_index(
+    const std::array<int, MAX_GRID_NDIM> multi_index, const int *dims,
+    const int ndim) {
 
   int index = 0, stride = 1;
   for (int i = ndim - 1; i >= 0; i--) {
@@ -77,9 +76,9 @@ get_flat_index(const std::array<int, MAX_GRID_NDIM> multi_index,
  * @param dims: The length of each dimension.
  * @param ndim: The number of dimensions.
  */
-static inline int
-get_flat_index(const std::array<int, MAX_GRID_NDIM + 1> multi_index,
-               const int *dims, const int ndim) {
+static inline int get_flat_index(
+    const std::array<int, MAX_GRID_NDIM + 1> multi_index, const int *dims,
+    const int ndim) {
   int index = 0, stride = 1;
   for (int i = ndim - 1; i >= 0; i--) {
     index += stride * multi_index[i];
@@ -89,4 +88,4 @@ get_flat_index(const std::array<int, MAX_GRID_NDIM + 1> multi_index,
   return index;
 }
 
-#endif // INDEX_UTILS_H_
+#endif  // INDEX_UTILS_H_

--- a/src/synthesizer/extensions/integrated_spectra.cpp
+++ b/src/synthesizer/extensions/integrated_spectra.cpp
@@ -3,17 +3,19 @@
  * Calculates weights on an arbitrary dimensional grid given the mass.
  *****************************************************************************/
 /* C includes */
-#include <array>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include <array>
+
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes */
 #include "cpp_to_python.h"
@@ -64,8 +66,7 @@ static PyArrayObject *get_spectra_serial(GridProps *grid_props) {
       const double weight = grid_weights[grid_ind];
 
       /* Skip zero weight cells. */
-      if (weight <= 0)
-        continue;
+      if (weight <= 0) continue;
 
       /* Get the grid spectra value at this index and wavelength. */
       const size_t spec_ind = static_cast<size_t>(grid_ind) * nlam + ilam;
@@ -138,8 +139,7 @@ static PyArrayObject *get_spectra_omp(GridProps *grid_props, int nthreads) {
         const double weight = grid_weights[grid_ind];
 
         /* Skip zero weight cells. */
-        if (weight <= 0)
-          continue;
+        if (weight <= 0) continue;
 
         /* Get the grid spectra value at this index and wavelength. */
         const size_t spec_ind =
@@ -218,11 +218,10 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
   PyArrayObject *np_mask, *np_lam_mask;
   char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOOiiisiOOO|O", &np_grid_spectra,
-                        &grid_tuple, &part_tuple, &np_part_mass, &np_ndims,
-                        &ndim, &npart, &nlam, &method, &nthreads,
-                        &np_grid_weights, &np_mask, &np_lam_mask,
-                        &prop_names))
+  if (!PyArg_ParseTuple(args, "OOOOOiiisiOOO|O", &np_grid_spectra, &grid_tuple,
+                        &part_tuple, &np_part_mass, &np_ndims, &ndim, &npart,
+                        &nlam, &method, &nthreads, &np_grid_weights, &np_mask,
+                        &np_lam_mask, &prop_names))
     return NULL;
 
   /* Extract the grid struct. */
@@ -232,8 +231,9 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
   RETURN_IF_PYERR();
 
   /* Create the object that holds the particle properties. */
-  Particles *part_props = new Particles(np_part_mass, /*np_velocities*/ NULL,
-                                        np_mask, part_tuple, prop_names, npart);
+  Particles *part_props =
+      new Particles(np_part_mass, /*np_velocities*/ NULL, np_mask, part_tuple,
+                    prop_names, npart);
   RETURN_IF_PYERR();
 
   /* Get existing grid weights or allocate new ones. */
@@ -250,7 +250,8 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
       weight_loop_ngp(grid_props, part_props, grid_props->size, grid_weights,
                       nthreads);
     } else {
-      PyErr_SetString(PyExc_ValueError, "Unknown grid assignment method (%s).");
+      PyErr_SetString(PyExc_ValueError,
+                      "Unknown grid assignment method (%s).");
       return NULL;
     }
   }
@@ -296,8 +297,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_integrated_spectra(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/integration.h
+++ b/src/synthesizer/extensions/integration.h
@@ -29,4 +29,4 @@ double simps_1d(const double *x, const double *y, size_t n);
  */
 double trapz_1d(const double *x, const double *y, size_t n);
 
-#endif // INTEGRATION_H_
+#endif  // INTEGRATION_H_

--- a/src/synthesizer/extensions/integration_py.cpp
+++ b/src/synthesizer/extensions/integration_py.cpp
@@ -3,9 +3,11 @@
  *****************************************************************************/
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
-#include <cmath>
 #include <Python.h>
+
+#include <cmath>
+
+#include "numpy_init.h"
 
 #ifdef WITH_OPENMP
 #include <omp.h>
@@ -304,8 +306,8 @@ static double *weighted_trapz_last_axis_serial(double *x, double *y, double *w,
  * @brief Parallel weighted trapezoidal integration over the final axis.
  */
 #ifdef WITH_OPENMP
-static double *weighted_trapz_last_axis_parallel(double *x, double *y, double *w,
-                                                 npy_intp n,
+static double *weighted_trapz_last_axis_parallel(double *x, double *y,
+                                                 double *w, npy_intp n,
                                                  npy_intp num_elements,
                                                  int nthreads) {
   if (num_elements == 0) {
@@ -482,10 +484,11 @@ static double *weighted_simps_last_axis_serial(double *x, double *y, double *w,
         continue;
       }
 
-      num += (h0 + h1) / 6.0 *
-             ((2.0 - h1 / h0) * y[i * n + k] * w[k] +
-              ((h0 + h1) * (h0 + h1) / (h0 * h1)) * y[i * n + k + 1] * w[k + 1] +
-              (2.0 - h0 / h1) * y[i * n + k + 2] * w[k + 2]);
+      num +=
+          (h0 + h1) / 6.0 *
+          ((2.0 - h1 / h0) * y[i * n + k] * w[k] +
+           ((h0 + h1) * (h0 + h1) / (h0 * h1)) * y[i * n + k + 1] * w[k + 1] +
+           (2.0 - h0 / h1) * y[i * n + k + 2] * w[k + 2]);
     }
     if ((n - 1) % 2 != 0) {
       num += 0.5 * (x[n - 1] - x[n - 2]) *
@@ -501,8 +504,8 @@ static double *weighted_simps_last_axis_serial(double *x, double *y, double *w,
  * @brief Parallel weighted Simpson integration over the final axis.
  */
 #ifdef WITH_OPENMP
-static double *weighted_simps_last_axis_parallel(double *x, double *y, double *w,
-                                                 npy_intp n,
+static double *weighted_simps_last_axis_parallel(double *x, double *y,
+                                                 double *w, npy_intp n,
                                                  npy_intp num_elements,
                                                  int nthreads) {
   if (num_elements == 0) {
@@ -553,10 +556,11 @@ static double *weighted_simps_last_axis_parallel(double *x, double *y, double *w
         continue;
       }
 
-      num += (h0 + h1) / 6.0 *
-             ((2.0 - h1 / h0) * y[i * n + k] * w[k] +
-              ((h0 + h1) * (h0 + h1) / (h0 * h1)) * y[i * n + k + 1] * w[k + 1] +
-              (2.0 - h0 / h1) * y[i * n + k + 2] * w[k + 2]);
+      num +=
+          (h0 + h1) / 6.0 *
+          ((2.0 - h1 / h0) * y[i * n + k] * w[k] +
+           ((h0 + h1) * (h0 + h1) / (h0 * h1)) * y[i * n + k + 1] * w[k + 1] +
+           (2.0 - h0 / h1) * y[i * n + k + 2] * w[k + 2]);
     }
     if ((n - 1) % 2 != 0) {
       num += 0.5 * (x[n - 1] - x[n - 2]) *
@@ -669,16 +673,15 @@ static PyMethodDef IntegrationMethods[] = {
      METH_VARARGS, "Weighted Simpson integration with OpenMP"},
     {NULL, NULL, 0, NULL}};
 
-static struct PyModuleDef integrationmodule = {
-    PyModuleDef_HEAD_INIT,
-    "integration",
-    NULL,
-    -1,
-    IntegrationMethods,
-    NULL,
-    NULL,
-    NULL,
-    NULL};
+static struct PyModuleDef integrationmodule = {PyModuleDef_HEAD_INIT,
+                                               "integration",
+                                               NULL,
+                                               -1,
+                                               IntegrationMethods,
+                                               NULL,
+                                               NULL,
+                                               NULL,
+                                               NULL};
 
 PyMODINIT_FUNC PyInit_integration(void) {
   if (numpy_import() < 0) {
@@ -686,8 +689,7 @@ PyMODINIT_FUNC PyInit_integration(void) {
     return NULL;
   }
   PyObject *m = PyModule_Create(&integrationmodule);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
 #ifdef ATOMIC_TIMING
   if (import_toc_capsule() < 0) {
     Py_DECREF(m);

--- a/src/synthesizer/extensions/kernel_extensions/kernel_bindings.cpp
+++ b/src/synthesizer/extensions/kernel_extensions/kernel_bindings.cpp
@@ -6,8 +6,8 @@
  * evaluation function to Python.
  *****************************************************************************/
 
-#include "kernels.h"
 #include "kernel_functions.h"
+#include "kernels.h"
 
 /**
  * @brief Evaluate a named kernel on a 1D radius array.

--- a/src/synthesizer/extensions/kernel_extensions/kernel_functions.h
+++ b/src/synthesizer/extensions/kernel_extensions/kernel_functions.h
@@ -40,7 +40,7 @@ static inline double sph_anarchy(const double r) {
   if (r <= 1.0) {
     const double one_minus_r = 1.0 - r;
     return (21.0 / (2.0 * M_PI)) * (one_minus_r * one_minus_r * one_minus_r *
-                                     one_minus_r * (1.0 + 4.0 * r));
+                                    one_minus_r * (1.0 + 4.0 * r));
   }
   return 0.0;
 }
@@ -99,8 +99,7 @@ static inline double quartic(const double r) {
     const double a = 2.5 - q;
     const double b = 1.5 - q;
     const double c = 0.5 - q;
-    return norm * (a * a * a * a - 5.0 * b * b * b * b +
-                   10.0 * c * c * c * c);
+    return norm * (a * a * a * a - 5.0 * b * b * b * b + 10.0 * c * c * c * c);
   }
   if (q < 1.5) {
     const double a = 2.5 - q;
@@ -123,9 +122,8 @@ static inline double quartic(const double r) {
  */
 static inline double quintic(const double r) {
   if (r < 0.333333333) {
-    return 27.0 *
-           (6.4457752 * r * r * r * r * (1.0 - r) - 1.4323945 * r * r +
-            0.17507044);
+    return 27.0 * (6.4457752 * r * r * r * r * (1.0 - r) - 1.4323945 * r * r +
+                   0.17507044);
   }
   if (r < 0.666666667) {
     return 27.0 *

--- a/src/synthesizer/extensions/kernel_extensions/kernel_utils.h
+++ b/src/synthesizer/extensions/kernel_extensions/kernel_utils.h
@@ -215,8 +215,8 @@ static inline double get_truncated_kernel_value(const double *kernel,
  *   boundary.
  *
  * Interpolation inside the table uses standard CIC / trilinear weights.
- * Because the tabulated q and u axes are uniform and the eta axis is uniform in
- * log-space, the interpolation cell is located with direct index arithmetic
+ * Because the tabulated q and u axes are uniform and the eta axis is uniform
+ * in log-space, the interpolation cell is located with direct index arithmetic
  * rather than generic binary searches.
  *
  * @param kernel The overlap kernel table.
@@ -232,11 +232,10 @@ static inline double get_truncated_kernel_value(const double *kernel,
  *
  * @return The interpolated overlap-kernel value.
  */
-static inline double
-get_overlap_kernel_value(const double *kernel, const double *q_grid,
-                         const double *u_grid, const double *eta_grid,
-                         const int qdim, const int udim, const int etadim,
-                         const double q, const double u, const double eta) {
+static inline double get_overlap_kernel_value(
+    const double *kernel, const double *q_grid, const double *u_grid,
+    const double *eta_grid, const int qdim, const int udim, const int etadim,
+    const double q, const double u, const double eta) {
 
   /* Outside the projected or LOS support there is no contribution. */
   if (q < 0.0 || q >= 1.0 || u <= -1.0) {
@@ -292,4 +291,4 @@ get_overlap_kernel_value(const double *kernel, const double *q_grid,
   /* Finally interpolate along the projected-separation direction. */
   return c0 + q_frac * (c1 - c0);
 }
-#endif // KERNEL_UTILS_H_
+#endif  // KERNEL_UTILS_H_

--- a/src/synthesizer/extensions/kernel_extensions/kernels.h
+++ b/src/synthesizer/extensions/kernel_extensions/kernels.h
@@ -26,8 +26,9 @@
 #define NO_IMPORT_ARRAY
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes. */
 #include "integration.h"

--- a/src/synthesizer/extensions/kernel_extensions/overlap_kernel.cpp
+++ b/src/synthesizer/extensions/kernel_extensions/overlap_kernel.cpp
@@ -4,11 +4,12 @@
  * This module builds the 3D overlap kernel table G(q, u, eta) used by the
  * smoothed-input LOS path. The table encodes the line-of-sight overlap between
  * an input (smoothing-length h_i) and source (smoothing-length h_j) kernel
- * as a function of projected separation, LOS offset, and smoothing-length ratio.
+ * as a function of projected separation, LOS offset, and smoothing-length
+ * ratio.
  *****************************************************************************/
 
-#include "kernels.h"
 #include "kernel_functions.h"
+#include "kernels.h"
 
 /**
  * @brief Evaluate the overlap kernel table for smoothed LOS calculations.
@@ -64,7 +65,8 @@ static void build_overlap_kernel_table(
     const int trunc_zdim, const int nthreads) {
 
 #ifdef WITH_OPENMP
-#pragma omp parallel for num_threads(nthreads) schedule(static) if (nthreads > 1)
+#pragma omp parallel for num_threads(nthreads) \
+    schedule(static) if (nthreads > 1)
 #endif
   for (int ieta = 0; ieta < etadim; ieta++) {
     const double eta = eta_grid[ieta];
@@ -138,15 +140,14 @@ PyObject *compute_overlap_kernel(PyObject *self, PyObject *args) {
       *np_sample_y, *np_sample_z, *np_sample_weights, *np_truncated_kernel,
       *np_trunc_q, *np_trunc_z;
 
-  if (!PyArg_ParseTuple(args, "O!O!O!O!O!O!O!O!O!O!iiiiiii", &PyArray_Type,
-                        &np_q_grid, &PyArray_Type, &np_u_grid, &PyArray_Type,
-                        &np_eta_grid, &PyArray_Type, &np_sample_x,
-                        &PyArray_Type, &np_sample_y, &PyArray_Type,
-                        &np_sample_z, &PyArray_Type, &np_sample_weights,
-                        &PyArray_Type, &np_truncated_kernel, &PyArray_Type,
-                        &np_trunc_q, &PyArray_Type, &np_trunc_z, &qdim,
-                        &udim, &etadim, &nsample, &trunc_qdim, &trunc_zdim,
-                        &nthreads)) {
+  if (!PyArg_ParseTuple(
+          args, "O!O!O!O!O!O!O!O!O!O!iiiiiii", &PyArray_Type, &np_q_grid,
+          &PyArray_Type, &np_u_grid, &PyArray_Type, &np_eta_grid,
+          &PyArray_Type, &np_sample_x, &PyArray_Type, &np_sample_y,
+          &PyArray_Type, &np_sample_z, &PyArray_Type, &np_sample_weights,
+          &PyArray_Type, &np_truncated_kernel, &PyArray_Type, &np_trunc_q,
+          &PyArray_Type, &np_trunc_z, &qdim, &udim, &etadim, &nsample,
+          &trunc_qdim, &trunc_zdim, &nthreads)) {
     return NULL;
   }
 
@@ -168,8 +169,7 @@ PyObject *compute_overlap_kernel(PyObject *self, PyObject *args) {
     return NULL;
   }
   if (PyArray_NDIM(np_truncated_kernel) != 2) {
-    PyErr_SetString(PyExc_ValueError,
-                    "truncated_kernel must be a 2D array.");
+    PyErr_SetString(PyExc_ValueError, "truncated_kernel must be a 2D array.");
     return NULL;
   }
 
@@ -195,13 +195,11 @@ PyObject *compute_overlap_kernel(PyObject *self, PyObject *args) {
 
   /* Validate dimensions match the declared sizes. */
   if (static_cast<int>(PyArray_DIM(np_q_grid, 0)) != qdim) {
-    PyErr_SetString(PyExc_ValueError,
-                    "q_grid dimension does not match qdim");
+    PyErr_SetString(PyExc_ValueError, "q_grid dimension does not match qdim");
     return NULL;
   }
   if (static_cast<int>(PyArray_DIM(np_u_grid, 0)) != udim) {
-    PyErr_SetString(PyExc_ValueError,
-                    "u_grid dimension does not match udim");
+    PyErr_SetString(PyExc_ValueError, "u_grid dimension does not match udim");
     return NULL;
   }
   if (static_cast<int>(PyArray_DIM(np_eta_grid, 0)) != etadim) {
@@ -231,8 +229,9 @@ PyObject *compute_overlap_kernel(PyObject *self, PyObject *args) {
   }
   if (static_cast<int>(PyArray_DIM(np_truncated_kernel, 0)) != trunc_qdim ||
       static_cast<int>(PyArray_DIM(np_truncated_kernel, 1)) != trunc_zdim) {
-    PyErr_SetString(PyExc_ValueError,
-                    "truncated_kernel dimensions do not match trunc_qdim x trunc_zdim");
+    PyErr_SetString(
+        PyExc_ValueError,
+        "truncated_kernel dimensions do not match trunc_qdim x trunc_zdim");
     return NULL;
   }
   if (static_cast<int>(PyArray_DIM(np_trunc_q, 0)) != trunc_qdim) {
@@ -271,10 +270,10 @@ PyObject *compute_overlap_kernel(PyObject *self, PyObject *args) {
   }
 
   tic("Evaluating overlap kernel table");
-  build_overlap_kernel_table(overlap_kernel, q_grid, u_grid, eta_grid, sample_x,
-                             sample_y, sample_z, sample_weights, weight_sum,
-                             truncated_kernel, qdim, udim, etadim, nsample,
-                             trunc_qdim, trunc_zdim, nthreads);
+  build_overlap_kernel_table(overlap_kernel, q_grid, u_grid, eta_grid,
+                             sample_x, sample_y, sample_z, sample_weights,
+                             weight_sum, truncated_kernel, qdim, udim, etadim,
+                             nsample, trunc_qdim, trunc_zdim, nthreads);
   toc("Evaluating overlap kernel table");
 
   return Py_BuildValue("N", np_overlap_kernel);

--- a/src/synthesizer/extensions/kernel_extensions/projected_kernel.cpp
+++ b/src/synthesizer/extensions/kernel_extensions/projected_kernel.cpp
@@ -6,10 +6,10 @@
  * the source kernel at a given dimensionless impact parameter.
  *****************************************************************************/
 
-#include "kernels.h"
-#include "kernel_functions.h"
-
 #include <vector>
+
+#include "kernel_functions.h"
+#include "kernels.h"
 
 /**
  * @brief Integrate the projected LOS kernel at one impact parameter.
@@ -111,14 +111,13 @@ PyObject *compute_projected_kernel(PyObject *self, PyObject *args) {
   const char *kernel_name;
   int nsteps;
 
-  if (!PyArg_ParseTuple(args, "O!si", &PyArray_Type, &np_q_grid,
-                        &kernel_name, &nsteps)) {
+  if (!PyArg_ParseTuple(args, "O!si", &PyArray_Type, &np_q_grid, &kernel_name,
+                        &nsteps)) {
     return NULL;
   }
 
   if (nsteps <= 0) {
-    PyErr_SetString(PyExc_ValueError,
-                  "nsteps must be a positive integer.");
+    PyErr_SetString(PyExc_ValueError, "nsteps must be a positive integer.");
     return NULL;
   }
 

--- a/src/synthesizer/extensions/kernel_extensions/truncated_kernel.cpp
+++ b/src/synthesizer/extensions/kernel_extensions/truncated_kernel.cpp
@@ -2,9 +2,9 @@
  * Truncated LOS kernel table builder.
  *
  * This module builds the 2D truncated LOS kernel lookup table used when the
- * input particle lies inside the source kernel. The table stores the cumulative
- * foreground LOS integral as a function of projected separation and truncation
- * coordinate.
+ * input particle lies inside the source kernel. The table stores the
+ * cumulative foreground LOS integral as a function of projected separation and
+ * truncation coordinate.
  *****************************************************************************/
 
 #include "kernel_functions.h"
@@ -82,8 +82,8 @@ PyObject *compute_truncated_los_kernel(PyObject *self, PyObject *args) {
   PyArrayObject *np_q_grid, *np_z_grid;
   const char *kernel_name;
 
-  if (!PyArg_ParseTuple(args, "O!O!s", &PyArray_Type, &np_q_grid, &PyArray_Type,
-                        &np_z_grid, &kernel_name)) {
+  if (!PyArg_ParseTuple(args, "O!O!s", &PyArray_Type, &np_q_grid,
+                        &PyArray_Type, &np_z_grid, &kernel_name)) {
     return NULL;
   }
 
@@ -107,16 +107,16 @@ PyObject *compute_truncated_los_kernel(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-const int qdim = static_cast<int>(PyArray_DIM(np_q_grid, 0));
+  const int qdim = static_cast<int>(PyArray_DIM(np_q_grid, 0));
   const int zdim = static_cast<int>(PyArray_DIM(np_z_grid, 0));
   if (qdim == 0) {
     PyErr_SetString(PyExc_ValueError,
-                  "q_grid must contain at least one element.");
+                    "q_grid must contain at least one element.");
     return NULL;
   }
   if (zdim == 0) {
     PyErr_SetString(PyExc_ValueError,
-                  "z_grid must contain at least one element.");
+                    "z_grid must contain at least one element.");
     return NULL;
   }
 

--- a/src/synthesizer/extensions/numpy_init.cpp
+++ b/src/synthesizer/extensions/numpy_init.cpp
@@ -1,11 +1,10 @@
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
-#undef NO_IMPORT_ARRAY // Allow import_array() to be defined
+#undef NO_IMPORT_ARRAY  // Allow import_array() to be defined
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 #include "numpy_init.h"
 
 int numpy_import() {
-  if (_import_array() < 0)
-    return -1;
+  if (_import_array() < 0) return -1;
   return 0;
 }

--- a/src/synthesizer/extensions/numpy_init.h
+++ b/src/synthesizer/extensions/numpy_init.h
@@ -14,4 +14,4 @@
 /* Declare init function. */
 int numpy_import();
 
-#endif // NUMPY_INIT_H_
+#endif  // NUMPY_INIT_H_

--- a/src/synthesizer/extensions/observed_spectra.cpp
+++ b/src/synthesizer/extensions/observed_spectra.cpp
@@ -5,7 +5,8 @@
  * This fills observer-frame wavelength, frequency, and flux buffers in place
  * so Python callers can avoid large temporary array allocations on the hot
  * path.
- * ************************************************************************** */
+ * **************************************************************************
+ */
 /* Standard includes */
 #include <cmath>
 
@@ -116,17 +117,16 @@ PyObject *compute_fnu(PyObject *self, PyObject *args) {
 
   /* Reject any inputs that would force an implicit conversion or copy in the
    * kernel so the hot path only ever sees float64 C-contiguous buffers. */
-  if (PyArray_TYPE(np_lnu) != NPY_DOUBLE || PyArray_TYPE(np_lam) != NPY_DOUBLE ||
+  if (PyArray_TYPE(np_lnu) != NPY_DOUBLE ||
+      PyArray_TYPE(np_lam) != NPY_DOUBLE ||
       PyArray_TYPE(np_nu) != NPY_DOUBLE ||
-      PyArray_TYPE(np_fnu_out) != NPY_DOUBLE ||
-      !PyArray_ISCARRAY_RO(np_lnu) || !PyArray_ISCARRAY_RO(np_lam) ||
-      !PyArray_ISCARRAY_RO(np_nu) || !PyArray_ISCARRAY(np_fnu_out) ||
-      (np_obslam_out != NULL &&
-       (PyArray_TYPE(np_obslam_out) != NPY_DOUBLE ||
-        !PyArray_ISCARRAY(np_obslam_out))) ||
-      (np_obsnu_out != NULL &&
-       (PyArray_TYPE(np_obsnu_out) != NPY_DOUBLE ||
-        !PyArray_ISCARRAY(np_obsnu_out)))) {
+      PyArray_TYPE(np_fnu_out) != NPY_DOUBLE || !PyArray_ISCARRAY_RO(np_lnu) ||
+      !PyArray_ISCARRAY_RO(np_lam) || !PyArray_ISCARRAY_RO(np_nu) ||
+      !PyArray_ISCARRAY(np_fnu_out) ||
+      (np_obslam_out != NULL && (PyArray_TYPE(np_obslam_out) != NPY_DOUBLE ||
+                                 !PyArray_ISCARRAY(np_obslam_out))) ||
+      (np_obsnu_out != NULL && (PyArray_TYPE(np_obsnu_out) != NPY_DOUBLE ||
+                                !PyArray_ISCARRAY(np_obsnu_out)))) {
     Py_DECREF(np_lnu);
     Py_DECREF(np_lam);
     Py_DECREF(np_nu);
@@ -210,9 +210,10 @@ PyObject *compute_fnu(PyObject *self, PyObject *args) {
   double *lam = static_cast<double *>(PyArray_DATA(np_lam));
   double *nu = static_cast<double *>(PyArray_DATA(np_nu));
   double *fnu_out = static_cast<double *>(PyArray_DATA(np_fnu_out));
-  double *obslam_out = np_obslam_out == NULL
-                           ? NULL
-                           : static_cast<double *>(PyArray_DATA(np_obslam_out));
+  double *obslam_out =
+      np_obslam_out == NULL
+          ? NULL
+          : static_cast<double *>(PyArray_DATA(np_obslam_out));
   double *obsnu_out = np_obsnu_out == NULL
                           ? NULL
                           : static_cast<double *>(PyArray_DATA(np_obsnu_out));
@@ -224,7 +225,8 @@ PyObject *compute_fnu(PyObject *self, PyObject *args) {
   tic("compute_fnu");
 
 #ifdef WITH_OPENMP
-#pragma omp parallel for if(nthreads > 1) num_threads(nthreads) schedule(static)
+#pragma omp parallel for if (nthreads > 1) num_threads(nthreads) \
+    schedule(static)
 #endif
   for (npy_intp idx = 0; idx < nelem; idx++) {
     fnu_out[idx] = lnu[idx] * conversion;
@@ -270,8 +272,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_observed_spectra(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
 
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");

--- a/src/synthesizer/extensions/octree.cpp
+++ b/src/synthesizer/extensions/octree.cpp
@@ -63,12 +63,9 @@ static void populate_cell_tree_recursive(struct cell *c, int *ncells,
     cp->loc[0] = c->loc[0];
     cp->loc[1] = c->loc[1];
     cp->loc[2] = c->loc[2];
-    if (ip & 4)
-      cp->loc[0] += cp->width;
-    if (ip & 2)
-      cp->loc[1] += cp->width;
-    if (ip & 1)
-      cp->loc[2] += cp->width;
+    if (ip & 4) cp->loc[0] += cp->width;
+    if (ip & 2) cp->loc[1] += cp->width;
+    if (ip & 1) cp->loc[2] += cp->width;
     cp->split = 0;
     cp->part_count = 0;
     cp->max_sml_squ = 0;
@@ -157,19 +154,22 @@ static void populate_cell_tree_recursive(struct cell *c, int *ncells,
       struct particle *pp = &cp->particles[ipart];
 
       if (pp->pos[0] < cp->loc[0] || pp->pos[0] > cp->loc[0] + cp->width) {
-        printf("Error: Particle outside cell bounds in x (c->loc[0] = %f, "
-               "c->loc[0] + c->width = %f, pp->pos[0] = %f)!\n",
-               cp->loc[0], cp->loc[0] + cp->width, pp->pos[0]);
+        printf(
+            "Error: Particle outside cell bounds in x (c->loc[0] = %f, "
+            "c->loc[0] + c->width = %f, pp->pos[0] = %f)!\n",
+            cp->loc[0], cp->loc[0] + cp->width, pp->pos[0]);
       }
       if (pp->pos[1] < cp->loc[1] || pp->pos[1] > cp->loc[1] + cp->width) {
-        printf("Error: Particle outside cell bounds in y (c->loc[1] = %f, "
-               "c->loc[1] + c->width = %f, pp->pos[1] = %f)!\n",
-               cp->loc[1], cp->loc[1] + cp->width, pp->pos[1]);
+        printf(
+            "Error: Particle outside cell bounds in y (c->loc[1] = %f, "
+            "c->loc[1] + c->width = %f, pp->pos[1] = %f)!\n",
+            cp->loc[1], cp->loc[1] + cp->width, pp->pos[1]);
       }
       if (pp->pos[2] < cp->loc[2] || pp->pos[2] > cp->loc[2] + cp->width) {
-        printf("Error: Particle outside cell bounds in z (c->loc[2] = %f, "
-               "c->loc[2] + c->width = %f, pp->pos[2] = %f)!\n",
-               cp->loc[2], cp->loc[2] + cp->width, pp->pos[2]);
+        printf(
+            "Error: Particle outside cell bounds in z (c->loc[2] = %f, "
+            "c->loc[2] + c->width = %f, pp->pos[2] = %f)!\n",
+            cp->loc[2], cp->loc[2] + cp->width, pp->pos[2]);
       }
     }
   }
@@ -247,16 +247,15 @@ static void construct_particles(struct particle *particles, const double *pos,
   /* Get the cell width based on the bounds we have found. Note that
    * we are assuming a cubic domain so the maximum width is the width. */
   double width = bounds[1] - bounds[0];
-  if (bounds[3] - bounds[2] > width)
-    width = bounds[3] - bounds[2];
-  if (bounds[5] - bounds[4] > width)
-    width = bounds[5] - bounds[4];
+  if (bounds[3] - bounds[2] > width) width = bounds[3] - bounds[2];
+  if (bounds[5] - bounds[4] > width) width = bounds[5] - bounds[4];
 
   /* Include a small buffer on the width. */
   width *= 1.0001;
 
   /* Get the geometric mid point. */
-  double mid[3] = {0.5 * (bounds[0] + bounds[1]), 0.5 * (bounds[2] + bounds[3]),
+  double mid[3] = {0.5 * (bounds[0] + bounds[1]),
+                   0.5 * (bounds[2] + bounds[3]),
                    0.5 * (bounds[4] + bounds[5])};
 
   /* Recalculate the bounds using the width and midpoint. */
@@ -370,8 +369,8 @@ void cleanup_cell_tree(struct cell *c) {
  */
 double min_projected_dist2(struct cell *c, double x, double y) {
 
-  /* Get the minimum separation along each axis (if the point is within the cell
-   * along an axis then the separation should be 0). */
+  /* Get the minimum separation along each axis (if the point is within the
+   * cell along an axis then the separation should be 0). */
   double dx = 0;
   double dy = 0;
   if (!(x > c->loc[0] && x < c->loc[0] + c->width)) {

--- a/src/synthesizer/extensions/octree.h
+++ b/src/synthesizer/extensions/octree.h
@@ -66,4 +66,4 @@ void construct_cell_tree(const double *pos, const double *sml,
 void cleanup_cell_tree(struct cell *c);
 double min_projected_dist2(struct cell *c, double x, double y);
 
-#endif // OCTREE_H_
+#endif  // OCTREE_H_

--- a/src/synthesizer/extensions/openmp_check.cpp
+++ b/src/synthesizer/extensions/openmp_check.cpp
@@ -24,7 +24,8 @@ static PyObject *check_openmp(PyObject *self, PyObject *args) {
 }
 
 static PyMethodDef OpenMPMethods[] = {
-    {"check_openmp", check_openmp, METH_VARARGS, "Check if OpenMP is enabled."},
+    {"check_openmp", check_openmp, METH_VARARGS,
+     "Check if OpenMP is enabled."},
     {NULL, NULL, 0, NULL}};
 
 static struct PyModuleDef openmpmodule = {

--- a/src/synthesizer/extensions/part_props.cpp
+++ b/src/synthesizer/extensions/part_props.cpp
@@ -22,13 +22,16 @@ class GridProps;
  * @param np_weights: The numpy array holding the particle weights.
  * @param np_velocities: The numpy array holding the particle velocities.
  * @param np_mask: The numpy array holding the particle mask.
- * @param part_tuple: The tuple of numpy arrays holding the particle properties.
+ * @param part_tuple: The tuple of numpy arrays holding the particle
+ * properties.
  */
 Particles::Particles(PyArrayObject *np_weights, PyArrayObject *np_velocities,
                      PyArrayObject *np_mask, PyObject *part_tuple,
                      PyObject *part_names_tuple, int npart_)
-    : np_weights_(np_weights), np_velocities_(np_velocities),
-      np_mask_(np_mask), part_tuple_(part_tuple) {
+    : np_weights_(np_weights),
+      np_velocities_(np_velocities),
+      np_mask_(np_mask),
+      part_tuple_(part_tuple) {
 
   tic("Particles.__init__");
 

--- a/src/synthesizer/extensions/part_props.h
+++ b/src/synthesizer/extensions/part_props.h
@@ -3,14 +3,16 @@
 
 /* Standard includes */
 #include <stdlib.h>
+
 #include <string>
 #include <vector>
 
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes */
 #include "property_funcs.h"
@@ -22,7 +24,7 @@
  * This is used to hold the particle properties and mass.
  */
 class Particles {
-public:
+ public:
   /* The number of particles. */
   int npart;
 
@@ -54,7 +56,7 @@ public:
   /* Is a particle masked? */
   bool part_is_masked(int pind) const;
 
-private:
+ private:
   /* The numpy array holding the particle weights (e.g. initial mass for
    * SPS grid weighting). */
   PyArrayObject *np_weights_;
@@ -79,4 +81,4 @@ void get_particle_indices_and_fracs(GridProps *grid_props, Particles *parts,
 void get_particle_indices(GridProps *grid_props, Particles *parts,
                           int nthreads = 1);
 
-#endif // PART_PROPS_H_
+#endif  // PART_PROPS_H_

--- a/src/synthesizer/extensions/particle_spectra.cpp
+++ b/src/synthesizer/extensions/particle_spectra.cpp
@@ -3,19 +3,21 @@
  * Calculates weights on an arbitrary dimensional grid given the mass.
  *****************************************************************************/
 /* C includes */
-#include <algorithm>
-#include <array>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <algorithm>
+#include <array>
 #include <vector>
 
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes */
 #include "cpp_to_python.h"
@@ -1018,23 +1020,24 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
   PyArrayObject *np_mask, *np_lam_mask;
   char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOOiiisiOOp|O", &np_grid_spectra,
-                        &grid_tuple, &part_tuple, &np_part_mass, &np_ndims,
-                        &ndim, &npart, &nlam, &method, &nthreads, &np_mask,
-                        &np_lam_mask, &has_lam_mask, &prop_names)) {
+  if (!PyArg_ParseTuple(args, "OOOOOiiisiOOp|O", &np_grid_spectra, &grid_tuple,
+                        &part_tuple, &np_part_mass, &np_ndims, &ndim, &npart,
+                        &nlam, &method, &nthreads, &np_mask, &np_lam_mask,
+                        &has_lam_mask, &prop_names)) {
     return NULL;
   }
 
   /* Extract the grid struct. */
-  GridProps *grid_props = new GridProps(np_grid_spectra, grid_tuple,
-                                        /*np_lam*/ nullptr, np_lam_mask, nlam,
-                                        /*np_grid_weights*/ nullptr,
-                                        prop_names);
+  GridProps *grid_props =
+      new GridProps(np_grid_spectra, grid_tuple,
+                    /*np_lam*/ nullptr, np_lam_mask, nlam,
+                    /*np_grid_weights*/ nullptr, prop_names);
   RETURN_IF_PYERR();
 
   /* Create the object that holds the particle properties. */
-  Particles *part_props = new Particles(np_part_mass, /*np_velocities*/ NULL,
-                                        np_mask, part_tuple, prop_names, npart);
+  Particles *part_props =
+      new Particles(np_part_mass, /*np_velocities*/ NULL, np_mask, part_tuple,
+                    prop_names, npart);
   RETURN_IF_PYERR();
 
   tic("compute_particle_seds.setup_output_arrays");
@@ -1094,8 +1097,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_particle_spectra(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/photometry.cpp
+++ b/src/synthesizer/extensions/photometry.cpp
@@ -13,15 +13,16 @@
  * Serial and parallel (OpenMP) versions are provided for each method. The
  * parallel versions use OpenMP parallel-for over (entry, filter) pairs to
  * maximize available parallelism and improve load balancing, especially for
- * small numbers of entries. Each work item is independent so no synchronization
- * is required.
+ * small numbers of entries. Each work item is independent so no
+ * synchronization is required.
  *****************************************************************************/
 
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* C/C++ includes */
 #include <cstring>
@@ -78,10 +79,12 @@ struct FilterWork {
  *
  * @return A vector of FilterWork descriptors for active filters only.
  */
-static std::vector<FilterWork>
-build_filter_work(const double *weight_matrix, const double *denominators,
-                  const npy_int64 *starts, const npy_int64 *ends,
-                  npy_intp wavelength_count, npy_intp nfilters) {
+static std::vector<FilterWork> build_filter_work(const double *weight_matrix,
+                                                 const double *denominators,
+                                                 const npy_int64 *starts,
+                                                 const npy_int64 *ends,
+                                                 npy_intp wavelength_count,
+                                                 npy_intp nfilters) {
 
   /* Pre-allocate space for up to nfilters entries. */
   std::vector<FilterWork> work;
@@ -125,7 +128,8 @@ build_filter_work(const double *weight_matrix, const double *denominators,
  * Results are written directly in filter-major layout.
  *
  * @param x_values:         1D wavelength/frequency grid.
- * @param spectra_values:   Flattened spectra, shape (nentries, wavelength_count).
+ * @param spectra_values:   Flattened spectra, shape (nentries,
+ * wavelength_count).
  * @param filter_work:      Vector of active filter descriptors.
  * @param wavelength_count: Number of wavelength/frequency samples.
  * @param nentries:         Number of spectra (entries).
@@ -160,10 +164,9 @@ static double *compute_photometry_trapz_serial(
       double numerator = 0.0;
       for (npy_int64 wavelength = work.start; wavelength < work.end - 1;
            ++wavelength) {
-        numerator +=
-            0.5 * (x_values[wavelength + 1] - x_values[wavelength]) *
-            (spectrum[wavelength + 1] * work.weights[wavelength + 1] +
-             spectrum[wavelength] * work.weights[wavelength]);
+        numerator += 0.5 * (x_values[wavelength + 1] - x_values[wavelength]) *
+                     (spectrum[wavelength + 1] * work.weights[wavelength + 1] +
+                      spectrum[wavelength] * work.weights[wavelength]);
       }
 
       /* Divide by the precomputed denominator and store directly in
@@ -188,7 +191,8 @@ static double *compute_photometry_trapz_serial(
  * Results are written directly in filter-major layout.
  *
  * @param x_values:         1D wavelength/frequency grid.
- * @param spectra_values:   Flattened spectra, shape (nentries, wavelength_count).
+ * @param spectra_values:   Flattened spectra, shape (nentries,
+ * wavelength_count).
  * @param filter_work:      Vector of active filter descriptors.
  * @param wavelength_count: Number of wavelength/frequency samples.
  * @param nentries:         Number of spectra (entries).
@@ -232,12 +236,11 @@ static double *compute_photometry_simps_serial(
       double numerator = 0.0;
       for (npy_int64 pair_index = 0; pair_index < npairs; ++pair_index) {
         const npy_int64 k = work.start + 2 * pair_index;
-        numerator +=
-            (x_values[k + 2] - x_values[k]) *
-            (spectrum[k] * work.weights[k] +
-             4.0 * spectrum[k + 1] * work.weights[k + 1] +
-             spectrum[k + 2] * work.weights[k + 2]) /
-            6.0;
+        numerator += (x_values[k + 2] - x_values[k]) *
+                     (spectrum[k] * work.weights[k] +
+                      4.0 * spectrum[k + 1] * work.weights[k + 1] +
+                      spectrum[k + 2] * work.weights[k + 2]) /
+                     6.0;
       }
 
       /* If there is a leftover interval, add a trapezoidal step. */
@@ -269,7 +272,8 @@ static double *compute_photometry_simps_serial(
  * still exploit thread-level parallelism across filters.
  *
  * @param x_values:         1D wavelength/frequency grid.
- * @param spectra_values:   Flattened spectra, shape (nentries, wavelength_count).
+ * @param spectra_values:   Flattened spectra, shape (nentries,
+ * wavelength_count).
  * @param filter_work:      Vector of active filter descriptors.
  * @param wavelength_count: Number of wavelength/frequency samples.
  * @param nentries:         Number of spectra (entries).
@@ -317,10 +321,9 @@ static double *compute_photometry_trapz_parallel(
     double numerator = 0.0;
     for (npy_int64 wavelength = work.start; wavelength < work.end - 1;
          ++wavelength) {
-      numerator +=
-          0.5 * (x_values[wavelength + 1] - x_values[wavelength]) *
-          (spectrum[wavelength + 1] * work.weights[wavelength + 1] +
-           spectrum[wavelength] * work.weights[wavelength]);
+      numerator += 0.5 * (x_values[wavelength + 1] - x_values[wavelength]) *
+                   (spectrum[wavelength + 1] * work.weights[wavelength + 1] +
+                    spectrum[wavelength] * work.weights[wavelength]);
     }
 
     /* Write directly to the output. Each work_idx maps to a unique
@@ -341,7 +344,8 @@ static double *compute_photometry_trapz_parallel(
  * each work item writes to a unique output location.
  *
  * @param x_values:         1D wavelength/frequency grid.
- * @param spectra_values:   Flattened spectra, shape (nentries, wavelength_count).
+ * @param spectra_values:   Flattened spectra, shape (nentries,
+ * wavelength_count).
  * @param filter_work:      Vector of active filter descriptors.
  * @param wavelength_count: Number of wavelength/frequency samples.
  * @param nentries:         Number of spectra (entries).
@@ -396,21 +400,20 @@ static double *compute_photometry_simps_parallel(
     double numerator = 0.0;
     for (npy_int64 pair_index = 0; pair_index < npairs; ++pair_index) {
       const npy_int64 k = work.start + 2 * pair_index;
-      numerator +=
-          (x_values[k + 2] - x_values[k]) *
-          (spectrum[k] * work.weights[k] +
-           4.0 * spectrum[k + 1] * work.weights[k + 1] +
-           spectrum[k + 2] * work.weights[k + 2]) /
-          6.0;
+      numerator += (x_values[k + 2] - x_values[k]) *
+                   (spectrum[k] * work.weights[k] +
+                    4.0 * spectrum[k + 1] * work.weights[k + 1] +
+                    spectrum[k + 2] * work.weights[k + 2]) /
+                   6.0;
     }
 
     /* If there is a leftover interval, add a trapezoidal step. */
     if (has_tail) {
       const npy_int64 k0 = work.end - 2;
       const npy_int64 k1 = work.end - 1;
-      numerator += 0.5 * (x_values[k1] - x_values[k0]) *
-                   (spectrum[k1] * work.weights[k1] +
-                    spectrum[k0] * work.weights[k0]);
+      numerator +=
+          0.5 * (x_values[k1] - x_values[k0]) *
+          (spectrum[k1] * work.weights[k1] + spectrum[k0] * work.weights[k0]);
     }
 
     /* Write directly to the output. Each work_idx maps to a unique
@@ -435,7 +438,8 @@ static double *compute_photometry_simps_parallel(
  *   - xs      (ndarray):  1D wavelength/frequency grid, shape (nlam,).
  *   - ys      (ndarray):  ND spectra array; wavelength on the last axis.
  *   - ws      (ndarray):  2D filter weight matrix, shape (nfilters, nlam).
- *   - dens    (ndarray):  1D precomputed filter denominators, shape (nfilters,).
+ *   - dens    (ndarray):  1D precomputed filter denominators, shape
+ * (nfilters,).
  *   - starts  (ndarray):  1D start indices per filter, shape (nfilters,).
  *   - ends    (ndarray):  1D end indices per filter, shape (nfilters,).
  *   - nthreads (int):     Number of OpenMP threads requested.
@@ -443,7 +447,8 @@ static double *compute_photometry_simps_parallel(
  *
  * @return A numpy array of shape (nfilters, *leading_spectrum_shape).
  */
-static PyObject *compute_photometry_integration(PyObject *self, PyObject *args) {
+static PyObject *compute_photometry_integration(PyObject *self,
+                                                PyObject *args) {
 
   /* We don't need the self argument but it has to be there. Tell the
    * compiler we don't care. */
@@ -563,9 +568,8 @@ static PyObject *compute_photometry_integration(PyObject *self, PyObject *args) 
   }
 
   /* Build the compact work descriptors for active filters. */
-  const std::vector<FilterWork> filter_work =
-      build_filter_work(weight_matrix, denominators, starts, ends,
-                        wavelength_count, nfilters);
+  const std::vector<FilterWork> filter_work = build_filter_work(
+      weight_matrix, denominators, starts, ends, wavelength_count, nfilters);
 
   /* Dispatch to the appropriate kernel. */
   double *result_array = NULL;
@@ -599,13 +603,13 @@ static PyObject *compute_photometry_integration(PyObject *self, PyObject *args) 
 
   /* We don't have OpenMP, just call the serial version. */
   if (use_trapz) {
-    result_array = compute_photometry_trapz_serial(
-        x_values, spectra_values, filter_work, wavelength_count, nentries,
-        nfilters);
+    result_array =
+        compute_photometry_trapz_serial(x_values, spectra_values, filter_work,
+                                        wavelength_count, nentries, nfilters);
   } else {
-    result_array = compute_photometry_simps_serial(
-        x_values, spectra_values, filter_work, wavelength_count, nentries,
-        nfilters);
+    result_array =
+        compute_photometry_simps_serial(x_values, spectra_values, filter_work,
+                                        wavelength_count, nentries, nfilters);
   }
 #endif
 
@@ -648,20 +652,19 @@ static PyMethodDef PhotometryMethods[] = {
 /* Make this importable. */
 static struct PyModuleDef photometrymodule = {
     PyModuleDef_HEAD_INIT,
-    "photometry",                                          /* m_name */
+    "photometry",                                            /* m_name */
     "A module for batched broadband photometry integration", /* m_doc */
-    -1,                                                    /* m_size */
-    PhotometryMethods,                                     /* m_methods */
-    NULL,                                                  /* m_reload */
-    NULL,                                                  /* m_traverse */
-    NULL,                                                  /* m_clear */
-    NULL,                                                  /* m_free */
+    -1,                                                      /* m_size */
+    PhotometryMethods,                                       /* m_methods */
+    NULL,                                                    /* m_reload */
+    NULL,                                                    /* m_traverse */
+    NULL,                                                    /* m_clear */
+    NULL,                                                    /* m_free */
 };
 
 PyMODINIT_FUNC PyInit_photometry(void) {
   PyObject *m = PyModule_Create(&photometrymodule);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/property_funcs.cpp
+++ b/src/synthesizer/extensions/property_funcs.cpp
@@ -5,8 +5,9 @@
 
 /* C headers. */
 #include <Python.h>
-#include <iostream>
 #include <string.h>
+
+#include <iostream>
 
 /* Header */
 #include "property_funcs.h"
@@ -36,8 +37,7 @@ double *extract_data_double(PyArrayObject *np_arr, const char *name) {
 
   if (!PyArray_IS_C_CONTIGUOUS(np_arr)) {
     char error_msg[120];
-    snprintf(error_msg, sizeof(error_msg),
-             "%s must be C-contiguous.", name);
+    snprintf(error_msg, sizeof(error_msg), "%s must be C-contiguous.", name);
     PyErr_SetString(PyExc_ValueError, error_msg);
     return NULL;
   }

--- a/src/synthesizer/extensions/property_funcs.h
+++ b/src/synthesizer/extensions/property_funcs.h
@@ -11,8 +11,9 @@
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /**
  * @brief Get a double value at a specific index in a numpy array.
@@ -32,8 +33,7 @@ static inline double get_double_at(PyArrayObject *np_arr, npy_intp ind,
 
   if (PyArray_TYPE(np_arr) != NPY_FLOAT64) {
     PyErr_Format(PyExc_TypeError,
-                 "[get_double_at]: Array '%s' must be of type float64.",
-                 name);
+                 "[get_double_at]: Array '%s' must be of type float64.", name);
     return 0.0;
   }
 
@@ -149,4 +149,4 @@ npy_bool *extract_data_bool(PyArrayObject *np_arr, const char *name);
 const npy_int64 *extract_index_array(PyArrayObject *np_arr, const char *name);
 double **extract_grid_props(PyObject *grid_tuple, int ndim, int *dims);
 
-#endif // PROPERTY_FUNCS_H_
+#endif  // PROPERTY_FUNCS_H_

--- a/src/synthesizer/extensions/reductions.cpp
+++ b/src/synthesizer/extensions/reductions.cpp
@@ -66,7 +66,7 @@ static void reduce_spectra_parallel(double *spectra, double *part_spectra,
       spectra[ilam] += part_spectra_row[ilam];
     }
   }
-#else // OpenMP < 4.5 or no array reduction support
+#else  // OpenMP < 4.5 or no array reduction support
 #pragma omp parallel num_threads(nthreads)
   {
     // Thread-local accumulation to avoid false sharing and atomics
@@ -86,7 +86,7 @@ static void reduce_spectra_parallel(double *spectra, double *part_spectra,
       }
     }
   }
-#endif // WITH_OPENMP
+#endif  // WITH_OPENMP
 }
 #endif
 
@@ -165,7 +165,8 @@ PyObject *reduce_particle_spectra(PyObject *self, PyObject *args) {
 
   /* Validate that we have a two-dimensional array with shape
    * (npart, nlam). This helper is intentionally specialised to the common
-   * per-particle spectra reduction case used by the Python operations layer. */
+   * per-particle spectra reduction case used by the Python operations layer.
+   */
   if (PyArray_NDIM(np_part_spectra) != 2) {
     Py_DECREF(np_part_spectra);
     PyErr_SetString(PyExc_ValueError,
@@ -215,20 +216,19 @@ static PyMethodDef ReductionMethods[] = {
 /* Make this importable. */
 static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT,
-    "reductions",                              /* m_name */
+    "reductions",                             /* m_name */
     "A module containing spectra reductions", /* m_doc */
-    -1,                                         /* m_size */
-    ReductionMethods,                           /* m_methods */
-    NULL,                                       /* m_reload */
-    NULL,                                       /* m_traverse */
-    NULL,                                       /* m_clear */
-    NULL,                                       /* m_free */
+    -1,                                       /* m_size */
+    ReductionMethods,                         /* m_methods */
+    NULL,                                     /* m_reload */
+    NULL,                                     /* m_traverse */
+    NULL,                                     /* m_clear */
+    NULL,                                     /* m_free */
 };
 
 PyMODINIT_FUNC PyInit_reductions(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/sfzh.cpp
+++ b/src/synthesizer/extensions/sfzh.cpp
@@ -3,17 +3,19 @@
  * Calculates weights on an arbitrary dimensional grid given the mass.
  *****************************************************************************/
 /* C includes */
-#include <array>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include <array>
+
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "numpy_init.h"
 #include <Python.h>
+
+#include "numpy_init.h"
 
 /* Local includes */
 #include "cpp_to_python.h"
@@ -101,10 +103,10 @@ PyObject *compute_sfzh(PyObject *self, PyObject *args) {
 }
 
 /* Below is all the gubbins needed to make the module importable in Python. */
-static PyMethodDef SFZHMethods[] = {{"compute_sfzh", (PyCFunction)compute_sfzh,
-                                     METH_VARARGS,
-                                     "Method for calculating the SFZH."},
-                                    {NULL, NULL, 0, NULL}};
+static PyMethodDef SFZHMethods[] = {
+    {"compute_sfzh", (PyCFunction)compute_sfzh, METH_VARARGS,
+     "Method for calculating the SFZH."},
+    {NULL, NULL, 0, NULL}};
 
 /* Make this importable. */
 static struct PyModuleDef moduledef = {
@@ -121,8 +123,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_sfzh(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/spectra_operations.cpp
+++ b/src/synthesizer/extensions/spectra_operations.cpp
@@ -71,10 +71,9 @@ static void scale_spectra_2d_no_mask_serial(const double *__restrict__ spectra,
  * @param nspec: The number of spectra rows.
  * @param nlam: The number of wavelength bins.
  */
-static void scale_spectra_2d_row_mask_serial(const double *__restrict__ spectra,
-                                             const double *__restrict__ scaling,
-                                             const npy_bool *mask, double *out,
-                                             int nspec, int nlam) {
+static void scale_spectra_2d_row_mask_serial(
+    const double *__restrict__ spectra, const double *__restrict__ scaling,
+    const npy_bool *mask, double *out, int nspec, int nlam) {
 
   /* Loop over every spectrum in the grid. */
   for (int ispec = 0; ispec < nspec; ispec++) {
@@ -110,10 +109,9 @@ static void scale_spectra_2d_row_mask_serial(const double *__restrict__ spectra,
  * @param nspec: The number of spectra rows.
  * @param nlam: The number of wavelength bins.
  */
-static void scale_spectra_2d_lam_mask_serial(const double *__restrict__ spectra,
-                                             const double *__restrict__ scaling,
-                                             const npy_bool *lam_mask,
-                                             double *out, int nspec, int nlam) {
+static void scale_spectra_2d_lam_mask_serial(
+    const double *__restrict__ spectra, const double *__restrict__ scaling,
+    const npy_bool *lam_mask, double *out, int nspec, int nlam) {
   /* Loop over every spectrum in the grid. */
   for (int ispec = 0; ispec < nspec; ispec++) {
 
@@ -263,8 +261,9 @@ static void scale_spectra_2d_row_mask_omp(const double *__restrict__ spectra,
  */
 static void scale_spectra_2d_lam_mask_omp(const double *__restrict__ spectra,
                                           const double *__restrict__ scaling,
-                                          const npy_bool *lam_mask, double *out,
-                                          int nspec, int nlam, int nthreads) {
+                                          const npy_bool *lam_mask,
+                                          double *out, int nspec, int nlam,
+                                          int nthreads) {
 
   /* Split the spectra rows evenly across threads. */
 #pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -481,8 +480,8 @@ PyObject *scale_spectra_2d(PyObject *self, PyObject *args) {
   const int nspec = static_cast<int>(spectra_dims[0]);
   const int nlam = static_cast<int>(spectra_dims[1]);
 
-  /* The scaling length must match the spectra first dimension so we can apply a
-   * per-spectrum scale factor. */
+  /* The scaling length must match the spectra first dimension so we can apply
+   * a per-spectrum scale factor. */
   if (PyArray_DIMS(np_scaling)[0] != spectra_dims[0]) {
     PyErr_SetString(PyExc_ValueError,
                     "scaling length must match the spectra first dimension.");
@@ -493,8 +492,8 @@ PyObject *scale_spectra_2d(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  /* The optional masks must be 1D and match the corresponding spectra dimension
-   * so the kernel can apply them correctly. */
+  /* The optional masks must be 1D and match the corresponding spectra
+   * dimension so the kernel can apply them correctly. */
   if (np_mask != NULL && (PyArray_NDIM(np_mask) != 1 ||
                           PyArray_DIMS(np_mask)[0] != spectra_dims[0])) {
     PyErr_SetString(PyExc_ValueError,
@@ -565,8 +564,10 @@ PyObject *scale_spectra_2d(PyObject *self, PyObject *args) {
   }
 
   /* Extract the raw C pointers for the kernel. */
-  const double *spectra = static_cast<const double *>(PyArray_DATA(np_spectra));
-  const double *scaling = static_cast<const double *>(PyArray_DATA(np_scaling));
+  const double *spectra =
+      static_cast<const double *>(PyArray_DATA(np_spectra));
+  const double *scaling =
+      static_cast<const double *>(PyArray_DATA(np_scaling));
   double *out = static_cast<double *>(PyArray_DATA(np_out));
   const npy_bool *mask =
       np_mask == NULL ? NULL
@@ -824,8 +825,8 @@ PyObject *apply_separable_attenuation_2d(PyObject *self, PyObject *args) {
   PyObject *out_obj = Py_None;
   int nthreads;
 
-  if (!PyArg_ParseTuple(args, "OOOOi|O", &spectra_obj, &tau_v_obj, &tau_x_v_obj,
-                        &mask_obj, &nthreads, &out_obj)) {
+  if (!PyArg_ParseTuple(args, "OOOOi|O", &spectra_obj, &tau_v_obj,
+                        &tau_x_v_obj, &mask_obj, &nthreads, &out_obj)) {
     return NULL;
   }
 
@@ -943,10 +944,13 @@ PyObject *apply_separable_attenuation_2d(PyObject *self, PyObject *args) {
     }
   }
 
-  /* Turn the validated NumPy views into the raw pointers the kernels expect. */
-  const double *spectra = static_cast<const double *>(PyArray_DATA(np_spectra));
+  /* Turn the validated NumPy views into the raw pointers the kernels expect.
+   */
+  const double *spectra =
+      static_cast<const double *>(PyArray_DATA(np_spectra));
   const double *tau_v = static_cast<const double *>(PyArray_DATA(np_tau_v));
-  const double *tau_x_v = static_cast<const double *>(PyArray_DATA(np_tau_x_v));
+  const double *tau_x_v =
+      static_cast<const double *>(PyArray_DATA(np_tau_x_v));
   double *out = static_cast<double *>(PyArray_DATA(np_out));
   const npy_bool *mask =
       np_mask == NULL ? NULL
@@ -1070,8 +1074,8 @@ PyObject *multiply_array_by_vector_1d(PyObject *self, PyObject *args) {
   } else {
     /* Allocate a fresh output buffer with the same shape and memory layout as
      * the input array. */
-    np_out =
-        (PyArrayObject *)PyArray_NewLikeArray(np_array, NPY_KEEPORDER, NULL, 0);
+    np_out = (PyArrayObject *)PyArray_NewLikeArray(np_array, NPY_KEEPORDER,
+                                                   NULL, 0);
     if (np_out == NULL) {
       Py_DECREF(np_array);
       Py_DECREF(np_vector);
@@ -1093,7 +1097,7 @@ PyObject *multiply_array_by_vector_1d(PyObject *self, PyObject *args) {
   /* For 1D arrays nrows=1 and the outer loop runs once; for 2D each row
    * is scaled independently by the same vector. */
 #ifdef WITH_OPENMP
-#pragma omp parallel for if (nthreads > 1) num_threads(nthreads)               \
+#pragma omp parallel for if (nthreads > 1) num_threads(nthreads) \
     schedule(static)
 #endif
   for (int irow = 0; irow < nrows; irow++) {
@@ -1175,10 +1179,13 @@ static void scale_line_2d_no_mask_serial(const double *__restrict__ lum,
  * @param nspec: The number of spectra rows.
  * @param nlam: The number of wavelength bins.
  */
-static void scale_line_2d_row_mask_serial(
-    const double *__restrict__ lum, const double *__restrict__ cont,
-    const double *scaling_lum, const double *scaling_cont, const npy_bool *mask,
-    double *out_lum, double *out_cont, int nspec, int nlam) {
+static void scale_line_2d_row_mask_serial(const double *__restrict__ lum,
+                                          const double *__restrict__ cont,
+                                          const double *scaling_lum,
+                                          const double *scaling_cont,
+                                          const npy_bool *mask,
+                                          double *out_lum, double *out_cont,
+                                          int nspec, int nlam) {
 
   /* Loop over every spectrum and dispatch based on the mask. */
   for (int i = 0; i < nspec; i++) {
@@ -1269,9 +1276,9 @@ static void scale_line_2d_lam_mask_serial(const double *__restrict__ lum,
  */
 static void scale_line_2d_both_masks_serial(
     const double *__restrict__ lum, const double *__restrict__ cont,
-    const double *scaling_lum, const double *scaling_cont, const npy_bool *mask,
-    const npy_bool *lam_mask, double *out_lum, double *out_cont, int nspec,
-    int nlam) {
+    const double *scaling_lum, const double *scaling_cont,
+    const npy_bool *mask, const npy_bool *lam_mask, double *out_lum,
+    double *out_cont, int nspec, int nlam) {
 
   /* Loop over every spectrum and dispatch based on the row mask. */
   for (int i = 0; i < nspec; i++) {
@@ -1357,10 +1364,13 @@ static void scale_line_2d_no_mask_omp(const double *__restrict__ lum,
  * @param nlam: The number of wavelength bins.
  * @param nthreads: The number of OpenMP threads.
  */
-static void scale_line_2d_row_mask_omp(
-    const double *__restrict__ lum, const double *__restrict__ cont,
-    const double *scaling_lum, const double *scaling_cont, const npy_bool *mask,
-    double *out_lum, double *out_cont, int nspec, int nlam, int nthreads) {
+static void scale_line_2d_row_mask_omp(const double *__restrict__ lum,
+                                       const double *__restrict__ cont,
+                                       const double *scaling_lum,
+                                       const double *scaling_cont,
+                                       const npy_bool *mask, double *out_lum,
+                                       double *out_cont, int nspec, int nlam,
+                                       int nthreads) {
 
   /* Split the spectra rows evenly across threads. */
 #pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -1454,9 +1464,9 @@ static void scale_line_2d_lam_mask_omp(const double *__restrict__ lum,
  */
 static void scale_line_2d_both_masks_omp(
     const double *__restrict__ lum, const double *__restrict__ cont,
-    const double *scaling_lum, const double *scaling_cont, const npy_bool *mask,
-    const npy_bool *lam_mask, double *out_lum, double *out_cont, int nspec,
-    int nlam, int nthreads) {
+    const double *scaling_lum, const double *scaling_cont,
+    const npy_bool *mask, const npy_bool *lam_mask, double *out_lum,
+    double *out_cont, int nspec, int nlam, int nthreads) {
 
   /* Split the spectra rows evenly across threads. */
 #pragma omp parallel for num_threads(nthreads) schedule(static)
@@ -1524,8 +1534,8 @@ PyObject *scale_line_2d(PyObject *self, PyObject *args) {
   }
 
   /* Convert inputs to float64 NumPy array views. */
-  PyArrayObject *np_lum = (PyArrayObject *)PyArray_FROM_OTF(lum_obj, NPY_DOUBLE,
-                                                            NPY_ARRAY_IN_ARRAY);
+  PyArrayObject *np_lum = (PyArrayObject *)PyArray_FROM_OTF(
+      lum_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
   PyArrayObject *np_cont = (PyArrayObject *)PyArray_FROM_OTF(
       cont_obj, NPY_DOUBLE, NPY_ARRAY_IN_ARRAY);
   PyArrayObject *np_scaling_lum = (PyArrayObject *)PyArray_FROM_OTF(
@@ -1576,7 +1586,8 @@ PyObject *scale_line_2d(PyObject *self, PyObject *args) {
 
   /* Validate shapes. */
   if (PyArray_NDIM(np_lum) != 2 || PyArray_NDIM(np_cont) != 2 ||
-      PyArray_NDIM(np_scaling_lum) != 1 || PyArray_NDIM(np_scaling_cont) != 1) {
+      PyArray_NDIM(np_scaling_lum) != 1 ||
+      PyArray_NDIM(np_scaling_cont) != 1) {
     PyErr_SetString(PyExc_ValueError,
                     "lum and cont must be 2D, scalings must be 1D.");
     Py_DECREF(np_lum);
@@ -1588,14 +1599,16 @@ PyObject *scale_line_2d(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  /* Cache the common shape information once so the later checks stay simple. */
+  /* Cache the common shape information once so the later checks stay simple.
+   */
   const npy_intp *lum_dims = PyArray_DIMS(np_lum);
   const npy_intp *cont_dims = PyArray_DIMS(np_cont);
   const int nspec = static_cast<int>(lum_dims[0]);
   const int nlam = static_cast<int>(lum_dims[1]);
 
   if (cont_dims[0] != lum_dims[0] || cont_dims[1] != lum_dims[1]) {
-    PyErr_SetString(PyExc_ValueError, "lum and cont must have the same shape.");
+    PyErr_SetString(PyExc_ValueError,
+                    "lum and cont must have the same shape.");
     Py_DECREF(np_lum);
     Py_DECREF(np_cont);
     Py_DECREF(np_scaling_lum);
@@ -1618,8 +1631,8 @@ PyObject *scale_line_2d(PyObject *self, PyObject *args) {
     return NULL;
   }
 
-  if (np_mask != NULL &&
-      (PyArray_NDIM(np_mask) != 1 || PyArray_DIMS(np_mask)[0] != lum_dims[0])) {
+  if (np_mask != NULL && (PyArray_NDIM(np_mask) != 1 ||
+                          PyArray_DIMS(np_mask)[0] != lum_dims[0])) {
     PyErr_SetString(PyExc_ValueError,
                     "mask must be a 1D bool array matching rows.");
     Py_DECREF(np_lum);
@@ -1741,8 +1754,9 @@ PyObject *scale_line_2d(PyObject *self, PyObject *args) {
       scale_line_2d_row_mask_omp(lum, cont, scaling_lum, scaling_cont, mask,
                                  out_lum, out_cont, nspec, nlam, nthreads);
     } else if (!has_mask && has_lam_mask) {
-      scale_line_2d_lam_mask_omp(lum, cont, scaling_lum, scaling_cont, lam_mask,
-                                 out_lum, out_cont, nspec, nlam, nthreads);
+      scale_line_2d_lam_mask_omp(lum, cont, scaling_lum, scaling_cont,
+                                 lam_mask, out_lum, out_cont, nspec, nlam,
+                                 nthreads);
     } else {
       scale_line_2d_both_masks_omp(lum, cont, scaling_lum, scaling_cont, mask,
                                    lam_mask, out_lum, out_cont, nspec, nlam,
@@ -1831,8 +1845,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_spectra_operations(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/timers.cpp
+++ b/src/synthesizer/extensions/timers.cpp
@@ -13,14 +13,15 @@
  *     their own init time and cache the raw function pointer in timers.h.
  *   - At runtime, timers.h calls the cached pointer directly (no GIL).
  *****************************************************************************/
+#include "timers.h"
+
 #include <Python.h>
+
 #include <atomic>
 #include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#include "timers.h"
 
 /**
  * @brief Structure to hold timing data for a single operation.
@@ -41,8 +42,7 @@ struct OperationTimingData {
   /**
    * @brief Default constructor.
    */
-  OperationTimingData()
-      : cumulative_time(0.0), call_count(0), source("") {}
+  OperationTimingData() : cumulative_time(0.0), call_count(0), source("") {}
 
   /**
    * @brief Constructor with source specification.
@@ -61,8 +61,8 @@ struct OperationTimingData {
    */
   void add_time(double value) {
     double old_val = cumulative_time.load(std::memory_order_relaxed);
-    while (!cumulative_time.compare_exchange_weak(
-        old_val, old_val + value, std::memory_order_relaxed)) {
+    while (!cumulative_time.compare_exchange_weak(old_val, old_val + value,
+                                                  std::memory_order_relaxed)) {
       // Retry if another thread modified it
     }
   }
@@ -102,8 +102,10 @@ struct ActiveTimer {
   double accumulated_exclusive;
 
   ActiveTimer(const char *op, const char *src, double now)
-      : operation(op == nullptr ? "" : op), source(src == nullptr ? "" : src),
-        resume_time(now), accumulated_exclusive(0.0) {}
+      : operation(op == nullptr ? "" : op),
+        source(src == nullptr ? "" : src),
+        resume_time(now),
+        accumulated_exclusive(0.0) {}
 };
 
 /**
@@ -221,8 +223,7 @@ extern "C" void toc_stop(const char *msg, const char *source) {
 static PyObject *py_tic(PyObject *self, PyObject *args) {
   (void)self;
   char *msg;
-  if (!PyArg_ParseTuple(args, "s", &msg))
-    return NULL;
+  if (!PyArg_ParseTuple(args, "s", &msg)) return NULL;
 #ifdef ATOMIC_TIMING
   tic_start(msg, "Python");
 #endif
@@ -244,8 +245,7 @@ static PyObject *py_tic(PyObject *self, PyObject *args) {
 static PyObject *py_toc(PyObject *self, PyObject *args) {
   (void)self;
   char *msg;
-  if (!PyArg_ParseTuple(args, "s", &msg))
-    return NULL;
+  if (!PyArg_ParseTuple(args, "s", &msg)) return NULL;
 #ifdef ATOMIC_TIMING
   toc_stop(msg, "Python");
 #endif
@@ -286,8 +286,7 @@ static PyObject *py_get_operation_names(PyObject *self, PyObject *args) {
 static PyObject *py_get_operation_timings(PyObject *self, PyObject *args) {
   (void)self;
   const char *operation;
-  if (!PyArg_ParseTuple(args, "s", &operation))
-    return NULL;
+  if (!PyArg_ParseTuple(args, "s", &operation)) return NULL;
 
   std::lock_guard<std::mutex> lock(timings_mutex);
   // Find operation in map
@@ -317,8 +316,7 @@ static PyObject *py_get_operation_timings(PyObject *self, PyObject *args) {
 static PyObject *py_get_operation_source(PyObject *self, PyObject *args) {
   (void)self;
   const char *operation;
-  if (!PyArg_ParseTuple(args, "s", &operation))
-    return NULL;
+  if (!PyArg_ParseTuple(args, "s", &operation)) return NULL;
 
   std::lock_guard<std::mutex> lock(timings_mutex);
   // Find operation in map
@@ -370,8 +368,7 @@ static PyObject *py_test_toc_from_c(PyObject *self, PyObject *args) {
 #ifdef ATOMIC_TIMING
   char *msg;
   double elapsed_time;
-  if (!PyArg_ParseTuple(args, "sd", &msg, &elapsed_time))
-    return NULL;
+  if (!PyArg_ParseTuple(args, "sd", &msg, &elapsed_time)) return NULL;
 
   toc_accumulate(msg, elapsed_time, "C");
 #else
@@ -382,8 +379,7 @@ static PyObject *py_test_toc_from_c(PyObject *self, PyObject *args) {
 
 /* Module method table */
 static PyMethodDef TimerMethods[] = {
-    {"tic", py_tic, METH_VARARGS,
-     "Start a timer for a named operation."},
+    {"tic", py_tic, METH_VARARGS, "Start a timer for a named operation."},
     {"toc", py_toc, METH_VARARGS,
      "Stop a named timer and accumulate timing data."},
     {"get_operation_names", py_get_operation_names, METH_NOARGS,
@@ -404,7 +400,7 @@ static PyMethodDef TimerMethods[] = {
 /* Module definition */
 static struct PyModuleDef timermodule = {
     PyModuleDef_HEAD_INIT,
-    "timers",                             /* name of module */
+    "timers",                              /* name of module */
     "A module containing timer functions", /* module documentation */
     -1,                                    /* m_size */
     TimerMethods,                          /* m_methods */
@@ -417,8 +413,7 @@ static struct PyModuleDef timermodule = {
 /* Module initialization function */
 PyMODINIT_FUNC PyInit_timers(void) {
   PyObject *m = PyModule_Create(&timermodule);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
 
 #ifdef ATOMIC_TIMING
   /* Expose timer start callback for C++ extensions. */
@@ -448,8 +443,8 @@ PyMODINIT_FUNC PyInit_timers(void) {
   }
 
   /* Keep exposing toc_accumulate for testing helpers. */
-  PyObject *acc_capsule = PyCapsule_New((void *)toc_accumulate,
-                                        TOC_ACCUMULATE_CAPSULE_NAME, NULL);
+  PyObject *acc_capsule =
+      PyCapsule_New((void *)toc_accumulate, TOC_ACCUMULATE_CAPSULE_NAME, NULL);
   if (acc_capsule == NULL) {
     Py_DECREF(m);
     return NULL;

--- a/src/synthesizer/extensions/timers.h
+++ b/src/synthesizer/extensions/timers.h
@@ -27,6 +27,7 @@
 #define TIMERS_H_
 
 #include <time.h>
+
 #include <chrono>
 
 #ifdef WITH_OPENMP
@@ -37,12 +38,12 @@ inline double get_wall_time() {
 #if defined(CLOCK_MONOTONIC)
   struct timespec ts;
   if (clock_gettime(CLOCK_MONOTONIC, &ts) == 0) {
-    return static_cast<double>(ts.tv_sec)
-           + static_cast<double>(ts.tv_nsec) * 1.0e-9;
+    return static_cast<double>(ts.tv_sec) +
+           static_cast<double>(ts.tv_nsec) * 1.0e-9;
   }
 #endif
   auto now = std::chrono::steady_clock::now().time_since_epoch();
-  return std::chrono::duration_cast<std::chrono::duration<double>>(now)
+  return std::chrono::duration_cast<std::chrono::duration<double> >(now)
       .count();
 }
 #define GET_TIME() get_wall_time()
@@ -64,15 +65,13 @@ typedef void (*timer_stop_fn)(const char *, const char *);
 /** PyCapsule name for the timer start function pointer.
  *  Defined here (once) so timers.cpp and timers_init.h both use the
  *  same string. */
-#define TIC_START_CAPSULE_NAME                                                 \
-  "synthesizer.extensions.timers._tic_start"
+#define TIC_START_CAPSULE_NAME "synthesizer.extensions.timers._tic_start"
 
 /** PyCapsule name for the timer stop function pointer. */
-#define TOC_STOP_CAPSULE_NAME                                                  \
-  "synthesizer.extensions.timers._toc_stop"
+#define TOC_STOP_CAPSULE_NAME "synthesizer.extensions.timers._toc_stop"
 
 /** PyCapsule name for the accumulation helper function pointer. */
-#define TOC_ACCUMULATE_CAPSULE_NAME                                            \
+#define TOC_ACCUMULATE_CAPSULE_NAME \
   "synthesizer.extensions.timers._toc_accumulate"
 
 /**

--- a/src/synthesizer/extensions/weights.cpp
+++ b/src/synthesizer/extensions/weights.cpp
@@ -8,12 +8,13 @@
  * When compiled into another extension, PyInit_weights is dead code.
  *****************************************************************************/
 /* C includes */
-#include <array>
 #include <math.h>
-#include <new>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#include <array>
+#include <new>
 #include <vector>
 
 /* Python includes */
@@ -129,8 +130,8 @@ static void weight_loop_cic_serial(GridProps *grid_props, Particles *parts,
  *
  * @param grid_props: A struct containing the properties along each grid axis.
  * @param parts: A class containing the particle properties.
- * @param out_size: The size of the output array. (This will be allocated within
- *                  this function.)
+ * @param out_size: The size of the output array. (This will be allocated
+ * within this function.)
  * @param out: The output array.
  * @param nthreads: The number of threads to use.
  */
@@ -146,7 +147,7 @@ static void weight_loop_cic_omp(GridProps *grid_props, Particles *parts,
   const int ndim = grid_props->ndim;
 
   /* Set the sub cell constants we'll use below. */
-  const int num_sub_cells = 1 << ndim; // 2^ndim
+  const int num_sub_cells = 1 << ndim;  // 2^ndim
   std::array<int, MAX_GRID_NDIM> sub_dims;
   for (int i = 0; i < ndim; i++) {
     sub_dims[i] = 2;
@@ -174,8 +175,7 @@ static void weight_loop_cic_omp(GridProps *grid_props, Particles *parts,
     const int tid = omp_get_thread_num();
     const int start = tid * npart_per_thread;
     int end = start + npart_per_thread;
-    if (end > parts->npart)
-      end = parts->npart;
+    if (end > parts->npart) end = parts->npart;
 
     /* Allocate a local output array to avoid races. */
     std::vector<double> local_out_arr(out_size, 0.0);
@@ -489,7 +489,8 @@ PyObject *compute_grid_weights(PyObject *self, PyObject *args) {
 
   /* Allocate the sfzh array to output. */
   double *grid_weights = new (std::nothrow) double[grid_props->size]();
-  /* If allocation failed, clean up and return nullptr to propagate the MemoryError. */
+  /* If allocation failed, clean up and return nullptr to propagate the
+   * MemoryError. */
   if (grid_weights == nullptr) {
     PyErr_SetString(PyExc_MemoryError, "Could not allocate memory for sfzh.");
     delete part_props;
@@ -509,7 +510,8 @@ PyObject *compute_grid_weights(PyObject *self, PyObject *args) {
                     nthreads);
   } else {
     PyErr_SetString(PyExc_ValueError, "Unknown grid assignment method.");
-    /* Clean up all allocated memory before returning nullptr to propagate the ValueError. */
+    /* Clean up all allocated memory before returning nullptr to propagate the
+     * ValueError. */
     delete part_props;
     delete grid_props;
     delete[] grid_weights;
@@ -560,8 +562,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_weights(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -62,10 +62,10 @@ static inline int binary_search(int low, int high, const double *arr,
  * @param part_props: The properties of the particle.
  * @param p: The particle index.
  */
-static inline void
-get_part_ind_frac_cic(std::array<int, MAX_GRID_NDIM> &part_indices,
-                      std::array<double, MAX_GRID_NDIM> &axis_fracs,
-                      GridProps *grid_props, Particles *parts, int p) {
+static inline void get_part_ind_frac_cic(
+    std::array<int, MAX_GRID_NDIM> &part_indices,
+    std::array<double, MAX_GRID_NDIM> &axis_fracs, GridProps *grid_props,
+    Particles *parts, int p) {
 
   /* Loop over dimensions, finding the mass weightings and indices. */
   for (int dim = 0; dim < grid_props->ndim; dim++) {
@@ -128,9 +128,9 @@ get_part_ind_frac_cic(std::array<int, MAX_GRID_NDIM> &part_indices,
  * @param part_props: The properties of the particle.
  * @param p: The particle index.
  */
-static inline void
-get_part_inds_ngp(std::array<int, MAX_GRID_NDIM> &part_indices,
-                  GridProps *grid_props, Particles *parts, int p) {
+static inline void get_part_inds_ngp(
+    std::array<int, MAX_GRID_NDIM> &part_indices, GridProps *grid_props,
+    Particles *parts, int p) {
 
   /* Loop over dimensions finding the indices. */
   for (int dim = 0; dim < grid_props->ndim; dim++) {
@@ -178,9 +178,9 @@ get_part_inds_ngp(std::array<int, MAX_GRID_NDIM> &part_indices,
 }
 
 /* Prototypes */
-void weight_loop_cic(GridProps *grid, Particles *parts, int out_size, void *out,
-                     const int nthreads);
-void weight_loop_ngp(GridProps *grid, Particles *parts, int out_size, void *out,
-                     const int nthreads);
+void weight_loop_cic(GridProps *grid, Particles *parts, int out_size,
+                     void *out, const int nthreads);
+void weight_loop_ngp(GridProps *grid, Particles *parts, int out_size,
+                     void *out, const int nthreads);
 
-#endif // WEIGHTS_H_
+#endif  // WEIGHTS_H_

--- a/src/synthesizer/imaging/extensions/circular_aperture.cpp
+++ b/src/synthesizer/imaging/extensions/circular_aperture.cpp
@@ -19,8 +19,9 @@
 /* Python includes */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "../../extensions/numpy_init.h"
 #include <Python.h>
+
+#include "../../extensions/numpy_init.h"
 
 /* Local includes */
 #include "../../extensions/property_funcs.h"
@@ -35,8 +36,8 @@
 #endif
 
 /**
- * @brief Calculates the square root of a number, treating small negative values
- * as zero.
+ * @brief Calculates the square root of a number, treating small negative
+ * values as zero.
  *
  * @param x - The input value.
  * @return The square root of x if x >= 0, otherwise 0.
@@ -89,8 +90,8 @@ static double area_triangle(double x1, double y1, double x2, double y2,
 }
 
 /**
- * @brief Core function for calculating the area of overlap between a circle and
- * a rectangle.
+ * @brief Core function for calculating the area of overlap between a circle
+ * and a rectangle.
  *
  * @param xmin, ymin - Lower-left corner of the rectangle.
  * @param xmax, ymax - Upper-right corner of the rectangle.
@@ -147,7 +148,8 @@ static double circular_overlap_core(double xmin, double ymin, double xmax,
 }
 
 /**
- * @brief Calculates the exact area of overlap between a circle and a rectangle.
+ * @brief Calculates the exact area of overlap between a circle and a
+ * rectangle.
  *
  * @param xmin, ymin - Lower-left corner of the pixel.
  * @param xmax, ymax - Upper-right corner of the pixel.
@@ -161,7 +163,8 @@ static double circular_overlap_single_exact(double pix_xmin, double pix_ymin,
     if (0.0 <= pix_ymin) {
       return circular_overlap_core(pix_xmin, pix_ymin, pix_xmax, pix_ymax, r);
     } else if (0.0 >= pix_ymax) {
-      return circular_overlap_core(-pix_ymax, pix_xmin, -pix_ymin, pix_xmax, r);
+      return circular_overlap_core(-pix_ymax, pix_xmin, -pix_ymin, pix_xmax,
+                                   r);
     } else {
       return circular_overlap_single_exact(pix_xmin, pix_ymin, pix_xmax, 0.0,
                                            r) +
@@ -170,7 +173,8 @@ static double circular_overlap_single_exact(double pix_xmin, double pix_ymin,
     }
   } else if (0.0 >= pix_xmax) {
     if (0.0 <= pix_ymin) {
-      return circular_overlap_core(-pix_xmax, pix_ymin, -pix_xmin, pix_ymax, r);
+      return circular_overlap_core(-pix_xmax, pix_ymin, -pix_xmin, pix_ymax,
+                                   r);
     } else if (0.0 >= pix_ymax) {
       return circular_overlap_core(-pix_xmax, -pix_ymax, -pix_xmin, -pix_ymin,
                                    r);
@@ -277,7 +281,7 @@ static double calculate_overlap_omp(const double res, const double xmin,
 
   /* Loop over pixels and accumalate the pixel weight mulitiplied by pixel
    * values. */
-#pragma omp parallel for num_threads(nthreads) reduction(+ : signal)           \
+#pragma omp parallel for num_threads(nthreads) reduction(+ : signal) \
     schedule(dynamic)
   for (int i = 0; i < nx; i++) {
     double pxmin = xmin + i * res;
@@ -409,7 +413,7 @@ static PyMethodDef CircularOverlapMethods[] = {
 /* Define the module */
 static struct PyModuleDef circularoverlapmodule = {
     PyModuleDef_HEAD_INIT,
-    "circular_aperture", // name of module
+    "circular_aperture",  // name of module
     "Module for calculating the overlap area between a circle and a pixel "
     "grid.",
     -1,
@@ -426,8 +430,7 @@ PyMODINIT_FUNC PyInit_circular_aperture(void) {
     return NULL;
   }
   PyObject *m = PyModule_Create(&circularoverlapmodule);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
 #ifdef ATOMIC_TIMING
   if (import_toc_capsule() < 0) {
     Py_DECREF(m);

--- a/src/synthesizer/imaging/extensions/image.cpp
+++ b/src/synthesizer/imaging/extensions/image.cpp
@@ -3,22 +3,24 @@
  *****************************************************************************/
 
 /* C includes. */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <iostream>
-#include <math.h>
 #include <numeric>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <vector>
 
 /* Python includes. */
 #define PY_ARRAY_UNIQUE_SYMBOL SYNTHESIZER_ARRAY_API
 #define NO_IMPORT_ARRAY
-#include "../../extensions/numpy_init.h"
 #include <Python.h>
+
+#include "../../extensions/numpy_init.h"
 
 /* Local includes. */
 #include "../../extensions/cpp_to_python.h"
@@ -77,15 +79,14 @@ struct weighted_cell {
  *         false otherwise.
  */
 inline bool compare_by_cost(const weighted_cell &a, const weighted_cell &b) {
-  return a.cost > b.cost; // Descending order
+  return a.cost > b.cost;  // Descending order
 }
 
 /**
  * @brief Build balanced work list using adaptive subdivision
  */
-static std::vector<weighted_cell>
-build_balanced_work_list(struct cell *root, int nthreads,
-                         double balance_tolerance = 2.0) {
+static std::vector<weighted_cell> build_balanced_work_list(
+    struct cell *root, int nthreads, double balance_tolerance = 2.0) {
 
   tic("build_balanced_work_list");
 
@@ -93,7 +94,7 @@ build_balanced_work_list(struct cell *root, int nthreads,
   work_list.emplace_back(root);
 
   int target_cells =
-      std::max(2 * nthreads, 8); // At least 2x threads, minimum 8
+      std::max(2 * nthreads, 8);  // At least 2x threads, minimum 8
 
   while (true) {
     // Calculate statistics
@@ -104,8 +105,7 @@ build_balanced_work_list(struct cell *root, int nthreads,
     for (const auto &wc : work_list) {
       total_cost += wc.cost;
       max_cost = std::max(max_cost, wc.cost);
-      if (wc.can_subdivide)
-        subdividable_cells++;
+      if (wc.can_subdivide) subdividable_cells++;
     }
 
     double avg_cost = total_cost / work_list.size();
@@ -188,8 +188,9 @@ build_balanced_work_list(struct cell *root, int nthreads,
  */
 static void populate_pixel_recursive(const struct cell *c, double threshold,
                                      int kdim, const double *kernel,
-                                     double norm_factor, int npart, double *out,
-                                     int nimgs, const double *pix_values,
+                                     double norm_factor, int npart,
+                                     double *out, int nimgs,
+                                     const double *pix_values,
                                      const double res, const int npix_x,
                                      const int npix_y) {
 
@@ -226,7 +227,8 @@ static void populate_pixel_recursive(const struct cell *c, double threshold,
      * ensure we capture all affected pixels. */
     double buffer = max_kernel_radius + res;
 
-    /* Calculate the world coordinate bounds of the region this cell affects. */
+    /* Calculate the world coordinate bounds of the region this cell affects.
+     */
     double x_min_world = c->loc[0] - buffer;
     double x_max_world = c->loc[0] + c->width + buffer;
     double y_min_world = c->loc[1] - buffer;
@@ -255,7 +257,8 @@ static void populate_pixel_recursive(const struct cell *c, double threshold,
     /* Unpack the particles from this leaf cell. */
     struct particle *parts = c->particles;
 
-    /* Loop over the particles adding their contribution to the local buffer. */
+    /* Loop over the particles adding their contribution to the local buffer.
+     */
     for (int p = 0; p < c->part_count; p++) {
 
       /* Get the particle. */
@@ -333,11 +336,13 @@ static void populate_pixel_recursive(const struct cell *c, double threshold,
           if (local_i >= 0 && local_i < local_width && local_j >= 0 &&
               local_j < local_height) {
 
-            /* Loop over images and add the contribution to the local buffer. */
+            /* Loop over images and add the contribution to the local buffer.
+             */
             for (int nimg = 0; nimg < nimgs; nimg++) {
               int local_idx =
                   local_i * local_height * nimgs + local_j * nimgs + nimg;
-              if (local_idx >= 0 && static_cast<size_t>(local_idx) < local_img.size()) {
+              if (local_idx >= 0 &&
+                  static_cast<size_t>(local_idx) < local_img.size()) {
                 local_img[local_idx] +=
                     kvalue * pix_values[part->index * nimgs + nimg];
               }
@@ -536,9 +541,9 @@ void populate_smoothed_image(const double *pix_values, const double *kernel,
   (void)nthreads;
 
   /* If we don't have OpenMP call the serial version. */
-  populate_smoothed_image_serial(pix_values, kernel, res, npix_x, npix_y, npart,
-                                 threshold, kdim, norm_factor, img, nimgs,
-                                 root);
+  populate_smoothed_image_serial(pix_values, kernel, res, npix_x, npix_y,
+                                 npart, threshold, kdim, norm_factor, img,
+                                 nimgs, root);
 #endif
 
   toc("populate_smoothed_image");
@@ -658,8 +663,7 @@ static struct PyModuleDef moduledef = {
 
 PyMODINIT_FUNC PyInit_image(void) {
   PyObject *m = PyModule_Create(&moduledef);
-  if (m == NULL)
-    return NULL;
+  if (m == NULL) return NULL;
   if (numpy_import() < 0) {
     PyErr_SetString(PyExc_RuntimeError, "Failed to import numpy.");
     Py_DECREF(m);

--- a/src/synthesizer/imaging/extensions/kernel_smoothing_funcs.h
+++ b/src/synthesizer/imaging/extensions/kernel_smoothing_funcs.h
@@ -218,7 +218,7 @@ inline double pixel_inside_kernel_contribution(double pix_x_min,
                                                double threshold) {
 
   /* Use a small fixed grid to sample the pixel area (fast, deterministic). */
-  const int grid = 3; // 3x3 samples
+  const int grid = 3;  // 3x3 samples
   double sum = 0.0;
 
   for (int si = 0; si < grid; si++) {


### PR DESCRIPTION
Should have done this long ago, but this PR adds a config for clang-format, scripts to run it, and introduces it into the pre-commit hook and the CI. 

It also runs the formatter, which is why all C++ files have been "changed" it's all just formatting. 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added C++ code formatter configuration using Google style.
  * Introduced formatting validation in CI pipeline.
  * Added pre-commit hook for automatic C++ code formatting.
  * Created formatting script for extension source files.

* **Style**
  * Applied consistent C++ code formatting across extension modules and related source files, including include reordering, line wrapping, and whitespace normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->