### PR TITLE
Introducing a method to change Grid precision

### DIFF
--- a/docs/source/emission_grids/grids_modify.ipynb
+++ b/docs/source/emission_grids/grids_modify.ipynb
@@ -146,6 +146,75 @@
     "# Get the flattened version of the axes\n",
     "flattened_axes_values = grid.get_flattened_axes_values()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b79330a-4df4-4b6f-8aaa-2ad4dff8f7d1",
+   "metadata": {},
+   "source": [
+    "## Adjusting Grid Precision\n",
+    "\n",
+    "In many circumstances you will want to take control of the floating precision of the data stored on a ``Grid``. By default this will in most cases be ``float64`` (double), but rarely is this level of precision needed, often ``float32`` (single) precision can be used and yield a reduced memory footprint.\n",
+    "\n",
+    "To load a grid directly with reduced precision, you can pass the ``use_precision`` argument at construction time:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d82f3a8e-f6ed-44a2-8c62-f8b566c1aab9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from synthesizer import Grid\n",
+    "\n",
+    "# Load the grid with float32 precision\n",
+    "grid32 = Grid(\n",
+    "    \"test_grid.hdf5\",\n",
+    "    grid_dir=\"../../../tests/test_grid\",\n",
+    "    use_precision=np.float32,\n",
+    ")\n",
+    "\n",
+    "print(\"Grid spectra dtype:\", grid32.spectra[\"incident\"].dtype)\n",
+    "print(\"Grid wavelength dtype:\", grid32.lam.dtype)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59db438d-a104-4046-b016-09e864173ae4",
+   "metadata": {},
+   "source": [
+    "You can also convert an already-loaded grid to a different precision using ``convert_precision``. By default this returns a new ``Grid`` object, leaving the original untouched:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ec029fe-6ed2-4bbb-a80a-c6a4e71d5651",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert an existing grid to float32 (returns a new copy)\n",
+    "grid = Grid(\"test_grid.hdf5\", grid_dir=\"../../../tests/test_grid\")\n",
+    "grid32 = grid.convert_precision(np.float32)\n",
+    "\n",
+    "print(\"Original dtype:\", grid.spectra[\"incident\"].dtype)\n",
+    "print(\"Converted dtype:\", grid32.spectra[\"incident\"].dtype)\n",
+    "\n",
+    "# Or convert in place\n",
+    "grid.convert_precision(np.float32, inplace=True)\n",
+    "print(\"After in-place conversion:\", grid.spectra[\"incident\"].dtype)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "598027f9-714c-4ea4-8773-9eb8a9d4a4e4",
+   "metadata": {},
+   "source": [
+    "Conversion covers all grid arrays: axes, spectra, line luminosities, and metadata such as the stellar fraction and ionising luminosities. Both ``np.float32`` and ``np.float64`` are supported."
+   ]
   }
  ],
  "metadata": {},

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -173,6 +173,9 @@ class Grid:
         # Set up cache for stellar fraction
         self._stellar_frac = None
 
+        # Track the target floating-point dtype for lazy-loaded arrays
+        self._dtype = np.float64
+
         # Get the axes of the grid from the HDF5 file
         self.axes = []  # axes names
         self._axes_values = {}
@@ -422,7 +425,9 @@ class Grid:
         if self._stellar_frac is None:
             with h5py.File(self.grid_filename, "r") as hf:
                 if "star_fraction" in hf.keys():
-                    self._stellar_frac = hf["star_fraction"][:]
+                    self._stellar_frac = np.array(
+                        hf["star_fraction"], dtype=self._dtype
+                    )
                 else:
                     raise exceptions.GridError(
                         f"Grid {self.grid_name} does not contain a stellar "
@@ -868,6 +873,9 @@ class Grid:
                 grid.log10_specific_ionising_lum[ion] = convert_array_dtype(
                     grid.log10_specific_ionising_lum[ion], dtype
                 )
+
+        # Track the target dtype for lazy-loaded arrays
+        grid._dtype = dtype
 
         # Convert the stellar fraction to the target precision, safe if we
         # don't have it

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -43,7 +43,7 @@ from synthesizer.synth_warnings import warn
 from synthesizer.units import Quantity, accepts
 from synthesizer.utils.ascii_table import TableFormatter
 from synthesizer.utils.operation_timers import timed
-from synthesizer.utils.util_funcs import as_contiguous
+from synthesizer.utils.util_funcs import as_contiguous, convert_array_dtype
 
 
 class Grid:
@@ -113,6 +113,7 @@ class Grid:
         ignore_lines=False,
         new_lam=None,
         lam_lims=(),
+        use_precision=None,
     ):
         """Initialise the grid object.
 
@@ -139,6 +140,9 @@ class Grid:
                 A tuple of the lower and upper wavelength limits to truncate
                 the grid to (i.e. (lower_lam, upper_lam)). If new_lam is
                 provided these limits will be ignored.
+            use_precision (np.dtype/type/None):
+                If provided, coerce the loaded grid arrays to either
+                ``np.float32`` or ``np.float64`` in place before returning.
         """
         # Get the grid file path data
         self.grid_dir = ""
