### PR TITLE
Fixing the early return when there are no particles in Doppler Shifted spectra

### DIFF
--- a/src/synthesizer/emission_models/extractors/extractor.py
+++ b/src/synthesizer/emission_models/extractors/extractor.py
@@ -549,24 +549,36 @@ class DopplerShiftedParticleExtractor(Extractor):
             # Check we actually have to do the calculation
             if emitter.nparticles == 0:
                 warn("Found emitter with no particles, returning empty Sed")
-                return Sed(
-                    model.lam,
-                    np.zeros((emitter.nparticles, self._grid_nlam))
-                    * erg
-                    / s
-                    / Hz,
+                return (
+                    Sed(
+                        model.lam,
+                        np.zeros((emitter.nparticles, self._grid_nlam))
+                        * erg
+                        / s
+                        / Hz,
+                    ),
+                    Sed(
+                        model.lam,
+                        np.zeros(self._grid_nlam) * erg / s / Hz,
+                    ),
                 )
             elif mask is not None and np.sum(mask) == 0:
                 warn(
                     "A mask has filtered out all particles, returning "
                     "empty Sed"
                 )
-                return Sed(
-                    model.lam,
-                    np.zeros((emitter.nparticles, self._grid_nlam))
-                    * erg
-                    / s
-                    / Hz,
+                return (
+                    Sed(
+                        model.lam,
+                        np.zeros((emitter.nparticles, self._grid_nlam))
+                        * erg
+                        / s
+                        / Hz,
+                    ),
+                    Sed(
+                        model.lam,
+                        np.zeros(self._grid_nlam) * erg / s / Hz,
+                    ),
                 )
 
             # Get the attributes from the emitter

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -293,6 +293,68 @@ def test_doppler_shifted_generate_lnu(
     assert np.array_equal(result.lnu, mock_spectrum * erg / s / Hz)
 
 
+def test_doppler_shifted_empty_case(test_grid, nebular_emission_model):
+    """Test Doppler shifted extraction with an empty emitter."""
+    extractor = DopplerShiftedParticleExtractor(test_grid, "incident")
+    mock_emitter = MagicMock()
+    mock_emitter.nparticles = 0
+
+    with patch(
+        "synthesizer.emission_models.extractors.extractor.warn"
+    ) as mock_warn:
+        particle_sed, integrated_sed = extractor.generate_lnu(
+            mock_emitter,
+            nebular_emission_model,
+            None,
+            None,
+            "cic",
+            1,
+            False,
+        )
+
+    mock_warn.assert_called_once()
+    assert "no particles" in mock_warn.call_args[0][0]
+    assert isinstance(particle_sed, Sed)
+    assert isinstance(integrated_sed, Sed)
+    assert particle_sed.lnu.shape == (0, test_grid.nlam)
+    assert integrated_sed.lnu.shape == (test_grid.nlam,)
+    assert np.all(particle_sed.lnu == 0)
+    assert np.all(integrated_sed.lnu == 0)
+
+
+def test_doppler_shifted_masked_empty_case(
+    test_grid, random_part_stars, nebular_emission_model
+):
+    """Test Doppler shifted extraction when a mask removes all particles."""
+    extractor = DopplerShiftedParticleExtractor(test_grid, "incident")
+    mask = np.zeros(random_part_stars.nparticles, dtype=bool)
+
+    with patch(
+        "synthesizer.emission_models.extractors.extractor.warn"
+    ) as mock_warn:
+        particle_sed, integrated_sed = extractor.generate_lnu(
+            random_part_stars,
+            nebular_emission_model,
+            mask,
+            None,
+            "cic",
+            1,
+            False,
+        )
+
+    mock_warn.assert_called_once()
+    assert "filtered out all particles" in mock_warn.call_args[0][0]
+    assert isinstance(particle_sed, Sed)
+    assert isinstance(integrated_sed, Sed)
+    assert particle_sed.lnu.shape == (
+        random_part_stars.nparticles,
+        test_grid.nlam,
+    )
+    assert integrated_sed.lnu.shape == (test_grid.nlam,)
+    assert np.all(particle_sed.lnu == 0)
+    assert np.all(integrated_sed.lnu == 0)
+
+
 def test_doppler_shifted_no_velocities(
     test_grid, particle_stars_A, nebular_emission_model
 ):


### PR DESCRIPTION
This PR closes #1187. This issue had actually been solved in the other extractors. It essentially boils down to the early exits incorrectly returning a single Sed instead of 2.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
