### PR TITLE
Fix redshift dtype issue in flux density calculation

### DIFF
--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1177,7 +1177,7 @@ class Sed:
             self._obsnu = np.empty_like(self._nu)
 
         # Calculate the observed wavelength and frequency
-        one_plus_z = 1.0 + z
+        one_plus_z = 1.0 + float(z)
         luminosity_distance_cm = get_luminosity_distance(cosmo, z).to_value(cm)
         conversion = (
             get_attr_unit_conversion(


### PR DESCRIPTION
Fix an edge case I encountered in synference where if your redshift has a numpy dtype and is not a python float, the `compute_fnu` C extension outputs perfect 0's for flux density rather than the correct value.

This simply casts the redshift to a float before it is used to ensure it works. There could be other versions of this edge case in other C extensions as well

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved numeric precision in redshift-related calculations for flux computations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->