### PR TITLE
Stop unyt_quantity objects triggering array error

### DIFF
--- a/src/synthesizer/emissions/line.py
+++ b/src/synthesizer/emissions/line.py
@@ -49,6 +49,7 @@ from unyt import (
     pc,
     s,
     unyt_array,
+    unyt_quantity,
 )
 
 from synthesizer import exceptions
@@ -1293,8 +1294,12 @@ class LineCollection:
                     f"({mask.shape}, {self.lum.shape})"
                 )
 
-        # If tau_v is an array it needs to match the spectra shape
-        if isinstance(tau_v, np.ndarray):
+        # If tau_v is an array it needs to match the spectra shape, note
+        # that we need a special case here because unyt_quantity resolves
+        # to true in isinstance checks despite being a scalar quantity
+        if isinstance(tau_v, np.ndarray) and not isinstance(
+            tau_v, unyt_quantity
+        ):
             if self._luminosity.ndim < 1:
                 raise exceptions.InconsistentArguments(
                     "Arrays of tau_v values are only applicable for Lines"

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1594,8 +1594,12 @@ class Sed:
                     f"({mask.shape}, {self._lnu.shape})"
                 )
 
-        # If tau_v is an array it needs to match the spectra shape
-        if isinstance(tau_v, np.ndarray):
+        # If tau_v is an array it needs to match the spectra shape, note
+        # that we need a special case here because unyt_quantity resolves
+        # to true in isinstance checks despite being a scalar quantity
+        if isinstance(tau_v, np.ndarray) and not isinstance(
+            tau_v, unyt_quantity
+        ):
             if self._lnu.ndim < 2:
                 raise exceptions.InconsistentArguments(
                     "Arrays of tau_v values are only applicable for Seds"


### PR DESCRIPTION
Because `unyt_quantity` objects resolve to `True` in `isinstace(val, np.ndarray)` we were incorrectly triggering error for `tau_v`s with dimensionless units. This fixes that issue.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attenuation validation in emission line and SED calculations to properly support different input value types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->