### PR TITLE
Propagating adaptive precision into the Photometry

### DIFF
--- a/docs/source/observables/photometry/galaxy_phot.ipynb
+++ b/docs/source/observables/photometry/galaxy_phot.ipynb
@@ -165,7 +165,7 @@
     "    emitter=\"galaxy\",\n",
     ")\n",
     "# Get the spectra\n",
-    "sed = gal.get_spectra(gal_total)\n",
+    "sed = gal.get_spectra(gal_total, out_dtype=np.float64)\n",
     "\n",
     "# Get fluxes\n",
     "gal.get_observed_spectra(cosmo)"
@@ -303,7 +303,7 @@
    "source": [
     "# Get the particle spectra\n",
     "pc_model.set_per_particle(True)\n",
-    "gal.stars.get_spectra(pc_model)\n",
+    "gal.stars.get_spectra(pc_model, out_dtype=np.float64)\n",
     "\n",
     "# Get the particle photometry\n",
     "gal.stars.get_particle_photo_lnu(filters)\n",
@@ -381,7 +381,7 @@
    "outputs": [],
    "source": [
     "# We haven't computed fluxes yet so lets do that first\n",
-    "gal.stars.get_spectra(pc_model)\n",
+    "gal.stars.get_spectra(pc_model, out_dtype=np.float64)\n",
     "gal.get_observed_spectra(cosmo)\n",
     "gal.stars.get_particle_photo_fnu(filters)\n",
     "\n",

--- a/profiling/precision/_helpers.py
+++ b/profiling/precision/_helpers.py
@@ -1,0 +1,44 @@
+"""Shared helpers for photometry precision/memory profiling scripts."""
+
+from __future__ import annotations
+
+import numpy as np
+from unyt import angstrom
+
+from synthesizer.instruments import FilterCollection
+
+
+def make_synthetic_spectra(nparticles, nlam, dtype, rng):
+    """Create a contiguous synthetic 2D spectra array."""
+    lam_axis = np.linspace(-3.0, 3.0, nlam, dtype=np.float64)
+    base = np.exp(-0.5 * lam_axis**2) + 0.15 * np.sin(4.0 * lam_axis)
+    base = base[None, :]
+
+    amplitudes = rng.uniform(0.5, 2.0, size=(nparticles, 1))
+    slopes = rng.uniform(0.0, 0.2, size=(nparticles, 1))
+    continuum = np.linspace(0.8, 1.2, nlam, dtype=np.float64)[None, :]
+    spectra = amplitudes * base + slopes * continuum
+
+    return np.array(spectra, dtype=dtype, order="C", copy=True)
+
+
+def make_test_filters(lam, nfilters):
+    """Create a deterministic set of top-hat filters for profiling.
+
+    Using synthetic filters keeps the profiling scripts self-contained and
+    avoids depending on an external cached instrument file.
+    """
+    lam_values = lam.to("angstrom").value
+    lam_min = lam_values.min()
+    lam_max = lam_values.max()
+    centres = np.linspace(lam_min * 1.1, lam_max * 0.9, nfilters)
+    widths = np.full(nfilters, max((lam_max - lam_min) / (2 * nfilters), 50.0))
+
+    tophat_dict = {}
+    for i, (centre, width) in enumerate(zip(centres, widths, strict=True)):
+        tophat_dict[f"f{i + 1}"] = {
+            "lam_eff": centre * angstrom,
+            "lam_fwhm": width * angstrom,
+        }
+
+    return FilterCollection(tophat_dict=tophat_dict, new_lam=lam)

--- a/profiling/precision/profile_photometry_memory_scaling.py
+++ b/profiling/precision/profile_photometry_memory_scaling.py
@@ -35,10 +35,10 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import psutil
-from unyt import angstrom, c
+from _helpers import make_synthetic_spectra, make_test_filters
+from unyt import c
 
 from synthesizer.grid import Grid
-from synthesizer.instruments import FilterCollection
 
 LOGGER = logging.getLogger(__name__)
 
@@ -49,43 +49,6 @@ PRECISIONS = {
     "float32": np.float32,
     "float64": np.float64,
 }
-
-
-def make_synthetic_spectra(nparticles, nlam, dtype, rng):
-    """Create a contiguous synthetic 2D spectra array."""
-    lam_axis = np.linspace(-3.0, 3.0, nlam, dtype=np.float64)
-    base = np.exp(-0.5 * lam_axis**2) + 0.15 * np.sin(4.0 * lam_axis)
-    base = base[None, :]
-
-    amplitudes = rng.uniform(0.5, 2.0, size=(nparticles, 1))
-    slopes = rng.uniform(0.0, 0.2, size=(nparticles, 1))
-    continuum = np.linspace(0.8, 1.2, nlam, dtype=np.float64)[None, :]
-    spectra = amplitudes * base + slopes * continuum
-
-    return np.array(spectra, dtype=dtype, order="C", copy=True)
-
-
-def make_test_filters(lam, nfilters):
-    """Create a deterministic set of top-hat filters for profiling.
-
-    Using synthetic filters keeps the profiling scripts self-contained and
-    avoids depending on an external cached instrument file in worker
-    subprocesses.
-    """
-    lam_values = lam.to("angstrom").value
-    lam_min = lam_values.min()
-    lam_max = lam_values.max()
-    centres = np.linspace(lam_min * 1.1, lam_max * 0.9, nfilters)
-    widths = np.full(nfilters, max((lam_max - lam_min) / (2 * nfilters), 50.0))
-
-    tophat_dict = {}
-    for i, (centre, width) in enumerate(zip(centres, widths, strict=True)):
-        tophat_dict[f"f{i + 1}"] = {
-            "lam_eff": centre * angstrom,
-            "lam_fwhm": width * angstrom,
-        }
-
-    return FilterCollection(tophat_dict=tophat_dict, new_lam=lam)
 
 
 def _sample_worker_case(
@@ -115,12 +78,12 @@ def _sample_worker_case(
 
     rss_start = psutil.Process().memory_info().rss / (1024**2)
     samples = []
-    stop_sampling = False
+    stop_sampling = threading.Event()
     interval = 1.0 / sample_freq_hz
 
     def sampler():
         next_sample = time.perf_counter()
-        while not stop_sampling:
+        while not stop_sampling.is_set():
             now = time.perf_counter()
             if now >= next_sample:
                 rss_mib = psutil.Process().memory_info().rss / (1024**2)
@@ -147,7 +110,7 @@ def _sample_worker_case(
             out_dtype=output_dtype,
         )
 
-    stop_sampling = True
+    stop_sampling.set()
     sampler_thread.join()
 
     rss_end = psutil.Process().memory_info().rss / (1024**2)

--- a/profiling/precision/profile_photometry_memory_scaling.py
+++ b/profiling/precision/profile_photometry_memory_scaling.py
@@ -1,8 +1,9 @@
 """Profile photometry memory across input and output precisions.
 
-This script benchmarks the batched photometry path for a 2D spectra array
-with shape ``(nparticles, nlam)``.  For each particle count, all four
-input/output precision combinations are profiled:
+This script benchmarks the batched photometry path for one isolated workload
+per subprocess: a 2D spectra array with shape ``(nparticles, nlam)``. For
+each particle count, all four input/output precision combinations are
+profiled:
 
 - float32 -> float32
 - float32 -> float64
@@ -10,8 +11,9 @@ input/output precision combinations are profiled:
 - float64 -> float64
 
 Memory (RSS) is sampled continuously at a configurable frequency by a
-background thread while the extension runs.  The x-axis is normalised to
-% progress so runtime does not affect the plot shape.
+background thread while each isolated worker process builds its inputs and runs
+the extension. The x-axis is normalised to % progress so runtime does not
+affect the plot shape.
 
 Usage:
     python profile_photometry_memory_scaling.py --basename test
@@ -22,6 +24,11 @@ from __future__ import annotations
 import argparse
 import csv
 import importlib.util
+import json
+import logging
+import subprocess
+import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -42,6 +49,8 @@ spec = importlib.util.spec_from_file_location(
 pipeline_test_data = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(pipeline_test_data)
 get_test_instrument = pipeline_test_data.get_test_instrument
+
+LOGGER = logging.getLogger(__name__)
 
 plt.rcParams["font.family"] = "DejaVu Serif"
 plt.rcParams["font.serif"] = ["Times New Roman"]
@@ -66,25 +75,28 @@ def make_synthetic_spectra(nparticles, nlam, dtype, rng):
     return np.array(spectra, dtype=dtype, order="C", copy=True)
 
 
-def _sample_photometry(
-    filters,
-    spectra,
-    nu,
-    out_dtype,
+def _sample_worker_case(
+    nparticles,
+    nfilters,
+    input_dtype_name,
+    output_dtype_name,
     nthreads,
     repeats,
     sample_freq_hz,
+    seed,
 ):
-    """Run photometry repeats while continuously sampling RSS.
+    """Run one isolated precision case while continuously sampling RSS.
 
-    RSS is sampled on a background daemon thread at ``sample_freq_hz``
-    using a busy-wait loop so the requested frequency is respected even
-    for sub-ms calls.
-
-    Returns (memory_trace, peak_mib).  Always includes at least a start
-    and end sample so even fast operations produce a visible trace.
+    The worker process starts from a fresh interpreter so previous profiling
+    cases cannot inflate the resident set of the current measurement.
+    Sampling starts before inputs are created so input precision differences
+    are reflected directly in the reported memory usage.
     """
-    rss_start = psutil.Process().memory_info().rss / 1e6
+    input_dtype = PRECISIONS[input_dtype_name]
+    output_dtype = PRECISIONS[output_dtype_name]
+    rng = np.random.default_rng(seed)
+
+    rss_start = psutil.Process().memory_info().rss / (1024**2)
     samples = []
     stop_sampling = False
     interval = 1.0 / sample_freq_hz
@@ -94,29 +106,141 @@ def _sample_photometry(
         while not stop_sampling:
             now = time.perf_counter()
             if now >= next_sample:
-                rss_mb = psutil.Process().memory_info().rss / 1e6
-                samples.append(rss_mb)
+                rss_mib = psutil.Process().memory_info().rss / (1024**2)
+                samples.append(rss_mib)
                 next_sample += interval
 
     sampler_thread = threading.Thread(target=sampler, daemon=True)
     sampler_thread.start()
 
+    grid = Grid("test_grid")
+    instrument = get_test_instrument(grid)
+    filters = instrument.filters.select(
+        *instrument.available_filters[:nfilters]
+    )
+    spectra = make_synthetic_spectra(nparticles, grid.nlam, input_dtype, rng)
+    nu = np.array(
+        (c / grid.lam).to("Hz").value,
+        dtype=input_dtype,
+        order="C",
+        copy=True,
+    )
+
+    result = None
     for _ in range(repeats):
-        filters.apply_filters(
-            spectra, nu=nu, nthreads=nthreads, out_dtype=out_dtype
+        result = filters.apply_filters(
+            spectra,
+            nu=nu,
+            nthreads=nthreads,
+            out_dtype=output_dtype,
         )
 
     stop_sampling = True
     sampler_thread.join()
 
-    rss_end = psutil.Process().memory_info().rss / 1e6
+    rss_end = psutil.Process().memory_info().rss / (1024**2)
+
+    # Keep allocated objects alive until after sampling ends so the trace
+    # reflects the full memory footprint of the isolated case.
+    _ = (grid, instrument, filters, spectra, nu, result)
 
     all_samples = [rss_start] + samples + [rss_end]
     n = len(all_samples)
-    memory_trace = [
-        (i / (n - 1) * 100.0, s) for i, s in enumerate(all_samples)
+    peak_rss_mib = max(all_samples)
+    memory_trace = []
+    for i, rss_mib in enumerate(all_samples):
+        memory_trace.append(
+            {
+                "pct_complete": i / (n - 1) * 100.0,
+                "rss_mib": rss_mib,
+                "delta_mib": rss_mib - rss_start,
+            }
+        )
+
+    return {
+        "baseline_rss_mib": rss_start,
+        "peak_rss_mib": peak_rss_mib,
+        "peak_delta_mib": peak_rss_mib - rss_start,
+        "memory_trace": memory_trace,
+    }
+
+
+def _run_worker_subprocess(
+    nparticles,
+    nfilters,
+    input_dtype_name,
+    output_dtype_name,
+    nthreads,
+    repeats,
+    sample_freq,
+    seed,
+):
+    """Run one profiling case in a fresh subprocess.
+
+    The worker serializes its result to JSON for the parent process to read.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as handle:
+        result_path = Path(handle.name)
+
+    command = [
+        sys.executable,
+        __file__,
+        "--worker-mode",
+        "--worker-output",
+        str(result_path),
+        "--worker-nparticles",
+        str(nparticles),
+        "--worker-nfilters",
+        str(nfilters),
+        "--worker-input-dtype",
+        input_dtype_name,
+        "--worker-output-dtype",
+        output_dtype_name,
+        "--worker-nthreads",
+        str(nthreads),
+        "--worker-repeats",
+        str(repeats),
+        "--worker-sample-freq",
+        str(sample_freq),
+        "--worker-seed",
+        str(seed),
     ]
-    return {"peak_mib": max(all_samples), "memory_trace": memory_trace}
+
+    try:
+        try:
+            subprocess.run(command, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as error:
+            LOGGER.error(
+                "Worker subprocess failed for %s -> %s at nparticles=%s\n"
+                "stdout:\n%s\n"
+                "stderr:\n%s",
+                input_dtype_name,
+                output_dtype_name,
+                nparticles,
+                error.stdout,
+                error.stderr,
+            )
+            raise
+        with result_path.open() as handle:
+            return json.load(handle)
+    finally:
+        result_path.unlink(missing_ok=True)
+
+
+def _run_worker_mode(args):
+    """Execute one isolated case and serialize the result to JSON."""
+    result = _sample_worker_case(
+        nparticles=args.worker_nparticles,
+        nfilters=args.worker_nfilters,
+        input_dtype_name=args.worker_input_dtype,
+        output_dtype_name=args.worker_output_dtype,
+        nthreads=args.worker_nthreads,
+        repeats=args.worker_repeats,
+        sample_freq_hz=args.worker_sample_freq,
+        seed=args.worker_seed,
+    )
+    with Path(args.worker_output).open("w") as handle:
+        json.dump(result, handle)
 
 
 def write_results_csv(results, output_path):
@@ -124,11 +248,15 @@ def write_results_csv(results, output_path):
     fieldnames = [
         "benchmark",
         "nparticles",
+        "nfilters",
         "input_dtype",
         "output_dtype",
         "pct_complete",
         "rss_mib",
-        "peak_mib",
+        "delta_mib",
+        "baseline_rss_mib",
+        "peak_rss_mib",
+        "peak_delta_mib",
     ]
 
     with output_path.open("w", newline="") as handle:
@@ -138,34 +266,66 @@ def write_results_csv(results, output_path):
 
 
 def plot_results(results, output_path):
-    """Plot RSS memory against % progress for each precision pair."""
-    figure, axis = plt.subplots(1, 1, figsize=(8, 6))
+    """Plot RSS above baseline against % progress for each precision pair."""
+    nparticle_values = sorted({row["nparticles"] for row in results})
+    figure, axes = plt.subplots(
+        len(nparticle_values),
+        1,
+        figsize=(8, 3.5 * len(nparticle_values)),
+        squeeze=False,
+        sharex=True,
+    )
 
-    for input_name in PRECISIONS:
-        for output_name in PRECISIONS:
-            rows = [
-                row
+    row_max_delta = {
+        nparticles: max(
+            (
+                row["delta_mib"]
                 for row in results
-                if row["input_dtype"] == input_name
-                and row["output_dtype"] == output_name
-            ]
-            rows.sort(key=lambda row: row["pct_complete"])
-            if not rows:
-                continue
-            xvals = [row["pct_complete"] for row in rows]
-            yvals = [row["rss_mib"] for row in rows]
-            axis.plot(
-                xvals,
-                yvals,
-                linewidth=1,
-                label=f"{input_name} -> {output_name}",
-            )
+                if row["nparticles"] == nparticles
+            ),
+            default=0.0,
+        )
+        for nparticles in nparticle_values
+    }
 
-    axis.set_xlabel("Progress through benchmark (%)")
-    axis.set_ylabel("RSS memory (MiB)")
-    axis.set_title("Photometry Memory Scaling")
-    axis.grid(True, alpha=0.3)
-    axis.legend(loc="best", fontsize=9)
+    for row_index, nparticles in enumerate(nparticle_values):
+        axis = axes[row_index][0]
+
+        for input_name in PRECISIONS:
+            for output_name in PRECISIONS:
+                rows = [
+                    row
+                    for row in results
+                    if row["nparticles"] == nparticles
+                    and row["input_dtype"] == input_name
+                    and row["output_dtype"] == output_name
+                ]
+                rows.sort(key=lambda row: row["pct_complete"])
+                if not rows:
+                    continue
+
+                axis.step(
+                    [row["pct_complete"] for row in rows],
+                    [row["delta_mib"] for row in rows],
+                    where="post",
+                    linewidth=1.2,
+                    label=f"{input_name} -> {output_name}",
+                )
+
+        axis.set_ylabel(f"nparticles={nparticles}\nRSS above baseline (MiB)")
+        axis.grid(True, alpha=0.3)
+        upper_limit = (
+            row_max_delta[nparticles] * 1.05
+            if row_max_delta[nparticles] > 0.0
+            else 1.0
+        )
+        axis.set_ylim(0.0, upper_limit)
+
+        if row_index == len(nparticle_values) - 1:
+            axis.set_xlabel("Progress through benchmark (%)")
+
+    axes[0][0].legend(loc="best", fontsize=9)
+    figure.suptitle("Photometry Memory Scaling")
     figure.tight_layout()
     figure.savefig(output_path, dpi=300, bbox_inches="tight")
     plt.close(figure)
@@ -182,15 +342,6 @@ def profile_photometry_memory_scaling(
     seed,
 ):
     """Run photometry memory scaling benchmarks."""
-    rng = np.random.default_rng(seed)
-
-    grid = Grid("test_grid")
-    instrument = get_test_instrument(grid)
-    filters = instrument.filters.select(
-        *instrument.available_filters[:nfilters]
-    )
-    nlam = grid.nlam
-
     output_dir = Path(out_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
     csv_path = output_dir / f"{basename}_photometry_memory_scaling.csv"
@@ -200,48 +351,43 @@ def profile_photometry_memory_scaling(
     for particle_count in nparticles:
         print(f"Profiling photometry memory for nparticles={particle_count}")
 
-        spectra_by_dtype = {}
-        nu_by_dtype = {}
-        for input_name, input_dtype in PRECISIONS.items():
-            spectra_by_dtype[input_name] = make_synthetic_spectra(
-                particle_count, nlam, input_dtype, rng
-            )
-            nu_by_dtype[input_name] = np.array(
-                (c / grid.lam).to("Hz").value,
-                dtype=input_dtype,
-                order="C",
-                copy=True,
-            )
-
         for input_name in PRECISIONS:
-            for output_name, output_dtype in PRECISIONS.items():
-                result = _sample_photometry(
-                    filters,
-                    spectra_by_dtype[input_name],
-                    nu_by_dtype[input_name],
-                    output_dtype,
-                    nthreads,
-                    repeats,
-                    sample_freq,
+            for output_name, _output_dtype in PRECISIONS.items():
+                result = _run_worker_subprocess(
+                    nparticles=particle_count,
+                    nfilters=nfilters,
+                    input_dtype_name=input_name,
+                    output_dtype_name=output_name,
+                    nthreads=nthreads,
+                    repeats=repeats,
+                    sample_freq=sample_freq,
+                    seed=seed,
                 )
 
-                peak = round(result["peak_mib"], 3)
-                for pct, rss_mib in result["memory_trace"]:
+                peak_rss = round(result["peak_rss_mib"], 3)
+                peak_delta = round(result["peak_delta_mib"], 3)
+                baseline = round(result["baseline_rss_mib"], 3)
+                for sample in result["memory_trace"]:
                     results.append(
                         {
                             "benchmark": "synthetic_2d",
                             "nparticles": int(particle_count),
+                            "nfilters": int(nfilters),
                             "input_dtype": input_name,
                             "output_dtype": output_name,
-                            "pct_complete": round(pct, 2),
-                            "rss_mib": round(rss_mib, 3),
-                            "peak_mib": peak,
+                            "pct_complete": round(sample["pct_complete"], 2),
+                            "rss_mib": round(sample["rss_mib"], 3),
+                            "delta_mib": round(sample["delta_mib"], 3),
+                            "baseline_rss_mib": baseline,
+                            "peak_rss_mib": peak_rss,
+                            "peak_delta_mib": peak_delta,
                         }
                     )
 
                 print(
                     f"  {input_name} -> {output_name}: "
-                    f"peak={peak:.3f}MiB, "
+                    f"peak_delta={peak_delta:.3f}MiB, "
+                    f"peak_rss={peak_rss:.3f}MiB, "
                     f"samples={len(result['memory_trace'])}"
                 )
 
@@ -302,7 +448,33 @@ if __name__ == "__main__":
         default=42,
         help="Random seed used for synthetic spectra generation.",
     )
+    parser.add_argument(
+        "--worker-mode",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parser.add_argument("--worker-output", type=str, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--worker-nparticles", type=int, help=argparse.SUPPRESS
+    )
+    parser.add_argument("--worker-nfilters", type=int, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--worker-input-dtype", type=str, help=argparse.SUPPRESS
+    )
+    parser.add_argument(
+        "--worker-output-dtype", type=str, help=argparse.SUPPRESS
+    )
+    parser.add_argument("--worker-nthreads", type=int, help=argparse.SUPPRESS)
+    parser.add_argument("--worker-repeats", type=int, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--worker-sample-freq", type=float, help=argparse.SUPPRESS
+    )
+    parser.add_argument("--worker-seed", type=int, help=argparse.SUPPRESS)
     args = parser.parse_args()
+
+    if args.worker_mode:
+        _run_worker_mode(args)
+        sys.exit(0)
 
     profile_photometry_memory_scaling(
         basename=args.basename,

--- a/profiling/precision/profile_photometry_memory_scaling.py
+++ b/profiling/precision/profile_photometry_memory_scaling.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import argparse
 import csv
-import importlib.util
 import json
 import logging
 import subprocess
@@ -36,19 +35,10 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import numpy as np
 import psutil
-from unyt import c
+from unyt import angstrom, c
 
 from synthesizer.grid import Grid
-
-pipeline_path = (
-    Path(__file__).parent.parent / "pipeline" / "pipeline_test_data.py"
-)
-spec = importlib.util.spec_from_file_location(
-    "pipeline_test_data", pipeline_path
-)
-pipeline_test_data = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(pipeline_test_data)
-get_test_instrument = pipeline_test_data.get_test_instrument
+from synthesizer.instruments import FilterCollection
 
 LOGGER = logging.getLogger(__name__)
 
@@ -75,6 +65,29 @@ def make_synthetic_spectra(nparticles, nlam, dtype, rng):
     return np.array(spectra, dtype=dtype, order="C", copy=True)
 
 
+def make_test_filters(lam, nfilters):
+    """Create a deterministic set of top-hat filters for profiling.
+
+    Using synthetic filters keeps the profiling scripts self-contained and
+    avoids depending on an external cached instrument file in worker
+    subprocesses.
+    """
+    lam_values = lam.to("angstrom").value
+    lam_min = lam_values.min()
+    lam_max = lam_values.max()
+    centres = np.linspace(lam_min * 1.1, lam_max * 0.9, nfilters)
+    widths = np.full(nfilters, max((lam_max - lam_min) / (2 * nfilters), 50.0))
+
+    tophat_dict = {}
+    for i, (centre, width) in enumerate(zip(centres, widths, strict=True)):
+        tophat_dict[f"f{i + 1}"] = {
+            "lam_eff": centre * angstrom,
+            "lam_fwhm": width * angstrom,
+        }
+
+    return FilterCollection(tophat_dict=tophat_dict, new_lam=lam)
+
+
 def _sample_worker_case(
     nparticles,
     nfilters,
@@ -89,12 +102,16 @@ def _sample_worker_case(
 
     The worker process starts from a fresh interpreter so previous profiling
     cases cannot inflate the resident set of the current measurement.
-    Sampling starts before inputs are created so input precision differences
-    are reflected directly in the reported memory usage.
+    Common setup is performed before sampling so the trace focuses on
+    precision-dependent input allocation and photometry execution rather than
+    one-time grid and filter preparation.
     """
     input_dtype = PRECISIONS[input_dtype_name]
     output_dtype = PRECISIONS[output_dtype_name]
     rng = np.random.default_rng(seed)
+
+    grid = Grid("test_grid")
+    filters = make_test_filters(grid.lam, nfilters)
 
     rss_start = psutil.Process().memory_info().rss / (1024**2)
     samples = []
@@ -113,11 +130,6 @@ def _sample_worker_case(
     sampler_thread = threading.Thread(target=sampler, daemon=True)
     sampler_thread.start()
 
-    grid = Grid("test_grid")
-    instrument = get_test_instrument(grid)
-    filters = instrument.filters.select(
-        *instrument.available_filters[:nfilters]
-    )
     spectra = make_synthetic_spectra(nparticles, grid.nlam, input_dtype, rng)
     nu = np.array(
         (c / grid.lam).to("Hz").value,
@@ -142,7 +154,7 @@ def _sample_worker_case(
 
     # Keep allocated objects alive until after sampling ends so the trace
     # reflects the full memory footprint of the isolated case.
-    _ = (grid, instrument, filters, spectra, nu, result)
+    _ = (grid, filters, spectra, nu, result)
 
     all_samples = [rss_start] + samples + [rss_end]
     n = len(all_samples)

--- a/profiling/precision/profile_photometry_memory_scaling.py
+++ b/profiling/precision/profile_photometry_memory_scaling.py
@@ -1,0 +1,316 @@
+"""Profile photometry memory across input and output precisions.
+
+This script benchmarks the batched photometry path for a 2D spectra array
+with shape ``(nparticles, nlam)``.  For each particle count, all four
+input/output precision combinations are profiled:
+
+- float32 -> float32
+- float32 -> float64
+- float64 -> float32
+- float64 -> float64
+
+Memory (RSS) is sampled continuously at a configurable frequency by a
+background thread while the extension runs.  The x-axis is normalised to
+% progress so runtime does not affect the plot shape.
+
+Usage:
+    python profile_photometry_memory_scaling.py --basename test
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.util
+import threading
+import time
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import psutil
+from unyt import c
+
+from synthesizer.grid import Grid
+
+pipeline_path = (
+    Path(__file__).parent.parent / "pipeline" / "pipeline_test_data.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "pipeline_test_data", pipeline_path
+)
+pipeline_test_data = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pipeline_test_data)
+get_test_instrument = pipeline_test_data.get_test_instrument
+
+plt.rcParams["font.family"] = "DejaVu Serif"
+plt.rcParams["font.serif"] = ["Times New Roman"]
+
+PRECISIONS = {
+    "float32": np.float32,
+    "float64": np.float64,
+}
+
+
+def make_synthetic_spectra(nparticles, nlam, dtype, rng):
+    """Create a contiguous synthetic 2D spectra array."""
+    lam_axis = np.linspace(-3.0, 3.0, nlam, dtype=np.float64)
+    base = np.exp(-0.5 * lam_axis**2) + 0.15 * np.sin(4.0 * lam_axis)
+    base = base[None, :]
+
+    amplitudes = rng.uniform(0.5, 2.0, size=(nparticles, 1))
+    slopes = rng.uniform(0.0, 0.2, size=(nparticles, 1))
+    continuum = np.linspace(0.8, 1.2, nlam, dtype=np.float64)[None, :]
+    spectra = amplitudes * base + slopes * continuum
+
+    return np.array(spectra, dtype=dtype, order="C", copy=True)
+
+
+def _sample_photometry(
+    filters,
+    spectra,
+    nu,
+    out_dtype,
+    nthreads,
+    repeats,
+    sample_freq_hz,
+):
+    """Run photometry repeats while continuously sampling RSS.
+
+    RSS is sampled on a background daemon thread at ``sample_freq_hz``
+    using a busy-wait loop so the requested frequency is respected even
+    for sub-ms calls.
+
+    Returns (memory_trace, peak_mib).  Always includes at least a start
+    and end sample so even fast operations produce a visible trace.
+    """
+    rss_start = psutil.Process().memory_info().rss / 1e6
+    samples = []
+    stop_sampling = False
+    interval = 1.0 / sample_freq_hz
+
+    def sampler():
+        next_sample = time.perf_counter()
+        while not stop_sampling:
+            now = time.perf_counter()
+            if now >= next_sample:
+                rss_mb = psutil.Process().memory_info().rss / 1e6
+                samples.append(rss_mb)
+                next_sample += interval
+
+    sampler_thread = threading.Thread(target=sampler, daemon=True)
+    sampler_thread.start()
+
+    for _ in range(repeats):
+        filters.apply_filters(
+            spectra, nu=nu, nthreads=nthreads, out_dtype=out_dtype
+        )
+
+    stop_sampling = True
+    sampler_thread.join()
+
+    rss_end = psutil.Process().memory_info().rss / 1e6
+
+    all_samples = [rss_start] + samples + [rss_end]
+    n = len(all_samples)
+    memory_trace = [
+        (i / (n - 1) * 100.0, s) for i, s in enumerate(all_samples)
+    ]
+    return {"peak_mib": max(all_samples), "memory_trace": memory_trace}
+
+
+def write_results_csv(results, output_path):
+    """Write per-sample benchmark results to a CSV file."""
+    fieldnames = [
+        "benchmark",
+        "nparticles",
+        "input_dtype",
+        "output_dtype",
+        "pct_complete",
+        "rss_mib",
+        "peak_mib",
+    ]
+
+    with output_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
+
+
+def plot_results(results, output_path):
+    """Plot RSS memory against % progress for each precision pair."""
+    figure, axis = plt.subplots(1, 1, figsize=(8, 6))
+
+    for input_name in PRECISIONS:
+        for output_name in PRECISIONS:
+            rows = [
+                row
+                for row in results
+                if row["input_dtype"] == input_name
+                and row["output_dtype"] == output_name
+            ]
+            rows.sort(key=lambda row: row["pct_complete"])
+            if not rows:
+                continue
+            xvals = [row["pct_complete"] for row in rows]
+            yvals = [row["rss_mib"] for row in rows]
+            axis.plot(
+                xvals,
+                yvals,
+                linewidth=1,
+                label=f"{input_name} -> {output_name}",
+            )
+
+    axis.set_xlabel("Progress through benchmark (%)")
+    axis.set_ylabel("RSS memory (MiB)")
+    axis.set_title("Photometry Memory Scaling")
+    axis.grid(True, alpha=0.3)
+    axis.legend(loc="best", fontsize=9)
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=300, bbox_inches="tight")
+    plt.close(figure)
+
+
+def profile_photometry_memory_scaling(
+    basename,
+    out_dir,
+    nparticles,
+    nfilters,
+    repeats,
+    nthreads,
+    sample_freq,
+    seed,
+):
+    """Run photometry memory scaling benchmarks."""
+    rng = np.random.default_rng(seed)
+
+    grid = Grid("test_grid")
+    instrument = get_test_instrument(grid)
+    filters = instrument.filters.select(
+        *instrument.available_filters[:nfilters]
+    )
+    nlam = grid.nlam
+
+    output_dir = Path(out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / f"{basename}_photometry_memory_scaling.csv"
+    plot_path = output_dir / f"{basename}_photometry_memory_scaling.png"
+
+    results = []
+    for particle_count in nparticles:
+        print(f"Profiling photometry memory for nparticles={particle_count}")
+
+        spectra_by_dtype = {}
+        nu_by_dtype = {}
+        for input_name, input_dtype in PRECISIONS.items():
+            spectra_by_dtype[input_name] = make_synthetic_spectra(
+                particle_count, nlam, input_dtype, rng
+            )
+            nu_by_dtype[input_name] = np.array(
+                (c / grid.lam).to("Hz").value,
+                dtype=input_dtype,
+                order="C",
+                copy=True,
+            )
+
+        for input_name in PRECISIONS:
+            for output_name, output_dtype in PRECISIONS.items():
+                result = _sample_photometry(
+                    filters,
+                    spectra_by_dtype[input_name],
+                    nu_by_dtype[input_name],
+                    output_dtype,
+                    nthreads,
+                    repeats,
+                    sample_freq,
+                )
+
+                peak = round(result["peak_mib"], 3)
+                for pct, rss_mib in result["memory_trace"]:
+                    results.append(
+                        {
+                            "benchmark": "synthetic_2d",
+                            "nparticles": int(particle_count),
+                            "input_dtype": input_name,
+                            "output_dtype": output_name,
+                            "pct_complete": round(pct, 2),
+                            "rss_mib": round(rss_mib, 3),
+                            "peak_mib": peak,
+                        }
+                    )
+
+                print(
+                    f"  {input_name} -> {output_name}: "
+                    f"peak={peak:.3f}MiB, "
+                    f"samples={len(result['memory_trace'])}"
+                )
+
+    write_results_csv(results, csv_path)
+    plot_results(results, plot_path)
+    print(f"Saved CSV to: {csv_path}")
+    print(f"Saved plot to: {plot_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--basename",
+        type=str,
+        default="test",
+        help="The basename of the output files.",
+    )
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        default="profiling/outputs",
+        help="The output directory for the CSV file and plot.",
+    )
+    parser.add_argument(
+        "--nparticles",
+        type=int,
+        nargs="+",
+        default=[10**3, 3 * 10**3, 10**4, 3 * 10**4, 10**5],
+        help="Particle counts to profile.",
+    )
+    parser.add_argument(
+        "--nfilters",
+        type=int,
+        default=10,
+        help="The number of filters to use for photometry.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=5,
+        help="Calls per precision combo (lengthens sample window).",
+    )
+    parser.add_argument(
+        "--nthreads",
+        type=int,
+        default=1,
+        help="The number of threads to use for each photometry call.",
+    )
+    parser.add_argument(
+        "--sample-freq",
+        type=float,
+        default=10000.0,
+        help="RSS sampling frequency in Hz (busy-wait).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed used for synthetic spectra generation.",
+    )
+    args = parser.parse_args()
+
+    profile_photometry_memory_scaling(
+        basename=args.basename,
+        out_dir=args.out_dir,
+        nparticles=args.nparticles,
+        nfilters=args.nfilters,
+        repeats=args.repeats,
+        nthreads=args.nthreads,
+        sample_freq=args.sample_freq,
+        seed=args.seed,
+    )

--- a/profiling/precision/profile_photometry_precision_scaling.py
+++ b/profiling/precision/profile_photometry_precision_scaling.py
@@ -1,0 +1,284 @@
+"""Profile photometry scaling across input and output precisions.
+
+This script benchmarks the batched photometry path for one consistent workload:
+a 2D spectra array with shape ``(nparticles, nlam)``. For each particle count,
+all four input/output precision combinations are timed:
+
+- float32 -> float32
+- float32 -> float64
+- float64 -> float32
+- float64 -> float64
+
+Usage:
+    python profile_photometry_precision_scaling.py --basename test
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.util
+import time
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+from unyt import c
+
+from synthesizer.grid import Grid
+
+pipeline_path = (
+    Path(__file__).parent.parent / "pipeline" / "pipeline_test_data.py"
+)
+spec = importlib.util.spec_from_file_location(
+    "pipeline_test_data", pipeline_path
+)
+pipeline_test_data = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pipeline_test_data)
+get_test_instrument = pipeline_test_data.get_test_instrument
+
+plt.rcParams["font.family"] = "DejaVu Serif"
+plt.rcParams["font.serif"] = ["Times New Roman"]
+
+PRECISIONS = {
+    "float32": np.float32,
+    "float64": np.float64,
+}
+
+
+def make_synthetic_spectra(nparticles, nlam, dtype, rng):
+    """Create a contiguous synthetic 2D spectra array."""
+    lam_axis = np.linspace(-3.0, 3.0, nlam, dtype=np.float64)
+    base = np.exp(-0.5 * lam_axis**2) + 0.15 * np.sin(4.0 * lam_axis)
+    base = base[None, :]
+
+    amplitudes = rng.uniform(0.5, 2.0, size=(nparticles, 1))
+    slopes = rng.uniform(0.0, 0.2, size=(nparticles, 1))
+    continuum = np.linspace(0.8, 1.2, nlam, dtype=np.float64)[None, :]
+    spectra = amplitudes * base + slopes * continuum
+
+    return np.array(spectra, dtype=dtype, order="C", copy=True)
+
+
+def benchmark_photometry(filters, spectra, nu, out_dtype, nthreads, repeats):
+    """Time repeated photometry calls for a prepared spectra array."""
+    # Prime the extension and filter caches before timing.
+    filters.apply_filters(
+        spectra,
+        nu=nu,
+        nthreads=nthreads,
+        out_dtype=out_dtype,
+    )
+
+    times = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        filters.apply_filters(
+            spectra,
+            nu=nu,
+            nthreads=nthreads,
+            out_dtype=out_dtype,
+        )
+        times.append(time.perf_counter() - start)
+
+    times = np.array(times, dtype=np.float64)
+    return {
+        "mean_seconds": float(np.mean(times)),
+        "min_seconds": float(np.min(times)),
+        "std_seconds": float(np.std(times)),
+    }
+
+
+def write_results_csv(results, output_path):
+    """Write benchmark results to a CSV file."""
+    fieldnames = [
+        "benchmark",
+        "nparticles",
+        "input_dtype",
+        "output_dtype",
+        "mean_seconds",
+        "min_seconds",
+        "std_seconds",
+    ]
+
+    with output_path.open("w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
+
+
+def plot_results(results, output_path):
+    """Plot runtime against particle count for each precision pair."""
+    figure, axis = plt.subplots(1, 1, figsize=(8, 6))
+
+    for input_name in PRECISIONS:
+        for output_name in PRECISIONS:
+            rows = [
+                row
+                for row in results
+                if row["input_dtype"] == input_name
+                and row["output_dtype"] == output_name
+            ]
+            rows.sort(key=lambda row: row["nparticles"])
+            xvals = [row["nparticles"] for row in rows]
+            yvals = [row["mean_seconds"] for row in rows]
+            axis.plot(
+                xvals,
+                yvals,
+                marker="o",
+                label=f"{input_name} -> {output_name}",
+            )
+
+    axis.set_xscale("log")
+    axis.set_yscale("log")
+    axis.set_xlabel("Number of particles")
+    axis.set_ylabel("Mean runtime (seconds)")
+    axis.set_title("Photometry Precision Scaling")
+    axis.grid(True, which="both", alpha=0.3)
+    axis.legend(loc="best", fontsize=9)
+    figure.tight_layout()
+    figure.savefig(output_path, dpi=300, bbox_inches="tight")
+    plt.close(figure)
+
+
+def profile_photometry_precision_scaling(
+    basename,
+    out_dir,
+    nparticles,
+    nfilters,
+    repeats,
+    nthreads,
+    seed,
+):
+    """Run the photometry precision scaling benchmarks."""
+    rng = np.random.default_rng(seed)
+
+    grid = Grid("test_grid")
+    instrument = get_test_instrument(grid)
+    filters = instrument.filters.select(
+        *instrument.available_filters[:nfilters]
+    )
+    nlam = grid.nlam
+
+    output_dir = Path(out_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = output_dir / f"{basename}_photometry_precision_scaling.csv"
+    plot_path = output_dir / f"{basename}_photometry_precision_scaling.png"
+
+    results = []
+    for particle_count in nparticles:
+        print(
+            f"Profiling photometry precision for nparticles={particle_count}"
+        )
+
+        spectra_by_dtype = {}
+        nu_by_dtype = {}
+
+        base_spectra = make_synthetic_spectra(
+            particle_count,
+            nlam,
+            np.float64,
+            rng,
+        )
+        base_nu = np.array(
+            (c / grid.lam).to("Hz").value,
+            dtype=np.float64,
+            order="C",
+            copy=True,
+        )
+        for input_name, input_dtype in PRECISIONS.items():
+            spectra_by_dtype[input_name] = np.array(
+                base_spectra, dtype=input_dtype, order="C", copy=True
+            )
+            nu_by_dtype[input_name] = np.array(
+                base_nu, dtype=input_dtype, order="C", copy=True
+            )
+
+        for input_name, _input_dtype in PRECISIONS.items():
+            for output_name, output_dtype in PRECISIONS.items():
+                benchmark_result = benchmark_photometry(
+                    filters,
+                    spectra_by_dtype[input_name],
+                    nu_by_dtype[input_name],
+                    output_dtype,
+                    nthreads,
+                    repeats,
+                )
+                results.append(
+                    {
+                        "benchmark": "synthetic_2d",
+                        "nparticles": int(particle_count),
+                        "input_dtype": input_name,
+                        "output_dtype": output_name,
+                        **benchmark_result,
+                    }
+                )
+
+                print(
+                    "  "
+                    f"{input_name} -> {output_name}: "
+                    f"{benchmark_result['mean_seconds']:.6f}s"
+                )
+
+    write_results_csv(results, csv_path)
+    plot_results(results, plot_path)
+    print(f"Saved CSV to: {csv_path}")
+    print(f"Saved plot to: {plot_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--basename",
+        type=str,
+        default="test",
+        help="The basename of the output files.",
+    )
+    parser.add_argument(
+        "--out_dir",
+        type=str,
+        default="profiling/outputs",
+        help="The output directory for the CSV file and plot.",
+    )
+    parser.add_argument(
+        "--nparticles",
+        type=int,
+        nargs="+",
+        default=[10**3, 3 * 10**3, 10**4, 3 * 10**4, 10**5],
+        help="Particle counts to profile.",
+    )
+    parser.add_argument(
+        "--nfilters",
+        type=int,
+        default=10,
+        help="The number of filters to use for photometry.",
+    )
+    parser.add_argument(
+        "--repeats",
+        type=int,
+        default=5,
+        help="The number of timed repeats per precision combination.",
+    )
+    parser.add_argument(
+        "--nthreads",
+        type=int,
+        default=1,
+        help="The number of threads to use for each photometry call.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        help="Random seed used for synthetic spectra generation.",
+    )
+    args = parser.parse_args()
+
+    profile_photometry_precision_scaling(
+        basename=args.basename,
+        out_dir=args.out_dir,
+        nparticles=args.nparticles,
+        nfilters=args.nfilters,
+        repeats=args.repeats,
+        nthreads=args.nthreads,
+        seed=args.seed,
+    )

--- a/profiling/precision/profile_photometry_precision_scaling.py
+++ b/profiling/precision/profile_photometry_precision_scaling.py
@@ -17,25 +17,15 @@ from __future__ import annotations
 
 import argparse
 import csv
-import importlib.util
 import time
 from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
-from unyt import c
+from unyt import angstrom, c
 
 from synthesizer.grid import Grid
-
-pipeline_path = (
-    Path(__file__).parent.parent / "pipeline" / "pipeline_test_data.py"
-)
-spec = importlib.util.spec_from_file_location(
-    "pipeline_test_data", pipeline_path
-)
-pipeline_test_data = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(pipeline_test_data)
-get_test_instrument = pipeline_test_data.get_test_instrument
+from synthesizer.instruments import FilterCollection
 
 plt.rcParams["font.family"] = "DejaVu Serif"
 plt.rcParams["font.serif"] = ["Times New Roman"]
@@ -58,6 +48,28 @@ def make_synthetic_spectra(nparticles, nlam, dtype, rng):
     spectra = amplitudes * base + slopes * continuum
 
     return np.array(spectra, dtype=dtype, order="C", copy=True)
+
+
+def make_test_filters(lam, nfilters):
+    """Create a deterministic set of top-hat filters for profiling.
+
+    Using synthetic filters keeps the profiling scripts self-contained and
+    avoids depending on an external cached instrument file.
+    """
+    lam_values = lam.to("angstrom").value
+    lam_min = lam_values.min()
+    lam_max = lam_values.max()
+    centres = np.linspace(lam_min * 1.1, lam_max * 0.9, nfilters)
+    widths = np.full(nfilters, max((lam_max - lam_min) / (2 * nfilters), 50.0))
+
+    tophat_dict = {}
+    for i, (centre, width) in enumerate(zip(centres, widths, strict=True)):
+        tophat_dict[f"f{i + 1}"] = {
+            "lam_eff": centre * angstrom,
+            "lam_fwhm": width * angstrom,
+        }
+
+    return FilterCollection(tophat_dict=tophat_dict, new_lam=lam)
 
 
 def benchmark_photometry(filters, spectra, nu, out_dtype, nthreads, repeats):
@@ -154,10 +166,7 @@ def profile_photometry_precision_scaling(
     rng = np.random.default_rng(seed)
 
     grid = Grid("test_grid")
-    instrument = get_test_instrument(grid)
-    filters = instrument.filters.select(
-        *instrument.available_filters[:nfilters]
-    )
+    filters = make_test_filters(grid.lam, nfilters)
     nlam = grid.nlam
 
     output_dir = Path(out_dir)

--- a/profiling/precision/profile_photometry_precision_scaling.py
+++ b/profiling/precision/profile_photometry_precision_scaling.py
@@ -22,10 +22,10 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
-from unyt import angstrom, c
+from _helpers import make_synthetic_spectra, make_test_filters
+from unyt import c
 
 from synthesizer.grid import Grid
-from synthesizer.instruments import FilterCollection
 
 plt.rcParams["font.family"] = "DejaVu Serif"
 plt.rcParams["font.serif"] = ["Times New Roman"]
@@ -34,42 +34,6 @@ PRECISIONS = {
     "float32": np.float32,
     "float64": np.float64,
 }
-
-
-def make_synthetic_spectra(nparticles, nlam, dtype, rng):
-    """Create a contiguous synthetic 2D spectra array."""
-    lam_axis = np.linspace(-3.0, 3.0, nlam, dtype=np.float64)
-    base = np.exp(-0.5 * lam_axis**2) + 0.15 * np.sin(4.0 * lam_axis)
-    base = base[None, :]
-
-    amplitudes = rng.uniform(0.5, 2.0, size=(nparticles, 1))
-    slopes = rng.uniform(0.0, 0.2, size=(nparticles, 1))
-    continuum = np.linspace(0.8, 1.2, nlam, dtype=np.float64)[None, :]
-    spectra = amplitudes * base + slopes * continuum
-
-    return np.array(spectra, dtype=dtype, order="C", copy=True)
-
-
-def make_test_filters(lam, nfilters):
-    """Create a deterministic set of top-hat filters for profiling.
-
-    Using synthetic filters keeps the profiling scripts self-contained and
-    avoids depending on an external cached instrument file.
-    """
-    lam_values = lam.to("angstrom").value
-    lam_min = lam_values.min()
-    lam_max = lam_values.max()
-    centres = np.linspace(lam_min * 1.1, lam_max * 0.9, nfilters)
-    widths = np.full(nfilters, max((lam_max - lam_min) / (2 * nfilters), 50.0))
-
-    tophat_dict = {}
-    for i, (centre, width) in enumerate(zip(centres, widths, strict=True)):
-        tophat_dict[f"f{i + 1}"] = {
-            "lam_eff": centre * angstrom,
-            "lam_fwhm": width * angstrom,
-        }
-
-    return FilterCollection(tophat_dict=tophat_dict, new_lam=lam)
 
 
 def benchmark_photometry(filters, spectra, nu, out_dtype, nthreads, repeats):

--- a/setup.py
+++ b/setup.py
@@ -430,6 +430,7 @@ extensions = [
         "synthesizer.extensions.photometry",
         [
             "src/synthesizer/extensions/photometry.cpp",
+            "src/synthesizer/extensions/python_to_cpp.cpp",
             "src/synthesizer/extensions/property_funcs.cpp",
             "src/synthesizer/extensions/cpp_to_python.cpp",
             "src/synthesizer/extensions/part_props.cpp",

--- a/src/synthesizer/extensions/photometry.cpp
+++ b/src/synthesizer/extensions/photometry.cpp
@@ -583,7 +583,6 @@ static PyObject *compute_photometry_integration_impl(
   PyArrayObject *result =
       wrap_array_to_numpy<OutT>(spectra_ndim, result_shape, result_array);
   if (result == NULL) {
-    delete[] result_array;
     return NULL;
   }
 

--- a/src/synthesizer/extensions/photometry.cpp
+++ b/src/synthesizer/extensions/photometry.cpp
@@ -26,6 +26,8 @@
 
 /* C/C++ includes */
 #include <cstring>
+#include <memory>
+#include <new>
 #include <vector>
 
 #ifdef WITH_OPENMP
@@ -35,6 +37,7 @@
 /* Local includes */
 #include "cpp_to_python.h"
 #include "property_funcs.h"
+#include "python_to_cpp.h"
 
 /**
  * @brief Compact per-filter metadata for use in tight inner loops.
@@ -51,12 +54,13 @@
  *                         transmission.
  * @param inv_denominator: Precomputed 1.0 / denominator for this filter.
  */
+template <typename Real, typename OutT>
 struct FilterWork {
   npy_intp filter_index;
-  const double *weights;
+  const Real *weights;
   npy_int64 start;
   npy_int64 end;
-  double inv_denominator;
+  OutT inv_denominator;
 };
 
 /**
@@ -79,22 +83,21 @@ struct FilterWork {
  *
  * @return A vector of FilterWork descriptors for active filters only.
  */
-static std::vector<FilterWork> build_filter_work(const double *weight_matrix,
-                                                 const double *denominators,
-                                                 const npy_int64 *starts,
-                                                 const npy_int64 *ends,
-                                                 npy_intp wavelength_count,
-                                                 npy_intp nfilters) {
+template <typename Real, typename OutT>
+static std::vector<FilterWork<Real, OutT>> build_filter_work(
+    const Real *weight_matrix, const Real *denominators,
+    const npy_int64 *starts, const npy_int64 *ends, npy_intp wavelength_count,
+    npy_intp nfilters) {
 
   /* Pre-allocate space for up to nfilters entries. */
-  std::vector<FilterWork> work;
+  std::vector<FilterWork<Real, OutT>> work;
   work.reserve((size_t)nfilters);
 
   /* Walk through every filter and keep only the active ones. */
   for (npy_intp filter_index = 0; filter_index < nfilters; ++filter_index) {
     const npy_int64 start = starts[filter_index];
     const npy_int64 end = ends[filter_index];
-    const double denominator = denominators[filter_index];
+    const OutT denominator = static_cast<OutT>(denominators[filter_index]);
 
     /* Skip filters with zero denominator or fewer than 2 samples. */
     if (denominator == 0.0 || end - start < 2) {
@@ -102,12 +105,12 @@ static std::vector<FilterWork> build_filter_work(const double *weight_matrix,
     }
 
     /* Populate the work descriptor. */
-    FilterWork item;
+    FilterWork<Real, OutT> item;
     item.filter_index = filter_index;
     item.weights = &weight_matrix[filter_index * wavelength_count];
     item.start = start;
     item.end = end;
-    item.inv_denominator = 1.0 / denominator;
+    item.inv_denominator = static_cast<OutT>(1.0) / denominator;
     work.push_back(item);
   }
 
@@ -137,16 +140,17 @@ static std::vector<FilterWork> build_filter_work(const double *weight_matrix,
  *
  * @return Newly allocated filter-major result buffer, or NULL on failure.
  */
-static double *compute_photometry_trapz_serial(
-    const double *x_values, const double *spectra_values,
-    const std::vector<FilterWork> &filter_work, npy_intp wavelength_count,
-    npy_intp nentries, npy_intp nfilters) {
+template <typename Real, typename OutT>
+static OutT *compute_photometry_trapz_serial(
+    const Real *x_values, const Real *spectra_values,
+    const std::vector<FilterWork<Real, OutT>> &filter_work,
+    npy_intp wavelength_count, npy_intp nentries, npy_intp nfilters) {
 
   /* Allocate output directly in filter-major layout. calloc zeroes the
    * memory so inactive filter slots are already 0. */
-  double *filter_major =
-      (double *)calloc((size_t)(nentries * nfilters), sizeof(double));
-  if (filter_major == NULL) {
+  std::unique_ptr<OutT[]> filter_major(
+      new (std::nothrow) OutT[(size_t)(nentries * nfilters)]());
+  if (filter_major == nullptr) {
     return NULL;
   }
 
@@ -154,19 +158,23 @@ static double *compute_photometry_trapz_serial(
   for (npy_intp entry = 0; entry < nentries; ++entry) {
 
     /* Get a pointer to this entry's spectrum. */
-    const double *spectrum = &spectra_values[entry * wavelength_count];
+    const Real *spectrum = &spectra_values[entry * wavelength_count];
 
     /* Loop over active filters. */
-    for (const FilterWork &work : filter_work) {
+    for (const FilterWork<Real, OutT> &work : filter_work) {
 
       /* Accumulate the trapezoidal quadrature numerator over the
        * filter's non-zero support range [start, end). */
-      double numerator = 0.0;
+      OutT numerator = static_cast<OutT>(0.0);
       for (npy_int64 wavelength = work.start; wavelength < work.end - 1;
            ++wavelength) {
-        numerator += 0.5 * (x_values[wavelength + 1] - x_values[wavelength]) *
-                     (spectrum[wavelength + 1] * work.weights[wavelength + 1] +
-                      spectrum[wavelength] * work.weights[wavelength]);
+        numerator += static_cast<OutT>(0.5) *
+                     static_cast<OutT>(x_values[wavelength + 1] -
+                                       x_values[wavelength]) *
+                     (static_cast<OutT>(spectrum[wavelength + 1]) *
+                          static_cast<OutT>(work.weights[wavelength + 1]) +
+                      static_cast<OutT>(spectrum[wavelength]) *
+                          static_cast<OutT>(work.weights[wavelength]));
       }
 
       /* Divide by the precomputed denominator and store directly in
@@ -176,7 +184,7 @@ static double *compute_photometry_trapz_serial(
     }
   }
 
-  return filter_major;
+  return filter_major.release();
 }
 
 /**
@@ -200,15 +208,16 @@ static double *compute_photometry_trapz_serial(
  *
  * @return Newly allocated filter-major result buffer, or NULL on failure.
  */
-static double *compute_photometry_simps_serial(
-    const double *x_values, const double *spectra_values,
-    const std::vector<FilterWork> &filter_work, npy_intp wavelength_count,
-    npy_intp nentries, npy_intp nfilters) {
+template <typename Real, typename OutT>
+static OutT *compute_photometry_simps_serial(
+    const Real *x_values, const Real *spectra_values,
+    const std::vector<FilterWork<Real, OutT>> &filter_work,
+    npy_intp wavelength_count, npy_intp nentries, npy_intp nfilters) {
 
   /* Allocate output directly in filter-major layout. */
-  double *filter_major =
-      (double *)calloc((size_t)(nentries * nfilters), sizeof(double));
-  if (filter_major == NULL) {
+  std::unique_ptr<OutT[]> filter_major(
+      new (std::nothrow) OutT[(size_t)(nentries * nfilters)]());
+  if (filter_major == nullptr) {
     return NULL;
   }
 
@@ -216,10 +225,10 @@ static double *compute_photometry_simps_serial(
   for (npy_intp entry = 0; entry < nentries; ++entry) {
 
     /* Get a pointer to this entry's spectrum. */
-    const double *spectrum = &spectra_values[entry * wavelength_count];
+    const Real *spectrum = &spectra_values[entry * wavelength_count];
 
     /* Loop over active filters. */
-    for (const FilterWork &work : filter_work) {
+    for (const FilterWork<Real, OutT> &work : filter_work) {
 
       /* How many wavelength samples does this filter span? */
       const npy_int64 sample_count = work.end - work.start;
@@ -233,23 +242,30 @@ static double *compute_photometry_simps_serial(
       const bool has_tail = ((sample_count - 1) % 2) != 0;
 
       /* Accumulate the Simpson's quadrature numerator. */
-      double numerator = 0.0;
+      OutT numerator = static_cast<OutT>(0.0);
       for (npy_int64 pair_index = 0; pair_index < npairs; ++pair_index) {
         const npy_int64 k = work.start + 2 * pair_index;
-        numerator += (x_values[k + 2] - x_values[k]) *
-                     (spectrum[k] * work.weights[k] +
-                      4.0 * spectrum[k + 1] * work.weights[k + 1] +
-                      spectrum[k + 2] * work.weights[k + 2]) /
-                     6.0;
+        numerator +=
+            static_cast<OutT>(x_values[k + 2] - x_values[k]) *
+            (static_cast<OutT>(spectrum[k]) *
+                 static_cast<OutT>(work.weights[k]) +
+             static_cast<OutT>(4.0) * static_cast<OutT>(spectrum[k + 1]) *
+                 static_cast<OutT>(work.weights[k + 1]) +
+             static_cast<OutT>(spectrum[k + 2]) *
+                 static_cast<OutT>(work.weights[k + 2])) /
+            static_cast<OutT>(6.0);
       }
 
       /* If there is a leftover interval, add a trapezoidal step. */
       if (has_tail) {
         const npy_int64 k0 = work.end - 2;
         const npy_int64 k1 = work.end - 1;
-        numerator += 0.5 * (x_values[k1] - x_values[k0]) *
-                     (spectrum[k1] * work.weights[k1] +
-                      spectrum[k0] * work.weights[k0]);
+        numerator += static_cast<OutT>(0.5) *
+                     static_cast<OutT>(x_values[k1] - x_values[k0]) *
+                     (static_cast<OutT>(spectrum[k1]) *
+                          static_cast<OutT>(work.weights[k1]) +
+                      static_cast<OutT>(spectrum[k0]) *
+                          static_cast<OutT>(work.weights[k0]));
       }
 
       /* Divide by the precomputed denominator and store directly in
@@ -259,7 +275,7 @@ static double *compute_photometry_simps_serial(
     }
   }
 
-  return filter_major;
+  return filter_major.release();
 }
 
 #ifdef WITH_OPENMP
@@ -282,16 +298,18 @@ static double *compute_photometry_simps_serial(
  *
  * @return Newly allocated filter-major result buffer, or NULL on failure.
  */
-static double *compute_photometry_trapz_parallel(
-    const double *x_values, const double *spectra_values,
-    const std::vector<FilterWork> &filter_work, npy_intp wavelength_count,
-    npy_intp nentries, npy_intp nfilters, int nthreads) {
+template <typename Real, typename OutT>
+static OutT *compute_photometry_trapz_parallel(
+    const Real *x_values, const Real *spectra_values,
+    const std::vector<FilterWork<Real, OutT>> &filter_work,
+    npy_intp wavelength_count, npy_intp nentries, npy_intp nfilters,
+    int nthreads) {
 
   /* Allocate the output directly in filter-major layout. calloc zeroes the
    * memory so inactive filter slots are already 0. */
-  double *filter_major =
-      (double *)calloc((size_t)(nentries * nfilters), sizeof(double));
-  if (filter_major == NULL) {
+  std::unique_ptr<OutT[]> filter_major(
+      new (std::nothrow) OutT[(size_t)(nentries * nfilters)]());
+  if (filter_major == nullptr) {
     return NULL;
   }
 
@@ -311,19 +329,23 @@ static double *compute_photometry_trapz_parallel(
     const npy_intp af = work_idx % nactive;
 
     /* Get the filter work descriptor. */
-    const FilterWork &work = filter_work[(size_t)af];
+    const FilterWork<Real, OutT> &work = filter_work[(size_t)af];
 
     /* Get a pointer to this entry's spectrum. */
-    const double *spectrum = &spectra_values[entry * wavelength_count];
+    const Real *spectrum = &spectra_values[entry * wavelength_count];
 
     /* Accumulate the trapezoidal quadrature numerator over the
      * filter's non-zero support range [start, end). */
-    double numerator = 0.0;
+    OutT numerator = static_cast<OutT>(0.0);
     for (npy_int64 wavelength = work.start; wavelength < work.end - 1;
          ++wavelength) {
-      numerator += 0.5 * (x_values[wavelength + 1] - x_values[wavelength]) *
-                   (spectrum[wavelength + 1] * work.weights[wavelength + 1] +
-                    spectrum[wavelength] * work.weights[wavelength]);
+      numerator +=
+          static_cast<OutT>(0.5) *
+          static_cast<OutT>(x_values[wavelength + 1] - x_values[wavelength]) *
+          (static_cast<OutT>(spectrum[wavelength + 1]) *
+               static_cast<OutT>(work.weights[wavelength + 1]) +
+           static_cast<OutT>(spectrum[wavelength]) *
+               static_cast<OutT>(work.weights[wavelength]));
     }
 
     /* Write directly to the output. Each work_idx maps to a unique
@@ -332,7 +354,7 @@ static double *compute_photometry_trapz_parallel(
         numerator * work.inv_denominator;
   }
 
-  return filter_major;
+  return filter_major.release();
 }
 
 /**
@@ -354,15 +376,17 @@ static double *compute_photometry_trapz_parallel(
  *
  * @return Newly allocated filter-major result buffer, or NULL on failure.
  */
-static double *compute_photometry_simps_parallel(
-    const double *x_values, const double *spectra_values,
-    const std::vector<FilterWork> &filter_work, npy_intp wavelength_count,
-    npy_intp nentries, npy_intp nfilters, int nthreads) {
+template <typename Real, typename OutT>
+static OutT *compute_photometry_simps_parallel(
+    const Real *x_values, const Real *spectra_values,
+    const std::vector<FilterWork<Real, OutT>> &filter_work,
+    npy_intp wavelength_count, npy_intp nentries, npy_intp nfilters,
+    int nthreads) {
 
   /* Allocate the output directly in filter-major layout. */
-  double *filter_major =
-      (double *)calloc((size_t)(nentries * nfilters), sizeof(double));
-  if (filter_major == NULL) {
+  std::unique_ptr<OutT[]> filter_major(
+      new (std::nothrow) OutT[(size_t)(nentries * nfilters)]());
+  if (filter_major == nullptr) {
     return NULL;
   }
 
@@ -382,10 +406,10 @@ static double *compute_photometry_simps_parallel(
     const npy_intp af = work_idx % nactive;
 
     /* Get the filter work descriptor. */
-    const FilterWork &work = filter_work[(size_t)af];
+    const FilterWork<Real, OutT> &work = filter_work[(size_t)af];
 
     /* Get a pointer to this entry's spectrum. */
-    const double *spectrum = &spectra_values[entry * wavelength_count];
+    const Real *spectrum = &spectra_values[entry * wavelength_count];
 
     /* How many wavelength samples does this filter span? */
     const npy_int64 sample_count = work.end - work.start;
@@ -397,23 +421,30 @@ static double *compute_photometry_simps_parallel(
     const bool has_tail = ((sample_count - 1) % 2) != 0;
 
     /* Accumulate the Simpson's quadrature numerator. */
-    double numerator = 0.0;
+    OutT numerator = static_cast<OutT>(0.0);
     for (npy_int64 pair_index = 0; pair_index < npairs; ++pair_index) {
       const npy_int64 k = work.start + 2 * pair_index;
-      numerator += (x_values[k + 2] - x_values[k]) *
-                   (spectrum[k] * work.weights[k] +
-                    4.0 * spectrum[k + 1] * work.weights[k + 1] +
-                    spectrum[k + 2] * work.weights[k + 2]) /
-                   6.0;
+      numerator +=
+          static_cast<OutT>(x_values[k + 2] - x_values[k]) *
+          (static_cast<OutT>(spectrum[k]) *
+               static_cast<OutT>(work.weights[k]) +
+           static_cast<OutT>(4.0) * static_cast<OutT>(spectrum[k + 1]) *
+               static_cast<OutT>(work.weights[k + 1]) +
+           static_cast<OutT>(spectrum[k + 2]) *
+               static_cast<OutT>(work.weights[k + 2])) /
+          static_cast<OutT>(6.0);
     }
 
     /* If there is a leftover interval, add a trapezoidal step. */
     if (has_tail) {
       const npy_int64 k0 = work.end - 2;
       const npy_int64 k1 = work.end - 1;
-      numerator +=
-          0.5 * (x_values[k1] - x_values[k0]) *
-          (spectrum[k1] * work.weights[k1] + spectrum[k0] * work.weights[k0]);
+      numerator += static_cast<OutT>(0.5) *
+                   static_cast<OutT>(x_values[k1] - x_values[k0]) *
+                   (static_cast<OutT>(spectrum[k1]) *
+                        static_cast<OutT>(work.weights[k1]) +
+                    static_cast<OutT>(spectrum[k0]) *
+                        static_cast<OutT>(work.weights[k0]));
     }
 
     /* Write directly to the output. Each work_idx maps to a unique
@@ -422,9 +453,142 @@ static double *compute_photometry_simps_parallel(
         numerator * work.inv_denominator;
   }
 
-  return filter_major;
+  return filter_major.release();
 }
 #endif /* WITH_OPENMP */
+
+/**
+ * @brief Run batched photometry integration.
+ *
+ * The Python-facing wrapper resolves the shared input precision and requested
+ * output precision once, then dispatches here so the hot numerical loops can
+ * operate entirely on raw typed pointers.
+ *
+ * @tparam Real: Floating-point type shared by all input arrays.
+ * @tparam OutT: Floating-point type used for the returned array.
+ */
+template <typename Real, typename OutT>
+static PyObject *compute_photometry_integration_impl(
+    PyArrayObject *np_x_values, PyArrayObject *np_spectra_values,
+    PyArrayObject *np_weight_matrix, PyArrayObject *np_denominators,
+    PyArrayObject *np_starts, PyArrayObject *np_ends, int nthreads,
+    const char *integration_method) {
+  /* Extract shape information. */
+  npy_intp *spectra_shape = PyArray_SHAPE(np_spectra_values);
+  const npy_intp spectra_ndim = PyArray_NDIM(np_spectra_values);
+  const npy_intp wavelength_count = spectra_shape[spectra_ndim - 1];
+  const npy_intp nfilters = PyArray_DIM(np_weight_matrix, 0);
+
+  /* Extract typed C pointers from the validated numpy arrays. */
+  const Real *x_values = data_ptr<const Real>(np_x_values);
+  const Real *spectra_values = data_ptr<const Real>(np_spectra_values);
+  const Real *weight_matrix = data_ptr<const Real>(np_weight_matrix);
+  const Real *denominators = data_ptr<const Real>(np_denominators);
+  const npy_int64 *starts = extract_index_array(np_starts, "starts");
+  if (starts == NULL) {
+    return NULL;
+  }
+  const npy_int64 *ends = extract_index_array(np_ends, "ends");
+  if (ends == NULL) {
+    return NULL;
+  }
+
+  for (npy_intp f = 0; f < nfilters; ++f) {
+    if (starts[f] < 0 || ends[f] < 0 || starts[f] > ends[f] ||
+        ends[f] > wavelength_count) {
+      PyErr_SetString(PyExc_ValueError,
+                      "Filter band indices must satisfy 0 <= start <= end <= "
+                      "wavelength_count.");
+      return NULL;
+    }
+  }
+
+  /* The total number of spectra is the product of all leading dimensions.
+   * We flatten them for the C kernel and reshape on return. */
+  const npy_intp nentries = PyArray_SIZE(np_spectra_values) / wavelength_count;
+
+  /* Which integration method was requested? */
+  const bool use_simps = strcmp(integration_method, "simps") == 0;
+  const bool use_trapz = strcmp(integration_method, "trapz") == 0;
+
+  if (!use_simps && !use_trapz) {
+    PyErr_SetString(PyExc_ValueError,
+                    "method must be either 'trapz' or 'simps'.");
+    return NULL;
+  }
+
+  /* Build the compact work descriptors for active filters. */
+  const std::vector<FilterWork<Real, OutT>> filter_work =
+      build_filter_work<Real, OutT>(weight_matrix, denominators, starts, ends,
+                                    wavelength_count, nfilters);
+
+  /* Dispatch to the appropriate kernel. */
+  OutT *result_array = NULL;
+
+#ifdef WITH_OPENMP
+  /* If we have multiple threads and OpenMP we can parallelise. */
+  if (nthreads > 1) {
+    if (use_trapz) {
+      result_array = compute_photometry_trapz_parallel<Real, OutT>(
+          x_values, spectra_values, filter_work, wavelength_count, nentries,
+          nfilters, nthreads);
+    } else {
+      result_array = compute_photometry_simps_parallel<Real, OutT>(
+          x_values, spectra_values, filter_work, wavelength_count, nentries,
+          nfilters, nthreads);
+    }
+  }
+  /* Otherwise there's no point paying the OpenMP overhead. */
+  else {
+    if (use_trapz) {
+      result_array = compute_photometry_trapz_serial<Real, OutT>(
+          x_values, spectra_values, filter_work, wavelength_count, nentries,
+          nfilters);
+    } else {
+      result_array = compute_photometry_simps_serial<Real, OutT>(
+          x_values, spectra_values, filter_work, wavelength_count, nentries,
+          nfilters);
+    }
+  }
+#else
+  /* We don't have OpenMP, just call the serial version. */
+  if (use_trapz) {
+    result_array = compute_photometry_trapz_serial<Real, OutT>(
+        x_values, spectra_values, filter_work, wavelength_count, nentries,
+        nfilters);
+  } else {
+    result_array = compute_photometry_simps_serial<Real, OutT>(
+        x_values, spectra_values, filter_work, wavelength_count, nentries,
+        nfilters);
+  }
+#endif
+
+  /* Check for allocation failure in the kernel. */
+  if (result_array == NULL) {
+    PyErr_SetString(PyExc_MemoryError,
+                    "Failed to allocate photometry output arrays.");
+    return NULL;
+  }
+
+  /* Build the output shape: (nfilters, *leading_spectrum_shape).
+   * The leading dimensions of the input spectra become the trailing
+   * dimensions of the output (the wavelength axis is consumed). */
+  npy_intp result_shape[NPY_MAXDIMS];
+  result_shape[0] = nfilters;
+  for (npy_intp axis = 1; axis < spectra_ndim; ++axis) {
+    result_shape[axis] = spectra_shape[axis - 1];
+  }
+
+  /* Wrap the raw C array into a numpy array (transfers ownership). */
+  PyArrayObject *result =
+      wrap_array_to_numpy<OutT>(spectra_ndim, result_shape, result_array);
+  if (result == NULL) {
+    delete[] result_array;
+    return NULL;
+  }
+
+  return (PyObject *)result;
+}
 
 /**
  * @brief Python-facing entry point for batched photometry integration.
@@ -444,6 +608,7 @@ static double *compute_photometry_simps_parallel(
  *   - ends    (ndarray):  1D end indices per filter, shape (nfilters,).
  *   - nthreads (int):     Number of OpenMP threads requested.
  *   - method   (str):     Integration method, "trapz" or "simps".
+ *   - out_dtype (dtype):  Requested output dtype, float32 or float64.
  *
  * @return A numpy array of shape (nfilters, *leading_spectrum_shape).
  */
@@ -459,13 +624,14 @@ static PyObject *compute_photometry_integration(PyObject *self,
   PyArrayObject *np_denominators, *np_starts, *np_ends;
   int nthreads;
   const char *integration_method;
+  PyObject *out_dtype;
 
   /* Parse the positional arguments from the Python call. */
-  if (!PyArg_ParseTuple(args, "O!O!O!O!O!O!is", &PyArray_Type, &np_x_values,
+  if (!PyArg_ParseTuple(args, "O!O!O!O!O!O!isO", &PyArray_Type, &np_x_values,
                         &PyArray_Type, &np_spectra_values, &PyArray_Type,
                         &np_weight_matrix, &PyArray_Type, &np_denominators,
                         &PyArray_Type, &np_starts, &PyArray_Type, &np_ends,
-                        &nthreads, &integration_method)) {
+                        &nthreads, &integration_method, &out_dtype)) {
     return NULL;
   }
 
@@ -510,134 +676,45 @@ static PyObject *compute_photometry_integration(PyObject *self,
     return NULL;
   }
 
-  /* Extract C pointers from the numpy arrays. */
-  const double *x_values = extract_data_double(np_x_values, "xs");
-  if (x_values == NULL) {
+  /* Validate that all floating-point inputs share the same precision family.
+   * For the first mixed-precision pass we keep a single Real type for the
+   * whole call and let the user request the output precision independently. */
+  PyArrayObject *float_arrays[] = {np_x_values, np_spectra_values,
+                                   np_weight_matrix, np_denominators};
+  const char *float_names[] = {"xs", "spectra", "weights", "denominators"};
+  int input_typenum = -1;
+  if (!is_matching_float_dtypes(float_arrays, float_names, 4,
+                                &input_typenum)) {
     return NULL;
   }
 
-  const double *spectra_values =
-      extract_data_double(np_spectra_values, "spectra");
-  if (spectra_values == NULL) {
+  const int output_typenum = resolve_output_typenum(out_dtype, "out_dtype");
+  if (output_typenum < 0) {
     return NULL;
   }
 
-  const double *weight_matrix =
-      extract_data_double(np_weight_matrix, "weights");
-  if (weight_matrix == NULL) {
-    return NULL;
+  int dispatch_key =
+      ((input_typenum == NPY_FLOAT64) << 1) | (output_typenum == NPY_FLOAT64);
+
+  /* Dispatch: call the matching typed kernel based on the dispatch key. */
+  switch (dispatch_key) {
+    case 0:
+      return compute_photometry_integration_impl<float, float>(
+          np_x_values, np_spectra_values, np_weight_matrix, np_denominators,
+          np_starts, np_ends, nthreads, integration_method);
+    case 1:
+      return compute_photometry_integration_impl<float, double>(
+          np_x_values, np_spectra_values, np_weight_matrix, np_denominators,
+          np_starts, np_ends, nthreads, integration_method);
+    case 2:
+      return compute_photometry_integration_impl<double, float>(
+          np_x_values, np_spectra_values, np_weight_matrix, np_denominators,
+          np_starts, np_ends, nthreads, integration_method);
+    default:
+      return compute_photometry_integration_impl<double, double>(
+          np_x_values, np_spectra_values, np_weight_matrix, np_denominators,
+          np_starts, np_ends, nthreads, integration_method);
   }
-
-  const double *denominators =
-      extract_data_double(np_denominators, "denominators");
-  if (denominators == NULL) {
-    return NULL;
-  }
-
-  const npy_int64 *starts = extract_index_array(np_starts, "starts");
-  if (starts == NULL) {
-    return NULL;
-  }
-  const npy_int64 *ends = extract_index_array(np_ends, "ends");
-  if (ends == NULL) {
-    return NULL;
-  }
-
-  for (npy_intp f = 0; f < nfilters; ++f) {
-    if (starts[f] < 0 || ends[f] < 0 || starts[f] > ends[f] ||
-        ends[f] > wavelength_count) {
-      PyErr_SetString(PyExc_ValueError,
-                      "Filter band indices must satisfy 0 <= start <= end <= "
-                      "wavelength_count.");
-      return NULL;
-    }
-  }
-
-  /* The total number of spectra is the product of all leading dimensions.
-   * We flatten them for the C kernel and reshape on return. */
-  const npy_intp nentries = PyArray_SIZE(np_spectra_values) / wavelength_count;
-
-  /* Which integration method was requested? */
-  const bool use_simps = strcmp(integration_method, "simps") == 0;
-  const bool use_trapz = strcmp(integration_method, "trapz") == 0;
-
-  if (!use_simps && !use_trapz) {
-    PyErr_SetString(PyExc_ValueError,
-                    "method must be either 'trapz' or 'simps'.");
-    return NULL;
-  }
-
-  /* Build the compact work descriptors for active filters. */
-  const std::vector<FilterWork> filter_work = build_filter_work(
-      weight_matrix, denominators, starts, ends, wavelength_count, nfilters);
-
-  /* Dispatch to the appropriate kernel. */
-  double *result_array = NULL;
-
-#ifdef WITH_OPENMP
-  /* If we have multiple threads and OpenMP we can parallelise. */
-  if (nthreads > 1) {
-    if (use_trapz) {
-      result_array = compute_photometry_trapz_parallel(
-          x_values, spectra_values, filter_work, wavelength_count, nentries,
-          nfilters, nthreads);
-    } else {
-      result_array = compute_photometry_simps_parallel(
-          x_values, spectra_values, filter_work, wavelength_count, nentries,
-          nfilters, nthreads);
-    }
-  }
-  /* Otherwise there's no point paying the OpenMP overhead. */
-  else {
-    if (use_trapz) {
-      result_array = compute_photometry_trapz_serial(
-          x_values, spectra_values, filter_work, wavelength_count, nentries,
-          nfilters);
-    } else {
-      result_array = compute_photometry_simps_serial(
-          x_values, spectra_values, filter_work, wavelength_count, nentries,
-          nfilters);
-    }
-  }
-#else
-
-  /* We don't have OpenMP, just call the serial version. */
-  if (use_trapz) {
-    result_array =
-        compute_photometry_trapz_serial(x_values, spectra_values, filter_work,
-                                        wavelength_count, nentries, nfilters);
-  } else {
-    result_array =
-        compute_photometry_simps_serial(x_values, spectra_values, filter_work,
-                                        wavelength_count, nentries, nfilters);
-  }
-#endif
-
-  /* Check for allocation failure in the kernel. */
-  if (result_array == NULL) {
-    PyErr_SetString(PyExc_MemoryError,
-                    "Failed to allocate photometry output arrays.");
-    return NULL;
-  }
-
-  /* Build the output shape: (nfilters, *leading_spectrum_shape).
-   * The leading dimensions of the input spectra become the trailing
-   * dimensions of the output (the wavelength axis is consumed). */
-  npy_intp result_shape[NPY_MAXDIMS];
-  result_shape[0] = nfilters;
-  for (npy_intp axis = 1; axis < spectra_ndim; ++axis) {
-    result_shape[axis] = spectra_shape[axis - 1];
-  }
-
-  /* Wrap the raw C array into a numpy array (transfers ownership). */
-  PyArrayObject *result =
-      wrap_array_to_numpy<double>(spectra_ndim, result_shape, result_array);
-  if (result == NULL) {
-    free(result_array);
-    return NULL;
-  }
-
-  return (PyObject *)result;
 }
 
 /* Below is all the gubbins needed to make the module importable in Python. */

--- a/src/synthesizer/instruments/filters.py
+++ b/src/synthesizer/instruments/filters.py
@@ -47,7 +47,7 @@ from synthesizer.utils.integrate import (
     integrate_weighted_last_axis,
     trapezoid,
 )
-from synthesizer.utils.operation_timers import timed, timer
+from synthesizer.utils.operation_timers import timed
 
 
 @accepts(new_lam=angstrom)
@@ -1026,9 +1026,8 @@ class FilterCollection:
         if self.lam is None or self.nfilters == 0:
             return
 
-        trans_2d = np.ascontiguousarray(
-            np.vstack([self.filters[code].t for code in self.filter_codes]),
-            dtype=np.float64,
+        trans_2d = np.vstack(
+            [self.filters[code].t for code in self.filter_codes]
         )
         nu_native = (c / self.lam).to("Hz").value
 
@@ -1071,6 +1070,13 @@ class FilterCollection:
             )
 
         xarr = xs
+        if xarr.dtype not in (np.float32, np.float64):
+            raise exceptions.InconsistentArguments(
+                "Batched filter integration requires a float32 or float64 "
+                f"grid (got {xarr.dtype})."
+            )
+
+        input_dtype = xarr.dtype
         cache_space = f"{space}_{method}"
         cache_key = self._grid_cache_key(xarr, cache_space)
         cached = self._batch_cache.get(cache_key)
@@ -1107,14 +1113,14 @@ class FilterCollection:
                         for code in self.filter_codes
                     ]
                 ),
-                dtype=np.float64,
+                dtype=input_dtype,
             )
 
-        weights = np.ascontiguousarray(trans / xarr, dtype=np.float64)
+        weights = np.ascontiguousarray(trans / xarr, dtype=input_dtype)
 
         starts = np.zeros(self.nfilters, dtype=np.int64)
         ends = np.zeros(self.nfilters, dtype=np.int64)
-        denominators = np.zeros(self.nfilters, dtype=np.float64)
+        denominators = np.zeros(self.nfilters, dtype=input_dtype)
         for i in range(self.nfilters):
             nonzero = np.flatnonzero(weights[i] != 0)
             if nonzero.size == 0:
@@ -1171,6 +1177,7 @@ class FilterCollection:
         nu=None,
         nthreads=1,
         integration_method="trapz",
+        out_dtype=np.float32,
     ):
         """Apply all filters to an array in a single batched integration.
 
@@ -1180,55 +1187,72 @@ class FilterCollection:
             nu (np.ndarray): Frequency grid.
             nthreads (int): Number of threads.
             integration_method (str): Integration method.
+            out_dtype (np.dtype): Requested floating-point dtype for the
+                returned photometry array. Input arrays must already be
+                contiguous and share one supported floating-point precision
+                family; no implicit casting is performed.
 
         Returns:
             np.ndarray:
                 Broadband values with shape (nfilters, *arr.shape[:-1]).
         """
+        # Get input array dtype
+        input_dtype = arr.dtype
+
+        # Ensure the wavelength or frequency grid is provided, or that a
+        # native grid is cached that matches the dtype of the input array
         if lam is None and nu is None:
-            native_payload = self._batch_cache.get(("__native__",))
-            xs = (
-                None if native_payload is None else native_payload["nu_native"]
-            )
-            if xs is None:
+            if self.lam is None:
                 raise exceptions.InconsistentArguments(
                     "No native frequency grid is cached. Provide lam/nu "
                     "or call prepare_for_grid first."
                 )
+
+            # The xs will be frequency values in Hz matching the input dtype
+            xs = np.asarray((c / self.lam).to("Hz").value, dtype=input_dtype)
             space = "nu"
+
+        # Frequencies provided, xs will be frequency values in Hz
         elif nu is not None:
-            xs = nu
+            xs = np.asarray(nu, dtype=input_dtype)
             space = "nu"
+
+        # Wavelengths provided, xs will be wavelength values in Angstrom
         else:
-            xs = lam
+            xs = np.asarray(lam, dtype=input_dtype)
             space = "lam"
 
+        # If nthreads is -1 we use all available threads
         if nthreads == -1:
             nthreads = os.cpu_count()
 
+        # Ensure the input array last dimension matches the grid size
         if arr.shape[-1] != xs.shape[0]:
             raise exceptions.InconsistentArguments(
                 "The shape of the integration grid and final axis of arr do "
                 f"not match (arr.shape={arr.shape}, xs.shape={np.shape(xs)})."
             )
 
+        # Get the cached weights and denominators for set of xs, or compute
+        # and cache them if not already cached.
         weights, denominators, starts, ends = self._get_batched_weights(
             xs,
             space=space,
             method=integration_method,
         )
 
-        with timer("FilterCollection.apply_filters.compute_photometry"):
-            return compute_photometry(
-                xs,
-                arr,
-                weights,
-                denominators,
-                starts,
-                ends,
-                nthreads,
-                integration_method,
-            )
+        # Get and return the photometry by applying the filter curves
+        return compute_photometry(
+            xs,
+            arr,
+            weights,
+            denominators,
+            starts,
+            ends,
+            nthreads,
+            integration_method,
+            out_dtype,
+        )
 
     def unify_with_grid(self, grid, loop_spectra=False):
         """Unify a grid with this FilterCollection.

--- a/src/synthesizer/instruments/filters.py
+++ b/src/synthesizer/instruments/filters.py
@@ -1190,7 +1190,8 @@ class FilterCollection:
             out_dtype (np.dtype): Requested floating-point dtype for the
                 returned photometry array. Input arrays must already be
                 contiguous and share one supported floating-point precision
-                family; no implicit casting is performed.
+                family. The ``lam`` / ``nu`` grid is implicitly cast to
+                match the input array's floating-point dtype.
 
         Returns:
             np.ndarray:

--- a/tests/test_photometry.py
+++ b/tests/test_photometry.py
@@ -116,6 +116,153 @@ def test_photometry_collection_select_preserves_lookup():
     np.testing.assert_allclose(sub["f3"].value, pc["f3"].value)
 
 
+def test_apply_filters_supports_float32_inputs_and_outputs():
+    """Batched photometry should preserve a float32 precision family."""
+    lam = np.linspace(1000, 5000, 500, dtype=np.float32) * angstrom
+    filters = _make_filters(lam)
+    nu = np.ascontiguousarray((c / lam).to("Hz").value, dtype=np.float32)
+    spectra = np.ascontiguousarray(
+        np.vstack(
+            [
+                np.ones(len(lam), dtype=np.float32),
+                np.linspace(0.1, 1.0, len(lam), dtype=np.float32),
+            ]
+        ),
+        dtype=np.float32,
+    )
+
+    photometry = filters.apply_filters(
+        spectra,
+        nu=nu,
+        integration_method="trapz",
+        out_dtype=np.float32,
+    )
+
+    assert photometry.dtype == np.float32
+
+
+def test_apply_filters_supports_float64_output_from_float32_inputs():
+    """Users should be able to request float64 output independently."""
+    lam = np.linspace(1000, 5000, 500, dtype=np.float32) * angstrom
+    filters = _make_filters(lam)
+    nu = np.ascontiguousarray((c / lam).to("Hz").value, dtype=np.float32)
+    spectra = np.ascontiguousarray(
+        np.vstack(
+            [
+                np.ones(len(lam), dtype=np.float32),
+                np.linspace(0.1, 1.0, len(lam), dtype=np.float32),
+            ]
+        ),
+        dtype=np.float32,
+    )
+
+    photometry = filters.apply_filters(
+        spectra,
+        nu=nu,
+        integration_method="trapz",
+        out_dtype=np.float64,
+    )
+
+    assert photometry.dtype == np.float64
+
+
+def test_apply_filters_precision_combinations_agree_with_float64_reference():
+    """Photometry precision combinations should agree within tolerance."""
+    lam = np.linspace(1000, 5000, 500) * angstrom
+    filters = _make_filters(lam)
+
+    spectra64 = np.ascontiguousarray(
+        np.vstack(
+            [
+                np.linspace(0.2, 1.4, len(lam), dtype=np.float64),
+                0.5 + 0.3 * np.sin(np.linspace(0.0, 8.0, len(lam))),
+                np.exp(-0.5 * np.linspace(-3.0, 3.0, len(lam)) ** 2),
+            ]
+        ),
+        dtype=np.float64,
+    )
+    nu64 = np.ascontiguousarray((c / lam).to("Hz").value, dtype=np.float64)
+
+    reference = filters.apply_filters(
+        spectra64,
+        nu=nu64,
+        integration_method="trapz",
+        out_dtype=np.float64,
+    )
+
+    spectra32 = np.ascontiguousarray(spectra64, dtype=np.float32)
+    nu32 = np.ascontiguousarray(nu64, dtype=np.float32)
+
+    float32_to_float32 = filters.apply_filters(
+        spectra32,
+        nu=nu32,
+        integration_method="trapz",
+        out_dtype=np.float32,
+    )
+    float32_to_float64 = filters.apply_filters(
+        spectra32,
+        nu=nu32,
+        integration_method="trapz",
+        out_dtype=np.float64,
+    )
+    float64_to_float32 = filters.apply_filters(
+        spectra64,
+        nu=nu64,
+        integration_method="trapz",
+        out_dtype=np.float32,
+    )
+
+    assert reference.dtype == np.float64
+    assert float32_to_float32.dtype == np.float32
+    assert float32_to_float64.dtype == np.float64
+    assert float64_to_float32.dtype == np.float32
+
+    np.testing.assert_allclose(
+        float32_to_float32,
+        reference,
+        rtol=5e-5,
+        atol=5e-7,
+    )
+    np.testing.assert_allclose(
+        float32_to_float64,
+        reference,
+        rtol=5e-5,
+        atol=5e-7,
+    )
+    np.testing.assert_allclose(
+        float64_to_float32,
+        reference,
+        rtol=5e-6,
+        atol=5e-8,
+    )
+
+
+def test_apply_filters_casts_lam_nu_to_input_dtype():
+    """apply_filters should cast lam/nu to match the spectra dtype."""
+    lam = np.linspace(1000, 5000, 500) * angstrom
+    filters = _make_filters(lam)
+    nu = np.ascontiguousarray((c / lam).to("Hz").value, dtype=np.float64)
+    spectra = np.ascontiguousarray(
+        np.vstack(
+            [
+                np.ones(len(lam), dtype=np.float32),
+                np.linspace(0.1, 1.0, len(lam), dtype=np.float32),
+            ]
+        ),
+        dtype=np.float32,
+    )
+
+    # Should not raise: nu (float64) is cast to match spectra (float32)
+    result = filters.apply_filters(
+        spectra,
+        nu=nu,
+        integration_method="trapz",
+        out_dtype=np.float32,
+    )
+    assert result.dtype == np.float32
+    assert result.shape == (3, 2)
+
+
 def test_photometry_collection_addition():
     """Photometry collections with matching filters should add."""
     lam = np.linspace(1000, 5000, 500) * angstrom


### PR DESCRIPTION
This PR includes the photometry portion of the precision templating from #1168. For photometry, there is a meaningful performance improvement by using lower precision.

<img width="2370" height="1770" alt="test_photometry_precision_scaling" src="https://github.com/user-attachments/assets/7915516a-84d8-4731-8aba-d8397b352e9f" />


## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `out_dtype` support (float32/float64) for photometry results, enabling mixed-precision output control.
  * Introduced benchmarking scripts to measure runtime and resident-memory scaling across precision pairs.
* **Documentation**
  * Updated the galaxy photometry documentation notebook to use float64 output generation.
* **Tests**
  * Added unit tests covering float32/float64 input/output combinations and verifying expected casting behavior for `lam`/`nu`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->