@@ -211,6 +215,12 @@ class Grid:
                 + self.available_spectra_emissions
             )
         )
+
+        # If a precision has been passed we need to coerce everything
+        # on the grid to this precision. We do this inplace at this point
+        # because we want to modify self
+        if use_precision is not None:
+            self.convert_precision(use_precision, inplace=True)
 
     def _ensure_axis_data_contiguous(self):
         """Ensure stored axis arrays are contiguous."""
@@ -786,6 +796,86 @@ class Grid:
             lams = unyt_array(lams, lam_units).to(angstrom)
 
         return lines, lams
+
+    def convert_precision(self, precision, inplace=False):
+        """Convert loaded grid arrays to a single floating precision.
+
+        Args:
+            precision (np.dtype/type):
+                Target precision. Must resolve to ``np.float32`` or
+                ``np.float64``.
+            inplace (bool):
+                Whether to modify the current grid in place or return a new
+                grid object. Defaults to False.
+
+        Returns:
+            Grid/None:
+                If inplace=False, returns a new Grid object with converted
+                precision. If inplace=True, returns None and modifies the
+                current grid.
+        """
+        # Get the target dtype and check it's valid
+        dtype = np.dtype(precision)
+        if dtype not in (np.dtype(np.float32), np.dtype(np.float64)):
+            raise ValueError(
+                "precision must be either np.float32 or np.float64"
+            )
+
+        # Resolve whether we are modifying inplace or returning a new grid
+        grid = self if inplace else copy.deepcopy(self)
+
+        # Convert all the grid axis arrays to the target precision
+        for axis_name in grid.axes:
+            grid._axes_values[axis_name] = convert_array_dtype(
+                grid._axes_values[axis_name], dtype
+            )
+
+        # Convert all the extraction axis arrays to the target precision
+        # (helpful arrays that handle log10 conversions of the axes for us)
+        for axis_name in grid._extract_axes:
+            grid._extract_axes_values[axis_name] = convert_array_dtype(
+                grid._extract_axes_values[axis_name], dtype
+            )
+
+        # Convert the wavelengths to the target precision, safe if we don't
+        # have spectra
+        grid.lam = convert_array_dtype(grid.lam, dtype)
+
+        # Convert the line wavelengths to the target precision, safe if we
+        # don't have lines
+        grid.line_lams = convert_array_dtype(grid.line_lams, dtype)
+
+        # Convert all the spectra to the target precision
+        for spectra_id in grid.spectra:
+            grid.spectra[spectra_id] = convert_array_dtype(
+                grid.spectra[spectra_id], dtype
+            )
+
+        # Convert all the line luminosities and continuums to the target
+        for line_id in grid.line_lums:
+            grid.line_lums[line_id] = convert_array_dtype(
+                grid.line_lums[line_id], dtype
+            )
+        for line_id in grid.line_conts:
+            grid.line_conts[line_id] = convert_array_dtype(
+                grid.line_conts[line_id], dtype
+            )
+
+        # Convert the ionising luminosities to the target precision if we
+        # have them
+        if hasattr(grid, "log10_specific_ionising_lum"):
+            for ion in grid.log10_specific_ionising_lum:
+                grid.log10_specific_ionising_lum[ion] = convert_array_dtype(
+                    grid.log10_specific_ionising_lum[ion], dtype
+                )
+
+        # Convert the stellar fraction to the target precision, safe if we
+        # don't have it
+        grid._stellar_frac = convert_array_dtype(grid._stellar_frac, dtype)
+
+        # If we created a new grid object return it
+        if not inplace:
+            return grid
 
     @accepts(new_lam=angstrom)
     @timed("Grid.interp_spectra")

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -642,6 +642,51 @@ def as_contiguous(array):
     return np.ascontiguousarray(array)
 
 
