### PR TITLE
Adding dtype arguments to the loading machinery

### DIFF
--- a/src/synthesizer/emission_models/extractors/extractor.py
+++ b/src/synthesizer/emission_models/extractors/extractor.py
@@ -164,7 +164,7 @@ class Extractor(ABC):
             self._log_emitter_attr,
         ):
             # Get the attribute from the emitter
-            value = get_param(axis, model, None, emitter)
+            value = get_param(axis, model, None, emitter, preserve_units=True)
 
             # Convert the units if necessary
             if (
@@ -174,6 +174,8 @@ class Extractor(ABC):
                 and value.units != units
             ):
                 value = unyt_to_ndview(value, units)
+            elif isinstance(value, (unyt_array, unyt_quantity)):
+                value = value.value
 
             # We know that the extracted values must be arrays, this can not be
             # the case when we only have 1 value (i.e. a single particle, or

--- a/src/synthesizer/emission_models/generators/generator.py
+++ b/src/synthesizer/emission_models/generators/generator.py
@@ -155,6 +155,7 @@ class Generator(ABC):
             None,
             emitter,
             obj=self,
+            preserve_units=True,
         )
 
         # Check if any of the required parameters are missing

--- a/src/synthesizer/emission_models/utils.py
+++ b/src/synthesizer/emission_models/utils.py
@@ -10,8 +10,6 @@ import numpy as np
 from synthesizer import exceptions
 from synthesizer.utils import (
     depluralize,
-    ensure_array_c_compatible_double,
-    get_attr_c_compatible_double,
     pluralize,
 )
 
@@ -212,34 +210,20 @@ def get_param(
             ParameterFunction,
         ):
             value = model.fixed_parameters[param]
-            if not preserve_units:
-                value = ensure_array_c_compatible_double(value)
         else:
             value = model.fixed_parameters[param]
 
     # Check the emission next
     elif emission is not None and hasattr(emission, param):
-        value = (
-            getattr(emission, param)
-            if preserve_units
-            else get_attr_c_compatible_double(emission, param)
-        )
+        value = getattr(emission, param)
 
     # Check the emitter
     elif emitter is not None and hasattr(emitter, param):
-        value = (
-            getattr(emitter, param)
-            if preserve_units
-            else get_attr_c_compatible_double(emitter, param)
-        )
+        value = getattr(emitter, param)
 
     # Finally, if we have an additional object, check that
     elif obj is not None and hasattr(obj, param):
-        value = (
-            getattr(obj, param)
-            if preserve_units
-            else get_attr_c_compatible_double(obj, param)
-        )
+        value = getattr(obj, param)
 
     # Do we need to recursively look for the parameter? (We know we're only
     # looking on the emitter at this point)

