### PR TITLE
Add Redshift Space Distortion (RSD) effects

### DIFF
--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -281,7 +281,9 @@ class BaseGalaxy:
 
         return equivalent_widths
 
-    def get_observed_spectra(self, cosmo, igm=Inoue14, nthreads=1):
+    def get_observed_spectra(
+        self, cosmo, igm=Inoue14, nthreads=1, peculiar_velocity=None
+    ):
         """Calculate the observed spectra for all Seds within this galaxy.
 
         This will run Sed.get_fnu(...) and populate Sed.fnu (and sed.obslam
@@ -306,6 +308,10 @@ class BaseGalaxy:
             nthreads (int):
                 The number of threads to use for observer-frame flux
                 conversion.
+            peculiar_velocity (unyt_quantity/float):
+                Line-of-sight peculiar velocity passed to Sed.get_fnu. If
+                None, a `peculiar_velocity` attribute on the galaxy is used if
+                set. Defaults to None.
 
         Raises:
             MissingAttribute
@@ -319,6 +325,10 @@ class BaseGalaxy:
                 " calculated without one."
             )
 
+        # An explicit argument overrides a peculiar_velocity set on the galaxy.
+        if peculiar_velocity is None:
+            peculiar_velocity = getattr(self, "peculiar_velocity", None)
+
         # Loop over all combined spectra
         for sed in self.spectra.values():
             # Calculate the observed spectra
@@ -327,6 +337,7 @@ class BaseGalaxy:
                 z=self.redshift,
                 igm=igm,
                 nthreads=nthreads,
+                peculiar_velocity=peculiar_velocity,
             )
 
         # Do we have stars?
@@ -339,6 +350,7 @@ class BaseGalaxy:
                     z=self.redshift,
                     igm=igm,
                     nthreads=nthreads,
+                    peculiar_velocity=peculiar_velocity,
                 )
 
             # Loop over all stellar particle spectra
@@ -350,6 +362,7 @@ class BaseGalaxy:
                         z=self.redshift,
                         igm=igm,
                         nthreads=nthreads,
+                        peculiar_velocity=peculiar_velocity,
                     )
 
         # Do we have black holes?
@@ -362,6 +375,7 @@ class BaseGalaxy:
                     z=self.redshift,
                     igm=igm,
                     nthreads=nthreads,
+                    peculiar_velocity=peculiar_velocity,
                 )
 
             # Loop over all black hole particle spectra
@@ -373,6 +387,7 @@ class BaseGalaxy:
                         z=self.redshift,
                         igm=igm,
                         nthreads=nthreads,
+                        peculiar_velocity=peculiar_velocity,
                     )
 
     def get_observed_lines(self, cosmo, igm=Inoue14):

--- a/src/synthesizer/emissions/sed.py
+++ b/src/synthesizer/emissions/sed.py
@@ -1130,7 +1130,7 @@ class Sed:
         return get_quantity_view(self, "_fnu")
 
     @timed("Sed.get_fnu")
-    def get_fnu(self, cosmo, z, igm=None, nthreads=1):
+    def get_fnu(self, cosmo, z, igm=None, nthreads=1, peculiar_velocity=None):
         """Calculate the observed frame spectral energy distribution.
 
         This will also populate the observed wavelength and frequency arrays
@@ -1144,12 +1144,18 @@ class Sed:
             cosmo (astropy.cosmology):
                 astropy cosmology instance.
             z (float):
-                The redshift of the spectra.
+                The cosmological redshift of the spectra (sets luminosity
+                distance and IGM).
             igm (igm):
                 The IGM class. e.g. `synthesizer.igm.Inoue14`.
                 Defaults to None.
             nthreads (int):
                 The number of threads to use for the bulk flux conversion.
+            peculiar_velocity (unyt_quantity/float):
+                Line-of-sight peculiar velocity (positive = receding), a unyt
+                velocity or a float in km/s. Shifts the spectrum to z_obs with
+                1 + z_obs = (1 + z)(1 + v / c); distance and IGM stay at z.
+                Defaults to None (no shift).
 
         Returns:
             fnu (ndarray)
@@ -1164,6 +1170,17 @@ class Sed:
         if self.redshift == 0:
             return self.get_fnu0()
 
+        # Peculiar velocity shifts the spectrum to z_obs without moving the
+        # source; z_obs == z when no velocity is given.
+        if peculiar_velocity is not None:
+            if hasattr(peculiar_velocity, "units"):
+                beta = float((peculiar_velocity / c).to_value(""))
+            else:
+                beta = float(peculiar_velocity) / c.to_value("km/s")
+            z_obs = (1.0 + float(z)) * (1.0 + beta) - 1.0
+        else:
+            z_obs = float(z)
+
         # Ensure the arrays are ready to be handed to the C++
         if self._lnu.dtype != np.float64 or not self._lnu.flags.c_contiguous:
             self._lnu = np.ascontiguousarray(self._lnu, dtype=np.float64)
@@ -1177,8 +1194,11 @@ class Sed:
             self._obsnu = np.empty_like(self._nu)
 
         # Calculate the observed wavelength and frequency
-        one_plus_z = 1.0 + float(z)
+        one_plus_z = 1.0 + z_obs
+        # d_L is set by the cosmological z, rescaled to the observed frame
+        # (factor 1 when there is no peculiar velocity).
         luminosity_distance_cm = get_luminosity_distance(cosmo, z).to_value(cm)
