### PR TITLE
remove stasmodels dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,6 @@ dependencies = [
   "tqdm",
   "requests",
   "pathos",
-  "statsmodels",
   "pympler",
   "platformdirs",
 ]


### PR DESCRIPTION
DWISOTT. no longer required.

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused dependency to streamline project requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->