### PR TITLE
Fixing velocity access in doppler shifting machinery

### DIFF
--- a/src/synthesizer/extensions/part_props.cpp
+++ b/src/synthesizer/extensions/part_props.cpp
@@ -181,7 +181,56 @@ double Particles::get_weight_at(int pind) const {
  * @return The velocity of the particle at the given index.
  */
 double Particles::get_vel_at(int pind) const {
-  return get_double_at(np_velocities_, pind, "velocities");
+  const int ndim = PyArray_NDIM(np_velocities_);
+
+  /* A 1D velocity array is already a line-of-sight velocity array. */
+  if (ndim == 1) {
+    return get_double_at(np_velocities_, pind, "velocities");
+  }
+
+  /* Particle velocities are normally stored as (npart, 3); use z as LOS. */
+  if (ndim == 2) {
+    if (PyArray_TYPE(np_velocities_) != NPY_FLOAT64) {
+      PyErr_SetString(PyExc_TypeError,
+                      "[get_vel_at]: Array 'velocities' must be of type "
+                      "float64.");
+      return 0.0;
+    }
+
+    if (!PyArray_ISCONTIGUOUS(np_velocities_)) {
+      PyErr_SetString(PyExc_ValueError,
+                      "[get_vel_at]: Array 'velocities' must be contiguous.");
+      return 0.0;
+    }
+
+    const npy_intp nvel = PyArray_DIM(np_velocities_, 0);
+    const npy_intp ncomp = PyArray_DIM(np_velocities_, 1);
+    if (ncomp != 3) {
+      PyErr_Format(PyExc_ValueError,
+                   "[get_vel_at]: Array 'velocities' must have shape "
+                   "(npart, 3) or (npart,), got second dimension %ld.",
+                   static_cast<long>(ncomp));
+      return 0.0;
+    }
+
+    if (pind < 0 || pind >= nvel) {
+      PyErr_Format(PyExc_IndexError,
+                   "[get_vel_at]: Particle index (%ld) out of bounds for "
+                   "array 'velocities'. Valid range is [0, %ld).",
+                   static_cast<long>(pind), static_cast<long>(nvel));
+      return 0.0;
+    }
+
+    const double *data_ptr =
+        static_cast<const double *>(PyArray_DATA(np_velocities_));
+    return data_ptr[static_cast<npy_intp>(pind) * ncomp + 2];
+  }
+
+  PyErr_Format(PyExc_ValueError,
+               "[get_vel_at]: Array 'velocities' must have shape (npart, 3) "
+               "or (npart,), got %d dimensions.",
+               ndim);
+  return 0.0;
 }
 
 /**

--- a/src/synthesizer/extensions/part_props.cpp
+++ b/src/synthesizer/extensions/part_props.cpp
@@ -30,6 +30,9 @@ Particles::Particles(PyArrayObject *np_weights, PyArrayObject *np_velocities,
                      PyObject *part_names_tuple, int npart_)
     : np_weights_(np_weights),
       np_velocities_(np_velocities),
+      velocities_(NULL),
+      velocity_ndim_(0),
+      velocity_ncomp_(0),
       np_mask_(np_mask),
       part_tuple_(part_tuple) {
 
@@ -37,6 +40,66 @@ Particles::Particles(PyArrayObject *np_weights, PyArrayObject *np_velocities,
 
   /* Assign the number of particles. */
   npart = npart_;
+
+  if (np_velocities_ != NULL) {
+    velocity_ndim_ = PyArray_NDIM(np_velocities_);
+
+    if (PyArray_TYPE(np_velocities_) != NPY_FLOAT64) {
+      PyErr_SetString(PyExc_TypeError,
+                      "[Particles.__init__]: Array 'velocities' must be of "
+                      "type float64.");
+      toc("Particles.__init__");
+      return;
+    }
+
+    if (!PyArray_ISCONTIGUOUS(np_velocities_)) {
+      PyErr_SetString(PyExc_ValueError,
+                      "[Particles.__init__]: Array 'velocities' must be "
+                      "contiguous.");
+      toc("Particles.__init__");
+      return;
+    }
+
+    if (velocity_ndim_ == 1) {
+      if (PyArray_DIM(np_velocities_, 0) < npart) {
+        PyErr_Format(PyExc_IndexError,
+                     "[Particles.__init__]: Array 'velocities' has %ld "
+                     "entries but %d particles were requested.",
+                     static_cast<long>(PyArray_DIM(np_velocities_, 0)), npart);
+        toc("Particles.__init__");
+        return;
+      }
+      velocity_ncomp_ = 1;
+    } else if (velocity_ndim_ == 2) {
+      if (PyArray_DIM(np_velocities_, 0) < npart) {
+        PyErr_Format(PyExc_IndexError,
+                     "[Particles.__init__]: Array 'velocities' has %ld "
+                     "particles but %d particles were requested.",
+                     static_cast<long>(PyArray_DIM(np_velocities_, 0)), npart);
+        toc("Particles.__init__");
+        return;
+      }
+
+      velocity_ncomp_ = PyArray_DIM(np_velocities_, 1);
+      if (velocity_ncomp_ != 3) {
+        PyErr_Format(PyExc_ValueError,
+                     "[Particles.__init__]: Array 'velocities' must have "
+                     "shape (npart, 3) or (npart,), got second dimension %ld.",
+                     static_cast<long>(velocity_ncomp_));
+        toc("Particles.__init__");
+        return;
+      }
+    } else {
+      PyErr_Format(PyExc_ValueError,
+                   "[Particles.__init__]: Array 'velocities' must have shape "
+                   "(npart, 3) or (npart,), got %d dimensions.",
+                   velocity_ndim_);
+      toc("Particles.__init__");
+      return;
+    }
+
+    velocities_ = static_cast<const double *>(PyArray_DATA(np_velocities_));
+  }
 
   if (part_names_tuple != NULL && PySequence_Check(part_names_tuple) &&
       !PyUnicode_Check(part_names_tuple)) {
@@ -181,56 +244,10 @@ double Particles::get_weight_at(int pind) const {
  * @return The velocity of the particle at the given index.
  */
 double Particles::get_vel_at(int pind) const {
-  const int ndim = PyArray_NDIM(np_velocities_);
-
-  /* A 1D velocity array is already a line-of-sight velocity array. */
-  if (ndim == 1) {
-    return get_double_at(np_velocities_, pind, "velocities");
+  if (velocity_ndim_ == 1) {
+    return velocities_[pind];
   }
-
-  /* Particle velocities are normally stored as (npart, 3); use z as LOS. */
-  if (ndim == 2) {
-    if (PyArray_TYPE(np_velocities_) != NPY_FLOAT64) {
-      PyErr_SetString(PyExc_TypeError,
-                      "[get_vel_at]: Array 'velocities' must be of type "
-                      "float64.");
-      return 0.0;
-    }
-
-    if (!PyArray_ISCONTIGUOUS(np_velocities_)) {
-      PyErr_SetString(PyExc_ValueError,
-                      "[get_vel_at]: Array 'velocities' must be contiguous.");
-      return 0.0;
-    }
-
-    const npy_intp nvel = PyArray_DIM(np_velocities_, 0);
-    const npy_intp ncomp = PyArray_DIM(np_velocities_, 1);
-    if (ncomp != 3) {
-      PyErr_Format(PyExc_ValueError,
-                   "[get_vel_at]: Array 'velocities' must have shape "
-                   "(npart, 3) or (npart,), got second dimension %ld.",
-                   static_cast<long>(ncomp));
-      return 0.0;
-    }
-
-    if (pind < 0 || pind >= nvel) {
-      PyErr_Format(PyExc_IndexError,
-                   "[get_vel_at]: Particle index (%ld) out of bounds for "
-                   "array 'velocities'. Valid range is [0, %ld).",
-                   static_cast<long>(pind), static_cast<long>(nvel));
-      return 0.0;
-    }
-
-    const double *data_ptr =
-        static_cast<const double *>(PyArray_DATA(np_velocities_));
-    return data_ptr[static_cast<npy_intp>(pind) * ncomp + 2];
-  }
-
-  PyErr_Format(PyExc_ValueError,
-               "[get_vel_at]: Array 'velocities' must have shape (npart, 3) "
-               "or (npart,), got %d dimensions.",
-               ndim);
-  return 0.0;
+  return velocities_[static_cast<npy_intp>(pind) * velocity_ncomp_ + 2];
 }
 
 /**

--- a/src/synthesizer/extensions/part_props.h
+++ b/src/synthesizer/extensions/part_props.h
@@ -64,6 +64,11 @@ class Particles {
   /* The numpy array holding the particle velocities. */
   PyArrayObject *np_velocities_;
 
+  /* Cached velocity array metadata for raw LOS velocity access. */
+  const double *velocities_;
+  int velocity_ndim_;
+  npy_intp velocity_ncomp_;
+
   /* The mask (can be Py_None). */
   PyArrayObject *np_mask_;
 

--- a/tests/test_particle_spectra_extension.py
+++ b/tests/test_particle_spectra_extension.py
@@ -296,3 +296,113 @@ class TestDopplerParticleSpectraExtension:
         np.testing.assert_allclose(
             threaded_spectra, serial_spectra, rtol=0.0, atol=1e-12
         )
+
+    @pytest.mark.parametrize("method", ["ngp", "cic"])
+    def test_uses_z_velocity_for_3d_velocities(self, method):
+        """Test 3D velocities are shifted using the z-axis component."""
+        (
+            grid_spectra,
+            wavelength,
+            axes,
+            part_props,
+            weights,
+            velocities,
+            grid_dims,
+            lam_mask,
+        ) = self._inputs()
+        velocities_3d = np.ascontiguousarray(
+            np.column_stack(
+                (
+                    velocities + 1000.0,
+                    velocities - 1000.0,
+                    velocities,
+                )
+            ),
+            dtype=np.float64,
+        )
+
+        los_part_spectra, los_spectra = compute_part_seds_with_vel_shift(
+            grid_spectra,
+            wavelength,
+            axes,
+            part_props,
+            weights,
+            velocities,
+            grid_dims,
+            len(axes),
+            weights.size,
+            grid_spectra.shape[-1],
+            method,
+            1,
+            100.0,
+            None,
+            lam_mask,
+            ("x",),
+        )
+        vel3d_part_spectra, vel3d_spectra = compute_part_seds_with_vel_shift(
+            grid_spectra,
+            wavelength,
+            axes,
+            part_props,
+            weights,
+            velocities_3d,
+            grid_dims,
+            len(axes),
+            weights.size,
+            grid_spectra.shape[-1],
+            method,
+            1,
+            100.0,
+            None,
+            lam_mask,
+            ("x",),
+        )
+
+        np.testing.assert_allclose(
+            vel3d_part_spectra, los_part_spectra, rtol=0.0, atol=0.0
+        )
+        np.testing.assert_allclose(
+            vel3d_spectra, los_spectra, rtol=0.0, atol=0.0
+        )
+
+    @pytest.mark.parametrize("method", ["ngp", "cic"])
+    def test_velocity_shift_matches_expected_interpolation(self, method):
+        """Test Doppler shifts scatter into expected wavelength bins."""
+        wavelength = np.ascontiguousarray(
+            [100.0, 200.0, 300.0, 400.0, 500.0], dtype=np.float64
+        )
+        axis = np.ascontiguousarray([0.0, 1.0], dtype=np.float64)
+        grid_spectra = np.ascontiguousarray(
+            [[10.0, 20.0, 30.0, 40.0, 0.0], [0.0, 0.0, 0.0, 0.0, 0.0]],
+            dtype=np.float64,
+        )
+        part_props = (np.ascontiguousarray([0.0], dtype=np.float64),)
+        weights = np.ascontiguousarray([1.0], dtype=np.float64)
+        velocities = np.ascontiguousarray([25.0], dtype=np.float64)
+        grid_dims = np.ascontiguousarray([axis.size], dtype=np.int32)
+        lam_mask = np.ascontiguousarray(
+            np.ones(wavelength.size, dtype=np.bool_)
+        )
+
+        part_spectra, spectra = compute_part_seds_with_vel_shift(
+            grid_spectra,
+            wavelength,
+            (axis,),
+            part_props,
+            weights,
+            velocities,
+            grid_dims,
+            1,
+            weights.size,
+            wavelength.size,
+            method,
+            1,
+            100.0,
+            None,
+            lam_mask,
+            ("x",),
+        )
+
+        expected = np.array([[7.5, 12.5, 17.5, 22.5, 40.0]])
+        np.testing.assert_allclose(part_spectra, expected, rtol=0.0, atol=0.0)
+        np.testing.assert_allclose(spectra, expected[0], rtol=0.0, atol=0.0)


### PR DESCRIPTION
As observed by Patrick LaChance, at some point, a disagreement has crept into the Doppler shift machinery where the Python passed the 2D array, and the C++ expected the z-axis slice. Luckily, this machinery hasn't been used in any publications.

The fix is to make the backend aware of the array dimensions for complete robustness.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness and upfront validation of particle velocity inputs used for Doppler wavelength shifting.
  * Correctly applies the line-of-sight component (z-axis) when 3D velocities are provided.
  * Improves velocity access performance by using cached velocity metadata.

* **Tests**
  * Added coverage for Doppler particle spectra behavior with 3D velocity inputs.
  * Added deterministic assertions for expected particle spectra outputs for both supported interpolation methods (NGP and CIC).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->