+        luminosity_distance_cm *= one_plus_z / (1.0 + float(z))
         conversion = (
             get_attr_unit_conversion(
                 self.__class__.__dict__["lnu"].unit,

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 from astropy.cosmology import Planck18
-from unyt import Hz, angstrom, cm, erg, nJy, pc, s
+from unyt import Hz, angstrom, c, cm, erg, km, nJy, pc, s
 
 from synthesizer.cosmology import get_luminosity_distance
 from synthesizer.emission_models.attenuation import PowerLaw
@@ -166,3 +166,44 @@ def test_get_fnu_applies_igm_with_observer_frame_wavelengths():
     assert igm.last_z == z
     np.testing.assert_allclose(igm.last_lam_obs.value, sed._obslam)
     np.testing.assert_allclose(fnu.value, 0.5 * baseline.value)
+
+
+def test_get_fnu_peculiar_velocity_zero_matches_default():
+    """peculiar_velocity of None or 0 reproduces the cosmological get_fnu."""
+    lam = np.linspace(1000, 2000, 8) * angstrom
+    lnu = np.linspace(1.0, 8.0, 8) * erg / s / Hz
+    z = 1.5
+
+    base = Sed(lam=lam, lnu=lnu).get_fnu(Planck18, z)
+    none = Sed(lam=lam, lnu=lnu).get_fnu(Planck18, z, peculiar_velocity=None)
+    zero = Sed(lam=lam, lnu=lnu).get_fnu(Planck18, z, peculiar_velocity=0.0)
+
+    np.testing.assert_array_equal(none.value, base.value)
+    np.testing.assert_allclose(zero.value, base.value)
+
+
+def test_get_fnu_peculiar_velocity_shifts_to_observed_redshift():
+    """A peculiar velocity shifts to z_obs while the luminosity distance and
+    (1+z) factor stay tied to the cosmological z."""
+    lam = np.linspace(1000, 2000, 8) * angstrom
+    lnu = np.linspace(1.0, 8.0, 8) * erg / s / Hz
+    z = 1.0
+    v = 600.0  # km/s, receding
+
+    z_obs = (1.0 + z) * (1.0 + v / c.to_value("km/s")) - 1.0
+    d_l = get_luminosity_distance(Planck18, z).to(cm)
+    d_l_eff = d_l * (1.0 + z_obs) / (1.0 + z)
+    expected = lnu * (1.0 + z_obs) / (4 * np.pi * d_l_eff**2)
+
+    sed = Sed(lam=lam, lnu=lnu)
+    fnu = sed.get_fnu(Planck18, z, peculiar_velocity=v)
+
+    np.testing.assert_allclose(sed._obslam, sed._lam * (1.0 + z_obs))
+    np.testing.assert_allclose(sed._obsnu, sed._nu / (1.0 + z_obs))
+    np.testing.assert_allclose(fnu.to("nJy").value, expected.to("nJy").value)
+
+    # A unyt velocity matches the float (km/s) shorthand.
+    fnu_unyt = Sed(lam=lam, lnu=lnu).get_fnu(
+        Planck18, z, peculiar_velocity=v * km / s
+    )
+    np.testing.assert_allclose(fnu_unyt.to("nJy").value, fnu.to("nJy").value)


### PR DESCRIPTION
Adds RSD effects from peculiar velocities at the galaxy level. Importantly it passes this at the `get_fnu` level; rest frame spectra are generated once, and RSD effects applied afterwards. Luminosity distances and IGM effects assume the cosmological redshift `z`, only the wavelength redshift includes the peculiar velocity contribution.

This functionality is needed for forward-modelling lightcones, where a galaxy's observed flux carries its bulk motion relative to the Hubble flow on top of the cosmological redshift. The change is fully backward compatible.

## What changed

- **`Sed.get_fnu(cosmo, z, igm=None, nthreads=1, peculiar_velocity=None)`**
  When `peculiar_velocity` is given, `z` is treated as the *cosmological*
  redshift and the spectrum is shifted to the observed redshift `z_obs`, with
  `1 + z_obs = (1 + z)(1 + v_los / c)`:
  - the wavelength shift and the `(1 + z)` flux factor use `z_obs`;
  - the luminosity distance uses the true `z` (effective
    `d_L = d_L(z)·(1 + z_obs)/(1 + z)`), since a peculiar velocity is a motion,
    not a displacement, and does not change the source distance;
  - the IGM attenuation uses the true `z`.
  Accepts a unyt velocity or a float interpreted as km/s; positive = receding.

- **`Galaxy.get_observed_spectra(..., peculiar_velocity=None)`**
  Passes `peculiar_velocity` through to every `Sed.get_fnu` call (integrated
  and per-particle), so the bulk shift is applied consistently. An explicit
  argument overrides a `peculiar_velocity` attribute set on the galaxy; if both
  are absent the behaviour is unchanged.

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Observed spectrum calculations now accept an optional line-of-sight peculiar velocity to improve observer-frame redshift accuracy and spectral conversions.
* Spectrum generation (including galaxy, stellar, particle, and black hole contributions) now applies the velocity-dependent observed redshift consistently when provided.

## Tests
* Added coverage for `peculiar_velocity` behavior: `None`/zero matches default cosmological results, while nonzero values produce the expected observed-frame redshift shift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->