+def convert_array_dtype(array, dtype):
+    """Convert a array-like object to a target dtype.
+
+    This works for NumPy arrays and unyt_arrays, preserving units for the
+    latter while ensuring the underlying storage is contiguous and of the
+    correct dtype.
+
+    Note that this will always make a copy of the array.
+
+    Args:
+        array (array-like):
+            The input array-like object.
+        dtype (np.dtype/type):
+            The target dtype to convert to.
+
+    Returns:
+        array-like:
+            Converted array with contiguous storage where applicable.
+    """
+    # Nothing to do if input is None
+    if array is None:
+        return None
+
+    # Handle the unyt_array case where we act on the underlying array and
+    # then reattach the units
+    if isinstance(array, unyt_array):
+        return unyt_array(
+            np.ascontiguousarray(array.ndview, dtype=dtype),
+            array.units,
+            bypass_validation=True,
+        )
+
+    # Convert to a plain NumPy array (always makes a copy)
+    array = np.array(array, copy=True)
+
+    # Validate it's floating-point
+    if not np.issubdtype(array.dtype, np.floating):
+        raise ValueError(
+            f"Unsupported array type or dtype for conversion: "
+            f"type(array)={type(array)}, dtype={getattr(array, 'dtype', None)}"
+        )
+
+    return np.ascontiguousarray(array, dtype=dtype)
+
+
 def get_attr_c_compatible_double(obj, attr):
     """Ensure an attribute of an object is compatible with our C extensions.
 

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -88,6 +88,49 @@ class TestGridInitialization:
         assert len(grid.line_lums) == 0
         assert len(grid.line_conts) == 0
 
+    def test_grid_with_use_precision(self, test_grid_name):
+        """Test Grid initialization with precision coercion."""
+        grid = Grid(test_grid_name, use_precision=np.float32)
+
+        assert grid.lam.dtype == np.float32
+        for axis in grid.axes:
+            assert grid._axes_values[axis].dtype == np.float32
+
+        for spectra in grid.spectra.values():
+            assert spectra.dtype == np.float32
+
+        if grid.has_lines:
+            assert grid.line_lams.dtype == np.float32
+            for line_lum in grid.line_lums.values():
+                assert line_lum.dtype == np.float32
+            for line_cont in grid.line_conts.values():
+                assert line_cont.dtype == np.float32
+
+    def test_grid_convert_precision_returns_new_grid(self, test_grid):
+        """Test precision conversion returns a new Grid by default."""
+        converted = test_grid.convert_precision(np.float32)
+
+        assert converted is not test_grid
+        assert converted.lam.dtype == np.float32
+        assert test_grid.lam.dtype != np.float32
+
+        for spectra in converted.spectra.values():
+            assert spectra.dtype == np.float32
+
+    def test_grid_convert_precision_inplace(self, test_grid_name):
+        """Test in-place precision conversion."""
+        grid = Grid(test_grid_name)
+        grid.convert_precision(np.float32, inplace=True)
+
+        assert grid.lam.dtype == np.float32
+        for axis in grid.axes:
+            assert grid._axes_values[axis].dtype == np.float32
+
+    def test_grid_convert_precision_invalid_dtype(self, test_grid):
+        """Test invalid precision raises a clear error."""
+        with pytest.raises(ValueError, match="precision must be either"):
+            test_grid.convert_precision(np.int32)
+
 
 class TestGridAxes:
     """Tests for Grid axis handling and attribute access."""


### PR DESCRIPTION
In preparation for the incoming precision changes, we need the ability to switch the ``Grid`` precision from its native loaded precision to the user-selected precision. This PR add that machinery. 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Control numeric precision for grid data (float32 or float64) at load time and convert existing grids, with optional in-place or copy semantics; conversion applies to all stored grid arrays and cached data and validates inputs.

* **Documentation**
  * Added a guide showing how to adjust grid precision and verify resulting numeric types.

* **Tests**
  * Added tests covering initialization with precision, conversion behavior (in-place vs new copy), and invalid-precision errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->