--- a/src/synthesizer/emission_models/utils.py
+++ b/src/synthesizer/emission_models/utils.py
@@ -6,6 +6,7 @@ import inspect
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+from unyt import unyt_array, unyt_quantity
 
 from synthesizer import exceptions
 from synthesizer.utils import (
@@ -251,7 +252,12 @@ def get_param(
 
     # If we found a ParameterFunction, call it to get the value
     elif value is not None and isinstance(value, ParameterFunction):
-        return value(model, emission, emitter, obj)
+        result = value(model, emission, emitter, obj)
+        if not preserve_units and isinstance(
+            result, (unyt_array, unyt_quantity)
+        ):
+            result = result.value
+        return result
 
     # If we found a value, return it
     elif value is not None:
@@ -264,6 +270,10 @@ def get_param(
                 model_label=model.label,
                 value=value,
             )
+        if not preserve_units and isinstance(
+            value, (unyt_array, unyt_quantity)
+        ):
+            value = value.value
         return value
 
     # If we were finding a logged parameter but failed, try the non-logged
@@ -335,6 +345,10 @@ def get_param(
                 model_label=model.label,
                 value=value,
             )
+        if not preserve_units and isinstance(
+            value, (unyt_array, unyt_quantity)
+        ):
+            value = value.value
         return value
 
     # Otherwise raise an exception

--- a/src/synthesizer/emission_models/utils.py
+++ b/src/synthesizer/emission_models/utils.py
@@ -252,7 +252,13 @@ def get_param(
 
     # If we found a ParameterFunction, call it to get the value
     elif value is not None and isinstance(value, ParameterFunction):
-        result = value(model, emission, emitter, obj)
+        result = value(
+            model,
+            emission,
+            emitter,
+            obj,
+            preserve_units=preserve_units,
+        )
         if not preserve_units and isinstance(
             result, (unyt_array, unyt_quantity)
         ):
@@ -333,6 +339,21 @@ def get_param(
     # parameter value, so we use a sentinel object instead.
     if value is None and default is not _NO_DEFAULT:
         value = default
+
+    # If we found a ParameterFunction, call it to get the value
+    if value is not None and isinstance(value, ParameterFunction):
+        result = value(
+            model,
+            emission,
+            emitter,
+            obj,
+            preserve_units=preserve_units,
+        )
+        if not preserve_units and isinstance(
+            result, (unyt_array, unyt_quantity)
+        ):
+            result = result.value
+        return result
 
     # If we found a value, return it
     if value is not None:
@@ -506,7 +527,14 @@ class ParameterFunction:
                     "of the ParameterFunction."
                 )
 
-    def __call__(self, model, emission, emitter, obj=None):
+    def __call__(
+        self,
+        model,
+        emission,
+        emitter,
+        obj=None,
+        preserve_units=False,
+    ):
         """Call the wrapped function with parameters extracted from objects.
 
         This will extract the required parameters from the model, emission,
@@ -522,6 +550,8 @@ class ParameterFunction:
                 The emitter object.
             obj (object, optional):
                 An optional additional object to look for parameters on last.
+            preserve_units (bool, optional):
+                If True, preserve units while resolving function arguments.
 
         Returns:
             value:
@@ -536,6 +566,7 @@ class ParameterFunction:
                 emission,
                 emitter,
                 obj,
+                preserve_units=preserve_units,
             )
 
         # Call the function with the extracted parameters

--- a/src/synthesizer/load_data/__init__.py
+++ b/src/synthesizer/load_data/__init__.py
@@ -1,0 +1,32 @@
+"""Load simulation particle data into Synthesizer galaxy objects.
+
+Each loader in this module reads particle data from a specific simulation
+and populates :class:`~synthesizer.particle.galaxy.Galaxy` objects with
+stellar, gas, and optionally black-hole components.
+
+.. rubric:: Controlling array precision
+
+All loader functions accept a ``dtype`` parameter (default: ``np.float64``)
+that controls the floating-point precision of the particle arrays passed to
+:meth:`Galaxy.load_stars <synthesizer.particle.galaxy.Galaxy.load_stars>`
+and :meth:`Galaxy.load_gas <synthesizer.particle.galaxy.Galaxy.load_gas>`.
+
+Setting ``dtype=np.float32`` reduces memory usage and is compatible with
+grids opened with ``Grid(use_precision=np.float32)``.
+
+Available loaders
+-----------------
+- :func:`load_camels.load_CAMELS_IllustrisTNG`
+- :func:`load_camels.load_CAMELS_Astrid`
+- :func:`load_camels.load_CAMELS_Simba`
+- :func:`load_camels.load_CAMELS_SwiftEAGLE_subfind`
+- :func:`load_illustris.load_IllustrisTNG`
+- :func:`load_simba.load_Simba`
+- :func:`load_simba.load_Simba_slab`
+- :func:`load_flares.load_FLARES`
+- :func:`load_bluetides.load_BlueTides`
+- :func:`load_scsam.load_SCSAM`
+- :func:`load_yt.load_yt`
+"""
+
+import numpy as np  # noqa: F401 — referenced by module docstring

--- a/src/synthesizer/load_data/load_bluetides.py
+++ b/src/synthesizer/load_data/load_bluetides.py
@@ -242,6 +242,7 @@ def load_BlueTides(
     sort_bhar=True,
     bluetides_data_folder="",
     center=False,
+    dtype=np.float64,
 ):
     """Load BlueTides galaxies into a galaxy object.
 
@@ -268,8 +269,13 @@ def load_BlueTides(
             location of BlueTides pig/sunset files. Only required if
             dataholder is `None` (default is an empty string)
         center (bool):
-             whether or not to center the galaxy on the Bh
-             (default is False)
+            whether or not to center the galaxy on the Bh
+            (default is False)
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
 
     Returns:
         galaxies (object):
@@ -346,11 +352,11 @@ def load_BlueTides(
 
         coords = np.transpose([x, y, z])
         galaxies[ii].load_stars(
-            initial_masses=imasses * Msun,
-            ages=ages * Myr,
-            metals=metallicities,
-            coordinates=coords * kpc,
-            current_masses=masses * Msun,
+            initial_masses=(imasses * Msun).astype(dtype),
+            ages=(ages * Myr).astype(dtype),
+            metals=metallicities.astype(dtype),
+            coordinates=(coords * kpc).astype(dtype),
+            current_masses=(masses * Msun).astype(dtype),
             smoothing_lengths=smoothing_lengths,
         )
 

--- a/src/synthesizer/load_data/load_bluetides.py
+++ b/src/synthesizer/load_data/load_bluetides.py
@@ -354,7 +354,7 @@ def load_BlueTides(
         galaxies[ii].load_stars(
             initial_masses=(imasses * Msun).astype(dtype),
             ages=(ages * Myr).astype(dtype),
-            metals=metallicities.astype(dtype),
+            metallicities=metallicities.astype(dtype),
             coordinates=(coords * kpc).astype(dtype),
             current_masses=(masses * Msun).astype(dtype),
             smoothing_lengths=smoothing_lengths,

--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -113,7 +113,7 @@ def _load_CAMELS(
         if s_hsml is None:
             smoothing_lengths = s_hsml
         else:
-            smoothing_lengths = s_hsml[b:e] * kpc
+            smoothing_lengths = (s_hsml[b:e] * kpc).astype(dtype)
 
         galaxies[i].load_stars(
             initial_masses=(imasses[b:e] * Msun).astype(dtype),
@@ -834,11 +834,11 @@ def load_CAMELS_SwiftEAGLE_subfind(
 
         gal.load_stars(
             initial_masses=(sh_imasses * Msun).astype(dtype),
-            ages=sh_ages * yr,
-            metallicities=sh_metallicity,
-            s_oxygen=s_oxygen,
-            s_hydrogen=s_hydrogen,
-            coordinates=sh_coods * Mpc,
+            ages=(sh_ages * yr).astype(dtype),
+            metallicities=sh_metallicity.astype(dtype),
+            s_oxygen=s_oxygen.astype(dtype),
+            s_hydrogen=s_hydrogen.astype(dtype),
+            coordinates=(sh_coods * Mpc).astype(dtype),
             current_masses=(sh_masses * Msun).astype(dtype),
             smoothing_lengths=smoothing_lengths,
         )
@@ -866,11 +866,11 @@ def load_CAMELS_SwiftEAGLE_subfind(
             star_forming = sh_g_sfr > 0.0
 
             gal.load_gas(
-                coordinates=sh_g_coods * Mpc,
+                coordinates=(sh_g_coods * Mpc).astype(dtype),
                 masses=(sh_g_masses * Msun).astype(dtype),
-                metallicities=sh_g_metals,
+                metallicities=sh_g_metals.astype(dtype),
                 star_forming=star_forming,
-                smoothing_lengths=sh_g_hsml * Mpc,
+                smoothing_lengths=(sh_g_hsml * Mpc).astype(dtype),
                 dust_to_metal_ratio=dtm,
             )
 

--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -51,6 +51,7 @@ def _load_CAMELS(
     centre,
     s_hsml=None,
     dtm=0.3,
+    dtype=np.float64,
 ):
     """Load CAMELS galaxies into a galaxy object.
 
@@ -92,6 +93,10 @@ def _load_CAMELS(
             as required (e.g. can be centre of mass)
         dtm (float):
             dust-to-metals ratio to apply to all particles
+        dtype (type):
+            The numpy dtype to cast arrays to after unit
+            multiplication. Needed because unyt unit multiplication
+            (e.g. ``* Msun``) can promote lower-precision dtypes.
 
     Returns:
         galaxies (object):
@@ -111,24 +116,24 @@ def _load_CAMELS(
             smoothing_lengths = s_hsml[b:e] * kpc
 
         galaxies[i].load_stars(
-            initial_masses=imasses[b:e] * Msun,
-            ages=ages[b:e] * yr,
-            metallicities=metallicities[b:e],
-            s_oxygen=s_oxygen[b:e],
-            s_hydrogen=s_hydrogen[b:e],
-            coordinates=coods[b:e, :] * kpc,
-            current_masses=masses[b:e] * Msun,
+            initial_masses=(imasses[b:e] * Msun).astype(dtype),
+            ages=(ages[b:e] * yr).astype(dtype),
+            metallicities=metallicities[b:e].astype(dtype),
+            s_oxygen=s_oxygen[b:e].astype(dtype),
+            s_hydrogen=s_hydrogen[b:e].astype(dtype),
+            coordinates=(coods[b:e, :] * kpc).astype(dtype),
+            current_masses=(masses[b:e] * Msun).astype(dtype),
             smoothing_lengths=smoothing_lengths,
         )
 
     begin, end = get_begin_end_pointers(lens[:, 0])
     for i, (b, e) in enumerate(zip(begin, end)):
         galaxies[i].load_gas(
-            coordinates=g_coods[b:e] * kpc,
-            masses=g_masses[b:e] * Msun,
-            metallicities=g_metallicities[b:e],
+            coordinates=(g_coods[b:e] * kpc).astype(dtype),
+            masses=(g_masses[b:e] * Msun).astype(dtype),
+            metallicities=g_metallicities[b:e].astype(dtype),
             star_forming=star_forming[b:e],
-            smoothing_lengths=g_hsml[b:e] * kpc,
+            smoothing_lengths=(g_hsml[b:e] * kpc).astype(dtype),
             dust_to_metal_ratio=dtm,
         )
 
@@ -145,6 +150,7 @@ def load_CAMELS_IllustrisTNG(
     physical=True,
     age_lookup=True,
     age_lookup_delta_a=1e-4,
+    dtype=np.float64,
     **kwargs,
 ):
     """Load CAMELS-IllustrisTNG galaxies.
@@ -169,6 +175,11 @@ def load_CAMELS_IllustrisTNG(
             Create a lookup table for ages
         age_lookup_delta_a (float):
             Scale factor resolution of the age lookup
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
         **kwargs (dict):
             Additional keyword arguments to pass to the
             `_load_CAMELS` function.
@@ -273,6 +284,21 @@ def load_CAMELS_IllustrisTNG(
     # Calculate ages at snapshot redshift
     ages = (universe_age - _ages).to("yr").value
 
+    # Cast all particle arrays to a common (user-controlled) dtype to avoid
+    # mixed-precision errors in downstream kernels.
+    masses = masses.astype(dtype, copy=False)
+    imasses = imasses.astype(dtype, copy=False)
+    ages = ages.astype(dtype, copy=False)
+    metallicity = metallicity.astype(dtype, copy=False)
+    s_oxygen = s_oxygen.astype(dtype, copy=False)
+    s_hydrogen = s_hydrogen.astype(dtype, copy=False)
+    coods = coods.astype(dtype, copy=False)
+    hsml = hsml.astype(dtype, copy=False)
+    g_masses = g_masses.astype(dtype, copy=False)
+    g_metals = g_metals.astype(dtype, copy=False)
+    g_coods = g_coods.astype(dtype, copy=False)
+    g_hsml = g_hsml.astype(dtype, copy=False)
+
     return _load_CAMELS(
         lens=lens,
         imasses=imasses,
@@ -291,6 +317,7 @@ def load_CAMELS_IllustrisTNG(
         redshift=redshift,
         centre=pos,
         dtm=dtm,
+        dtype=dtype,
     )
 
 
@@ -303,6 +330,7 @@ def load_CAMELS_Astrid(
     physical=True,
     age_lookup=True,
     age_lookup_delta_a=1e-4,
+    dtype=np.float64,
     **kwargs,
 ):
     """Load CAMELS-Astrid galaxies.
@@ -325,6 +353,11 @@ def load_CAMELS_Astrid(
             Create a lookup table for ages
         age_lookup_delta_a (float):
             Scale factor resolution of the age lookup
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
         **kwargs (dict):
             Additional keyword arguments to pass to the
             `_load_CAMELS` function.
@@ -396,6 +429,20 @@ def load_CAMELS_Astrid(
         g_hsml *= scale_factor
         pos *= scale_factor
 
+    # Cast all particle arrays to a common (user-controlled) dtype to avoid
+    # mixed-precision errors in downstream kernels.
+    masses = masses.astype(dtype, copy=False)
+    imasses = imasses.astype(dtype, copy=False)
+    ages = ages.astype(dtype, copy=False)
+    metallicity = metallicity.astype(dtype, copy=False)
+    s_oxygen = s_oxygen.astype(dtype, copy=False)
+    s_hydrogen = s_hydrogen.astype(dtype, copy=False)
+    coods = coods.astype(dtype, copy=False)
+    g_masses = g_masses.astype(dtype, copy=False)
+    g_metals = g_metals.astype(dtype, copy=False)
+    g_coods = g_coods.astype(dtype, copy=False)
+    g_hsml = g_hsml.astype(dtype, copy=False)
+
     return _load_CAMELS(
         redshift=redshift,
         lens=lens,
@@ -413,6 +460,7 @@ def load_CAMELS_Astrid(
         star_forming=star_forming,
         dtm=dtm,
         centre=pos,
+        dtype=dtype,
     )
 
 
@@ -425,6 +473,7 @@ def load_CAMELS_Simba(
     physical=True,
     age_lookup=True,
     age_lookup_delta_a=1e-4,
+    dtype=np.float64,
     **kwargs,
 ):
     """Load CAMELS-SIMBA galaxies.
@@ -447,6 +496,11 @@ def load_CAMELS_Simba(
             Create a lookup table for ages
         age_lookup_delta_a (float):
             Scale factor resolution of the age lookup
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
         **kwargs (dict):
             Additional keyword arguments to pass to the
             `_load_CAMELS` function.
@@ -518,6 +572,20 @@ def load_CAMELS_Simba(
         g_hsml *= scale_factor
         pos *= scale_factor
 
+    # Cast all particle arrays to a common (user-controlled) dtype to avoid
+    # mixed-precision errors in downstream kernels.
+    masses = masses.astype(dtype, copy=False)
+    imasses = imasses.astype(dtype, copy=False)
+    ages = ages.astype(dtype, copy=False)
+    metallicity = metallicity.astype(dtype, copy=False)
+    s_oxygen = s_oxygen.astype(dtype, copy=False)
+    s_hydrogen = s_hydrogen.astype(dtype, copy=False)
+    coods = coods.astype(dtype, copy=False)
+    g_masses = g_masses.astype(dtype, copy=False)
+    g_metals = g_metals.astype(dtype, copy=False)
+    g_coods = g_coods.astype(dtype, copy=False)
+    g_hsml = g_hsml.astype(dtype, copy=False)
+
     return _load_CAMELS(
         redshift=redshift,
         lens=lens,
@@ -535,6 +603,7 @@ def load_CAMELS_Simba(
         star_forming=star_forming,
         dtm=dtm,
         centre=pos,
+        dtype=dtype,
     )
 
 
@@ -549,6 +618,7 @@ def load_CAMELS_SwiftEAGLE_subfind(
     num_threads=-1,
     age_lookup=True,
     age_lookup_delta_a=1e-4,
+    dtype=np.float64,
     **kwargs,
 ):
     """Load CAMELS-Swift-EAGLE galaxies.
@@ -578,6 +648,11 @@ def load_CAMELS_SwiftEAGLE_subfind(
             Create a lookup table for ages
         age_lookup_delta_a (int):
             Scale factor resolution of the age lookup
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
         **kwargs (dict):
             Additional keyword arguments to pass to the
             `_load_CAMELS` function.
@@ -676,6 +751,20 @@ def load_CAMELS_SwiftEAGLE_subfind(
     # Calculate ages at snapshot redshift
     ages = (universe_age - _ages).to("yr").value
 
+    # Cast all particle arrays to a common (user-controlled) dtype to avoid
+    # mixed-precision errors in downstream kernels.
+    masses = masses.astype(dtype, copy=False)
+    imasses = imasses.astype(dtype, copy=False)
+    ages = ages.astype(dtype, copy=False)
+    metallicity = metallicity.astype(dtype, copy=False)
+    _metals = _metals.astype(dtype, copy=False)
+    coods = coods.astype(dtype, copy=False)
+    hsml = hsml.astype(dtype, copy=False)
+    g_masses = g_masses.astype(dtype, copy=False)
+    g_metals = g_metals.astype(dtype, copy=False)
+    g_coods = g_coods.astype(dtype, copy=False)
+    g_hsml = g_hsml.astype(dtype, copy=False)
+
     def swifteagle_particle_assignment(
         idx,
         redshift,
@@ -744,13 +833,13 @@ def load_CAMELS_SwiftEAGLE_subfind(
             smoothing_lengths = sh_hsml * Mpc
 
         gal.load_stars(
-            initial_masses=sh_imasses * Msun,
+            initial_masses=(sh_imasses * Msun).astype(dtype),
             ages=sh_ages * yr,
             metallicities=sh_metallicity,
             s_oxygen=s_oxygen,
             s_hydrogen=s_hydrogen,
             coordinates=sh_coods * Mpc,
-            current_masses=sh_masses * Msun,
+            current_masses=(sh_masses * Msun).astype(dtype),
             smoothing_lengths=smoothing_lengths,
         )
 
@@ -778,7 +867,7 @@ def load_CAMELS_SwiftEAGLE_subfind(
 
             gal.load_gas(
                 coordinates=sh_g_coods * Mpc,
-                masses=sh_g_masses * Msun,
+                masses=(sh_g_masses * Msun).astype(dtype),
                 metallicities=sh_g_metals,
                 star_forming=star_forming,
                 smoothing_lengths=sh_g_hsml * Mpc,

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -22,7 +22,9 @@ from synthesizer.load_data.utils import get_begin_end_pointers
 from ..particle.galaxy import Galaxy
 
 
-def load_FLARES(master_file, region, tag, read_abundances=False):
+def load_FLARES(
+    master_file, region, tag, read_abundances=False, dtype=np.float64
+):
     """Load FLARES galaxies from a FLARES master file.
 
     Args:
@@ -36,6 +38,11 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
             Whether to read the abundances of the stars.
             If True, the oxygen and hydrogen abundances are loaded.
             If False, only the metallicity is loaded.
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
 
     Returns:
         galaxies (object):
@@ -89,23 +96,23 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
         )
         if read_abundances:
             galaxies[i].load_stars(
-                imasses[b:e] * Msun,
-                ages[b:e] * yr,
-                metallicities[b:e],
-                s_oxygen=s_oxygen[b:e],
-                s_hydrogen=s_hydrogen[b:e],
-                coordinates=coods[b:e, :] * Mpc,
-                current_masses=masses[b:e] * Msun,
-                smoothing_lengths=s_hsml[b:e] * Mpc,
+                (imasses[b:e] * Msun).astype(dtype),
+                (ages[b:e] * yr).astype(dtype),
+                metallicities[b:e].astype(dtype),
+                s_oxygen=s_oxygen[b:e].astype(dtype),
+                s_hydrogen=s_hydrogen[b:e].astype(dtype),
+                coordinates=(coods[b:e, :] * Mpc).astype(dtype),
+                current_masses=(masses[b:e] * Msun).astype(dtype),
+                smoothing_lengths=(s_hsml[b:e] * Mpc).astype(dtype),
             )
         else:
             galaxies[i].load_stars(
-                imasses[b:e] * Msun,
-                ages[b:e] * yr,
-                metallicities[b:e],
-                coordinates=coods[b:e, :] * Mpc,
-                current_masses=masses[b:e] * Msun,
-                smoothing_lengths=s_hsml[b:e] * Mpc,
+                (imasses[b:e] * Msun).astype(dtype),
+                (ages[b:e] * yr).astype(dtype),
+                metallicities[b:e].astype(dtype),
+                coordinates=(coods[b:e, :] * Mpc).astype(dtype),
+                current_masses=(masses[b:e] * Msun).astype(dtype),
+                smoothing_lengths=(s_hsml[b:e] * Mpc).astype(dtype),
             )
 
     # Get the gas particle begin / end indices
@@ -122,10 +129,10 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
         )
 
         galaxies[i].load_gas(
-            coordinates=g_coods[b:e] * Mpc,
-            masses=g_masses[b:e] * Msun,
-            metallicities=g_metallicities[b:e],
-            smoothing_lengths=g_hsml[b:e] * Mpc,
+            coordinates=(g_coods[b:e] * Mpc).astype(dtype),
+            masses=(g_masses[b:e] * Msun).astype(dtype),
+            metallicities=g_metallicities[b:e].astype(dtype),
+            smoothing_lengths=(g_hsml[b:e] * Mpc).astype(dtype),
         )
 
     return galaxies

--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -54,6 +54,7 @@ def load_IllustrisTNG(
     metals=True,
     age_lookup=True,
     age_lookup_delta_a=1e-4,
+    dtype=np.float64,
 ):
     """Load IllustrisTNG particle data into galaxy objects.
 
@@ -86,6 +87,11 @@ def load_IllustrisTNG(
             Create a lookup table for ages
         age_lookup_delta_a (float):
             Scale factor resolution of the age lookup
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
 
     Returns:
         galaxies (list):
@@ -215,13 +221,19 @@ def load_IllustrisTNG(
                 smoothing_lengths = hsml * kpc
 
             galaxies[i].load_stars(
-                initial_masses=imasses * Msun,
-                ages=ages * yr,
-                metallicities=metallicities,
-                s_oxygen=s_oxygen,
-                s_hydrogen=s_hydrogen,
-                coordinates=coods * kpc,
-                current_masses=masses * Msun,
+                initial_masses=(imasses * Msun).astype(dtype),
+                ages=(ages * yr).astype(dtype),
+                metallicities=metallicities.astype(dtype),
+                s_oxygen=(
+                    s_oxygen.astype(dtype) if s_oxygen is not None else None
+                ),
+                s_hydrogen=(
+                    s_hydrogen.astype(dtype)
+                    if s_hydrogen is not None
+                    else None
+                ),
+                coordinates=(coods * kpc).astype(dtype),
+                current_masses=(masses * Msun).astype(dtype),
                 smoothing_lengths=smoothing_lengths,
             )
 
@@ -253,11 +265,11 @@ def load_IllustrisTNG(
                 g_hsml *= scale_factor
 
             galaxies[i].load_gas(
-                coordinates=g_coods * kpc,
-                masses=g_masses * Msun,
-                metallicities=g_metals,
+                coordinates=(g_coods * kpc).astype(dtype),
+                masses=(g_masses * Msun).astype(dtype),
+                metallicities=g_metals.astype(dtype),
                 star_forming=star_forming,
-                smoothing_lengths=g_hsml * kpc,
+                smoothing_lengths=(g_hsml * kpc).astype(dtype),
                 dust_to_metal_ratio=dtm,
             )
 

--- a/src/synthesizer/load_data/load_scsam.py
+++ b/src/synthesizer/load_data/load_scsam.py
@@ -16,7 +16,7 @@ from synthesizer.particle.galaxy import Galaxy as ParticleGalaxy
 from synthesizer.particle.stars import Stars as ParticleStars
 
 
-def load_SCSAM(fname, method, grid=None, verbose=False):
+def load_SCSAM(fname, method, grid=None, verbose=False, dtype=np.float64):
     r"""Read an SC-SAM star formation data file.
 
     Returns a list of galaxy objects, halo indices, and birth halo IDs.
@@ -36,15 +36,11 @@ def load_SCSAM(fname, method, grid=None, verbose=False):
             Grid object to extract from (needed for parametric galaxies).
         verbose (bool):
             Are we talking?
-
-    Returns:
-        tuple:
-            galaxies (list):
-                list of galaxy objects
-            halo_ind_list (list):
-                list of halo indices
-            birthhalo_id_list (list):
-                birth halo indices
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
     """
     # Prepare to read SFHist file
     sfhist = open(fname, "r")
@@ -126,7 +122,7 @@ def load_SCSAM(fname, method, grid=None, verbose=False):
             # Create galaxy object
             if method == "particle":
                 galaxy = _load_SCSAM_particle_galaxy(
-                    SFH, age_lst, Z_lst, verbose=verbose
+                    SFH, age_lst, Z_lst, verbose=verbose, dtype=dtype
                 )
             elif method == "parametric_NNI":
                 galaxy = _load_SCSAM_parametric_galaxy(
@@ -145,7 +141,9 @@ def load_SCSAM(fname, method, grid=None, verbose=False):
     return galaxies, halo_ind_list, birthhalo_id_list
 
 
-def _load_SCSAM_particle_galaxy(SFH, age_lst, Z_lst, verbose=False):
+def _load_SCSAM_particle_galaxy(
+    SFH, age_lst, Z_lst, verbose=False, dtype=np.float64
+):
     """Treat each age-Z bin as a particle.
 
     Args:
@@ -157,6 +155,11 @@ def _load_SCSAM_particle_galaxy(SFH, age_lst, Z_lst, verbose=False):
             metallicity bins in the SFH array (unitless).
         verbose (bool):
             Are we talking?
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
     """
     # Initialise arrays for storing particle information
     p_imass = []  # initial mass
@@ -182,9 +185,9 @@ def _load_SCSAM_particle_galaxy(SFH, age_lst, Z_lst, verbose=False):
     # Convert units
     if verbose:
         print("Converting units...")
-    p_imass = np.array(p_imass) * 10**9  # Msun
-    p_age = np.array(p_age) * 10**9  # yr
-    p_Z = np.array(p_Z)  # unitless
+    p_imass = np.array(p_imass, dtype=dtype) * 10**9  # Msun
+    p_age = np.array(p_age, dtype=dtype) * 10**9  # yr
+    p_Z = np.array(p_Z, dtype=dtype)  # unitless
 
     if verbose:
         print("Generating SED...")

--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -27,6 +27,7 @@ def load_Simba(
     load_halo=False,
     age_lookup=True,
     age_lookup_delta_a=1e-4,
+    dtype=np.float64,
 ):
     """Load Simba galaxy data from a caesar file and snapshot.
 
@@ -53,6 +54,11 @@ def load_Simba(
             faster age calculation.
         age_lookup_delta_a (float):
             The resolution of the age lookup table in terms of scale factor.
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
 
     Returns:
         galaxies (list):
@@ -190,13 +196,13 @@ def load_Simba(
         g_start, g_end = g_offsets[i], g_offsets[i] + g_particle_counts[i]
 
         galaxy.load_stars(
-            initial_masses=imasses[s_start:s_end] * Msun,
-            ages=ages[s_start:s_end] * yr,
-            metallicities=metallicity[s_start:s_end],
-            s_oxygen=s_oxygen[s_start:s_end],
-            s_hydrogen=s_hydrogen[s_start:s_end],
-            coordinates=coods[s_start:s_end, :] * kpc,
-            current_masses=masses[s_start:s_end] * Msun,
+            initial_masses=(imasses[s_start:s_end] * Msun).astype(dtype),
+            ages=(ages[s_start:s_end] * yr).astype(dtype),
+            metallicities=metallicity[s_start:s_end].astype(dtype),
+            s_oxygen=s_oxygen[s_start:s_end].astype(dtype),
+            s_hydrogen=s_hydrogen[s_start:s_end].astype(dtype),
+            coordinates=(coods[s_start:s_end, :] * kpc).astype(dtype),
+            current_masses=(masses[s_start:s_end] * Msun).astype(dtype),
             centre=centres[i] * kpc,
         )
 
@@ -211,11 +217,11 @@ def load_Simba(
             galaxy.sf_gas_metallicity = 0.0
 
         galaxy.load_gas(
-            coordinates=g_coods[g_start:g_end] * kpc,
-            masses=g_masses[g_start:g_end] * Msun,
-            metallicities=g_metals[g_start:g_end],
-            smoothing_lengths=g_hsml[g_start:g_end] * kpc,
-            dust_masses=g_dustmass[g_start:g_end] * Msun,
+            coordinates=(g_coods[g_start:g_end] * kpc).astype(dtype),
+            masses=(g_masses[g_start:g_end] * Msun).astype(dtype),
+            metallicities=g_metals[g_start:g_end].astype(dtype),
+            smoothing_lengths=(g_hsml[g_start:g_end] * kpc).astype(dtype),
+            dust_masses=(g_dustmass[g_start:g_end] * Msun).astype(dtype),
             centre=centres[i] * kpc,
         )
         galaxies.append(galaxy)
@@ -232,6 +238,7 @@ def load_Simba_slab(
     load_dark_matter=False,
     age_lookup=True,
     age_lookup_delta_a=1e-4,
+    dtype=np.float64,
 ):
     """Load a cuboid region of Simba simulation data into a Galaxy object.
 
@@ -258,6 +265,11 @@ def load_Simba_slab(
             faster age calculation.
         age_lookup_delta_a (float):
             The resolution of the age lookup table in terms of scale factor.
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
 
     Returns:
         galaxy (synthesizer.particle.galaxy.Galaxy):
@@ -419,13 +431,13 @@ def load_Simba_slab(
     # Load star data if requested and available
     if load_stars and masses is not None and len(masses) > 0:
         galaxy.load_stars(
-            initial_masses=imasses * Msun,
-            ages=ages * yr,
-            metallicities=metallicity,
-            s_oxygen=s_oxygen,
-            s_hydrogen=s_hydrogen,
-            coordinates=coods * kpc,
-            current_masses=masses * Msun,
+            initial_masses=(imasses * Msun).astype(dtype),
+            ages=(ages * yr).astype(dtype),
+            metallicities=metallicity.astype(dtype),
+            s_oxygen=s_oxygen.astype(dtype),
+            s_hydrogen=s_hydrogen.astype(dtype),
+            coordinates=(coods * kpc).astype(dtype),
+            current_masses=(masses * Msun).astype(dtype),
             centre=center * kpc,
         )
 
@@ -444,11 +456,11 @@ def load_Simba_slab(
 
         # Load gas data
         galaxy.load_gas(
-            coordinates=g_coods * kpc,
-            masses=g_masses * Msun,
-            metallicities=g_metals,
-            smoothing_lengths=g_hsml * kpc,
-            dust_masses=g_dustmass * Msun,
+            coordinates=(g_coods * kpc).astype(dtype),
+            masses=(g_masses * Msun).astype(dtype),
+            metallicities=g_metals.astype(dtype),
+            smoothing_lengths=(g_hsml * kpc).astype(dtype),
+            dust_masses=(g_dustmass * Msun).astype(dtype),
             centre=center * kpc,
             internal_energy=g_internalenergy,
         )

--- a/src/synthesizer/load_data/load_yt.py
+++ b/src/synthesizer/load_data/load_yt.py
@@ -1705,6 +1705,30 @@ def _infer_centre(stars, gas, black_holes):
     return None
 
 
+def _cast_component_dtype(component_dict, dtype):
+    """Cast all array values in a component dict to the requested dtype.
+
+    Args:
+        component_dict (dict):
+            Keyword-argument dictionary to pass to ``load_stars`` or
+            ``load_gas``.
+        dtype (type):
+            The target numpy dtype for numerical arrays.
+
+    Returns:
+        dict:
+            A shallow copy of the input with array values cast to ``dtype``.
+    """
+    result = dict(component_dict)
+    for key, value in result.items():
+        if isinstance(value, np.ndarray) and value.dtype in (
+            np.float32,
+            np.float64,
+        ):
+            result[key] = value.astype(dtype, copy=False)
+    return result
+
+
 def load_yt(
     data_source,
     data_containers=None,
@@ -1719,6 +1743,7 @@ def load_yt(
     load_derived_extra_fields=False,
     galaxy_name_prefix="yt_galaxy",
     verbose=False,
+    dtype=np.float64,
 ):
     """Load one or more yt selections into Synthesizer particle galaxies.
 
@@ -1767,6 +1792,11 @@ def load_yt(
             Prefix used when naming the output galaxy objects.
         verbose (bool):
             If `True`, print progress information during loading.
+        dtype (type):
+            The numpy dtype to cast all numerical particle arrays to.
+            Defaults to np.float64 to match standard SPS grids. Set to
+            np.float32 (with Grid(use_precision=np.float32)) to reduce
+            memory.
 
     Returns:
         tuple[list[Galaxy], dict]:
@@ -1923,9 +1953,11 @@ def load_yt(
         )
 
         if stars is not None:
+            stars = _cast_component_dtype(stars, dtype)
             galaxy.load_stars(**stars)
 
         if gas is not None:
+            gas = _cast_component_dtype(gas, dtype)
             galaxy.load_gas(**gas)
 
         if black_holes is not None:

--- a/src/synthesizer/load_data/load_yt.py
+++ b/src/synthesizer/load_data/load_yt.py
@@ -1961,6 +1961,7 @@ def load_yt(
             galaxy.load_gas(**gas)
 
         if black_holes is not None:
+            black_holes = _cast_component_dtype(black_holes, dtype)
             black_hole_kwargs = dict(black_holes)
             galaxy.black_holes = BlackHoles(
                 masses=black_hole_kwargs.pop("masses"),

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -603,7 +603,9 @@ class Particles:
         # Get the attribute
         attr_str = attr
         try:
-            attr = get_param(attr_str, attr_override_obj, None, self)
+            attr = get_param(
+                attr_str, attr_override_obj, None, self, preserve_units=True
+            )
         except exceptions.MissingAttribute as e:
             raise exceptions.MissingMaskAttribute(
                 f"Masking attribute ({attr_str}) not found on particle object."
@@ -613,7 +615,13 @@ class Particles:
         if isinstance(thresh, str):
             thresh_str = thresh
             try:
-                thresh = get_param(thresh_str, attr_override_obj, None, self)
+                thresh = get_param(
+                    thresh_str,
+                    attr_override_obj,
+                    None,
+                    self,
+                    preserve_units=True,
+                )
             except exceptions.MissingAttribute as e:
                 raise exceptions.MissingMaskAttribute(
                     f"Mask threshold alias ({thresh_str}) not found on "

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -655,7 +655,17 @@ class Particles:
         # If we only have a scalar attribute we need to expand it to a
         # nparticle array
         if attr.size == 1:
-            attr = np.full(self.nparticles, attr.value, dtype=np.float64)
+            if hasattr(attr, "units"):
+                attr = (
+                    np.full(
+                        self.nparticles,
+                        attr.value,
+                        dtype=np.float64,
+                    )
+                    * attr.units
+                )
+            else:
+                attr = np.full(self.nparticles, attr, dtype=np.float64)
 
         # Apply the operator
         if op == ">":

--- a/src/synthesizer/utils/integrate.py
+++ b/src/synthesizer/utils/integrate.py
@@ -93,7 +93,7 @@ def integrate_last_axis(xs, ys, nthreads=1, method="trapz"):
         out_shape = _ys.shape[:-1]
         return np.zeros(out_shape) if out_shape else 0.0
 
-    return integration_function(_xs, _ys, nthreads)
+    return integration_function(_xs, _ys, nthreads, None)
 
 
 def integrate_weighted_last_axis(xs, ys, weights, nthreads=1, method="trapz"):
@@ -150,4 +150,4 @@ def integrate_weighted_last_axis(xs, ys, weights, nthreads=1, method="trapz"):
         out_shape = _ys.shape[:-1]
         return np.zeros(out_shape) if out_shape else 0.0
 
-    return integration_function(_xs, _ys, _weights, nthreads)
+    return integration_function(_xs, _ys, _weights, nthreads, None)

--- a/tests/test_get_param.py
+++ b/tests/test_get_param.py
@@ -352,24 +352,24 @@ class TestGetParamCaching:
 class TestGetParamArrayConversion:
     """Test C-compatible array conversion in get_param."""
 
-    def test_get_param_converts_list_to_array(self):
-        """Test that lists are converted to numpy arrays."""
+    def test_get_param_keeps_list_values(self):
+        """Test that lists from fixed_parameters are returned unchanged."""
         model = MockModel()
         model.fixed_parameters["test_list"] = [1.0, 2.0, 3.0]
 
         result = get_param("test_list", model, None, None)
-        assert isinstance(result, np.ndarray)
-        assert result.dtype == np.float64
+        assert isinstance(result, list)
+        assert result == [1.0, 2.0, 3.0]
 
-    def test_get_param_converts_float32_to_float64(self):
-        """Test that float32 arrays are converted to float64."""
+    def test_get_param_keeps_float32_array_dtype(self):
+        """Test that float32 arrays are returned with their original dtype."""
         model = MockModel()
         model.fixed_parameters["test_array"] = np.array(
             [1.0, 2.0, 3.0], dtype=np.float32
         )
 
         result = get_param("test_array", model, None, None)
-        assert result.dtype == np.float64
+        assert result.dtype == np.float32
 
     def test_get_param_preserves_unyt_units(self):
         """Test that unyt units are stripped from fixed_parameters."""

--- a/tests/test_get_param.py
+++ b/tests/test_get_param.py
@@ -221,6 +221,27 @@ class TestGetParamParameterFunction:
         result = get_param("scaled", model, None, emitter)
         assert result == 300.0
 
+    def test_get_param_parameter_function_preserves_dependency_units(self):
+        """Test preserve_units flows into ParameterFunction dependencies."""
+
+        def identity(test_unyt):
+            return test_unyt
+
+        model = MockModel()
+        model.fixed_parameters["test_unyt"] = unyt.unyt_array(
+            [1.0, 2.0, 3.0], "Myr"
+        )
+        model.fixed_parameters["computed"] = ParameterFunction(
+            identity, "computed", ["test_unyt"]
+        )
+        emitter = MockEmitter()
+
+        result = get_param(
+            "computed", model, None, emitter, preserve_units=True
+        )
+        assert hasattr(result, "units")
+        assert str(result.units) == "Myr"
+
 
 class TestGetParamLogged:
     """Test log10 parameter handling in get_param."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,6 @@ from synthesizer.extensions.integration import (
     simps_last_axis,
     trapz_last_axis,
     weighted_simps_last_axis,
-    weighted_trapz_last_axis,
 )
 
 from synthesizer.utils.integrate import integrate_weighted_last_axis
@@ -56,7 +55,7 @@ def test_trapz_integration(example_data, threads, request):
     """Test the trapezoidal integration."""
     xs, ys = request.getfixturevalue(example_data.__name__)
     expected = trapezoid(y=ys, x=xs, axis=-1)
-    result = trapz_last_axis(xs, ys, threads)
+    result = trapz_last_axis(xs, ys, threads, None)
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 
@@ -68,7 +67,7 @@ def test_simpson_integration(example_data, threads, request):
     """Test the Simpson's rule integration."""
     xs, ys = request.getfixturevalue(example_data.__name__)
     expected = simpson(y=ys, x=xs, axis=-1)
-    result = simps_last_axis(xs, ys, threads)
+    result = simps_last_axis(xs, ys, threads, None)
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 
@@ -85,7 +84,7 @@ def test_weighted_trapz_integration(example_data, threads, request):
     expected_den = trapezoid(y=weights, x=xs)
     expected = expected_num / expected_den
 
-    result = weighted_trapz_last_axis(xs, ys, weights, threads)
+    result = weighted_simps_last_axis(xs, ys, weights, threads, None)
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 
@@ -118,7 +117,7 @@ def test_weighted_simpson_integration_nonuniform_grid(
     expected_den = simpson(y=weights, x=xs)
     expected = expected_num / expected_den
 
-    result = weighted_simps_last_axis(xs, ys, weights, threads)
+    result = weighted_simps_last_axis(xs, ys, weights, threads, None)
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,6 +7,7 @@ from synthesizer.extensions.integration import (
     simps_last_axis,
     trapz_last_axis,
     weighted_simps_last_axis,
+    weighted_trapz_last_axis,
 )
 
 from synthesizer.utils.integrate import integrate_weighted_last_axis
@@ -84,7 +85,7 @@ def test_weighted_trapz_integration(example_data, threads, request):
     expected_den = trapezoid(y=weights, x=xs)
     expected = expected_num / expected_den
 
-    result = weighted_simps_last_axis(xs, ys, weights, threads, None)
+    result = weighted_trapz_last_axis(xs, ys, weights, threads, None)
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-8)
 
 

--- a/tests/test_particles.py
+++ b/tests/test_particles.py
@@ -403,6 +403,16 @@ class TestParticlesMasking:
         with pytest.raises(exceptions.InconsistentArguments):
             sp.get_mask("dummy", 5.0, "invalid")
 
+    def test_get_mask_scalar_unitful_attribute_preserves_units(
+        self, simple_parts
+    ):
+        """Scalar unitful mask attributes preserve units when expanded."""
+        sp = simple_parts
+        sp.dummy = 5.0 * Msun
+
+        mask = sp.get_mask("dummy", 4.0 * Msun, ">")
+        assert mask.tolist() == [True, True, True]
+
 
 class TestWeightedAttributes:
     """Tests for weighted attribute and luminosity/flux weighting."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,9 +3,7 @@
 import numpy as np
 import unyt
 
-from synthesizer.emission_models.utils import (
-    ensure_array_c_compatible_double,
-)
+from synthesizer.utils import ensure_array_c_compatible_double
 
 
 class TestEnsureCompatibles:


### PR DESCRIPTION
Does what it says on the tin. 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `dtype` option to simulation data loaders to control numeric precision (e.g., float32 vs float64) when constructing star and gas particle data.
* **Bug Fixes / Behavior Changes**
  * Improved unit handling during parameter extraction and masking, including correct unit preservation for scalar unitful thresholds and unitless attribute outputs where appropriate.
  * Updated integration routine calls to match expected signatures.
* **Documentation**
  * Expanded loading documentation, including `dtype` behavior and available loaders.
* **Tests**
  * Updated/added coverage for refined unit and dtype behavior and integration call expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->