### PR TITLE
Maintain required_parameters on Transformers

### DIFF
--- a/docs/source/emission_models/attenuation/dust_attenuation.ipynb
+++ b/docs/source/emission_models/attenuation/dust_attenuation.ipynb
@@ -422,7 +422,7 @@
    "source": [
     "This emission model is not useable on its own, but when attached to a parent EmissionModel or emitter with the appropriate parameters, the parameters will be overridden on-the-fly when calculating the attenuation or transmission curves.\n",
     "\n",
-    "In the below example, we instantiate a ``ParametricLi08`` attenuation law, but override the ``OPT_NIR_slope``, ``UV_slope``, and ``bump`` parameters with strings. When this attenuation law is attached to an emitter or emission model with these parameters, the values will be used instead of the defaults. If you set a parameter to ``None``, it will expect an override with the same name as the parameter (e.g. ``FUV_slope`` in this case)."
+    "In the below example, we instantiate a ``ParametricLi08`` attenuation law, but override the ``OPT_NIR_slope``, ``UV_slope``, and ``bump`` parameters with strings. When this attenuation law is attached to an emitter or emission model with these parameters, the values will be used instead of the defaults. A parameter with a concrete value will also be overridden by a value of the same name on the model or emitter, with the value passed here acting as the fallback when neither defines it. If you instead set a parameter to ``None``, there is no fallback, so an override with the same name as the parameter is required (e.g. ``FUV_slope`` in this case)."
    ]
   },
   {

--- a/src/synthesizer/emission_models/transformers/dust_attenuation.py
+++ b/src/synthesizer/emission_models/transformers/dust_attenuation.py
@@ -216,12 +216,13 @@ class AttenuationLaw(Transformer):
             self._reset_params()
 
     def _check_required_params(self):
-        """Get the required parameters for the transformer.
+        """Set up the required parameters for the transformer.
 
-        Given the input params, this method will return the required
-        params by looking at required params which have been
-        set as strings or None.
-
+        Every declared parameter remains required so that the standard
+        priority order (model -> emission -> emitter -> curve) applies to all
+        of them. A parameter given a string at initialisation is treated as an
+        alias, i.e. the value will be looked up under that name and passed to
+        the curve under the original name.
         """
         param_values = [
             getattr(self, param, None) for param in self._required_params
@@ -229,11 +230,11 @@ class AttenuationLaw(Transformer):
 
         required_params = []
         for param, value in zip(self._required_params, param_values):
-            if value is None:
-                required_params.append(param)
-            elif isinstance(value, str):
+            if isinstance(value, str):
                 required_params.append(value)
                 self._name_transforms[value] = param
+            else:
+                required_params.append(param)
 
         self._required_params = required_params
 
@@ -263,8 +264,10 @@ class AttenuationLaw(Transformer):
         Returns:
             Line/Sed: The transformed emission.
         """
-        # Extract the required parameters
-        params = self._extract_params(model, emission, emitter)
+        # Extract the required parameters, falling back to the values the
+        # curve itself was constructed with (obj=self) if the model, emission
+        # and emitter say nothing about them
+        params = self._extract_params(model, emission, emitter, obj=self)
 
         # Ensure we aren't trying to use a wavelength mask
         if lam_mask is not None:

--- a/src/synthesizer/emission_models/transformers/transformer.py
+++ b/src/synthesizer/emission_models/transformers/transformer.py
@@ -141,10 +141,21 @@ class Transformer(ABC):
         ]
         if len(missing_params) > 0:
             missing_strs = [f"'{s}'" for s in missing_params]
+
+            # Report everywhere we actually looked, including the fallback
+            # object if one was given
+            searched = [
+                "the EmissionModel",
+                "emission (Sed/LineCollection)",
+                "emitter (Stars/BlackHoles/Galaxy)",
+            ]
+            if obj is not None:
+                searched.append(f"the {obj.__class__.__name__} itself")
+            searched_str = f"{', '.join(searched[:-1])}, or {searched[-1]}"
+
             raise exceptions.MissingAttribute(
-                f"{', '.join(missing_strs)} can't be "
-                "found on the EmissionModel, emission (Sed/LineCollection), "
-                f"or emitter (Stars/BlackHoles/Galaxy) "
+                f"{', '.join(missing_strs)} can't be found on "
+                f"{searched_str} "
                 f"(required by {self.__class__.__name__})"
             )
 

--- a/src/synthesizer/emission_models/transformers/transformer.py
+++ b/src/synthesizer/emission_models/transformers/transformer.py
@@ -90,7 +90,14 @@ class Transformer(ABC):
         """
         pass
 
-    def _extract_params(self, model, emission, emitter, preserve_units=False):
+    def _extract_params(
+        self,
+        model,
+        emission,
+        emitter,
+        obj=None,
+        preserve_units=False,
+    ):
         """Extract the required parameters for the transformation.
 
         This method should look for the required parameters in
@@ -105,6 +112,11 @@ class Transformer(ABC):
                 The emission to transform.
             emitter (Stars/Gas/BlackHole/Galaxy):
                 The object emitting the emission.
+            obj (object, optional):
+                An optional object to look for the parameters on last, after
+                the model, emission and emitter. Transformers which hold their
+                own parameter values should pass themselves here so those
+                values act as the final fallback.
             preserve_units (bool, optional):
                 If True, preserve units on extracted parameter values.
                 Defaults to False.
@@ -119,6 +131,7 @@ class Transformer(ABC):
             model,
             emission,
             emitter,
+            obj=obj,
             preserve_units=preserve_units,
         )
 

--- a/src/synthesizer/emission_models/utils.py
+++ b/src/synthesizer/emission_models/utils.py
@@ -355,13 +355,21 @@ def get_param(
 
     # Otherwise raise an exception
     else:
-        raise exceptions.MissingAttribute(
-            f"{param} can't be found on the model "
+        # Report everywhere we looked, including the fallback object if one
+        # was given
+        searched = (
+            f"the model "
             f"({model.label if model is not None else None}),"
             " emission ("
             f"{emission.__class__.__name__ if emission is not None else None}"
             "), or emitter ("
-            f"{emitter.__class__.__name__ if emitter is not None else None})."
+            f"{emitter.__class__.__name__ if emitter is not None else None})"
+        )
+        if obj is not None:
+            searched = searched.replace(", or emitter (", ", emitter (")
+            searched += f", or {obj.__class__.__name__} itself"
+        raise exceptions.MissingAttribute(
+            f"{param} can't be found on {searched}."
         )
 
 

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -1,12 +1,18 @@
 """A test suite for the transformers module."""
 
 import numpy as np
+from unyt import K, angstrom
 
 from synthesizer.emission_models import (
+    AttenuatedEmission,
+    DustEmission,
     IntrinsicEmission,
     ReprocessedEmission,
+    StellarEmissionModel,
     TransmittedEmission,
 )
+from synthesizer.emission_models.attenuation import Calzetti2000, PowerLaw
+from synthesizer.emission_models.generators.dust.greybody import Greybody
 
 
 def test_fesc_model_level(
@@ -101,3 +107,169 @@ def test_fesc_override(
             f"[{model.__class__.__name__}]: The spectra "
             "are the same with different fesc values"
         )
+
+
+def _attenuated_lnu(stars, test_grid, dust_curve, **model_params):
+    """Return the attenuated spectrum for a dust curve and model parameters.
+
+    Args:
+        stars (Stars): The emitter to generate the spectra with.
+        test_grid (Grid): The grid to extract the incident emission from.
+        dust_curve (AttenuationLaw): The dust curve to attenuate with.
+        **model_params (dict): Parameters to set on the EmissionModel itself.
+
+    Returns:
+        unyt_array: The attenuated luminosity.
+    """
+    incident = StellarEmissionModel(
+        label="incident",
+        grid=test_grid,
+        extract="incident",
+    )
+    attenuated = AttenuatedEmission(
+        label="attenuated",
+        dust_curve=dust_curve,
+        apply_to=incident,
+        tau_v=0.5,
+        emitter="stellar",
+        **model_params,
+    )
+    stars.clear_all_emissions()
+    return stars.get_spectra(attenuated).lnu
+
+
+def test_transformer_param_on_model_overrides_curve(
+    test_grid,
+    random_part_stars,
+):
+    """Test a parameter set on the model overrides the dust curve value."""
+    # The curve value should be used when the model says nothing about it
+    default = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        PowerLaw(slope=-1.0),
+    )
+    explicit = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        PowerLaw(slope=-0.5),
+    )
+    assert not np.allclose(default.value, explicit.value), (
+        "Changing the curve slope should change the attenuation"
+    )
+
+    # And a value set on the model should win over the curve value
+    overridden = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        PowerLaw(slope=-1.0),
+        slope=-0.5,
+    )
+    assert np.allclose(overridden.value, explicit.value), (
+        "A slope set on the EmissionModel should override the curve value"
+    )
+
+
+def test_transformer_unit_param_on_model_overrides_curve(
+    test_grid,
+    random_part_stars,
+):
+    """Test unit carrying parameters can also be overridden on the model."""
+    # Calzetti2000 declares slope, cent_lam, ampl and gamma alongside tau_v,
+    # with cent_lam and gamma carrying units
+    default = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        Calzetti2000(ampl=1.0, cent_lam=2175 * angstrom),
+    )
+    explicit = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        Calzetti2000(ampl=1.0, cent_lam=2500 * angstrom),
+    )
+    assert not np.allclose(default.value, explicit.value), (
+        "Changing the curve cent_lam should change the attenuation"
+    )
+
+    overridden = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        Calzetti2000(ampl=1.0, cent_lam=2175 * angstrom),
+        cent_lam=2500 * angstrom,
+    )
+    assert np.allclose(overridden.value, explicit.value), (
+        "A cent_lam set on the EmissionModel should override the curve value"
+    )
+
+
+def test_transformer_string_param_is_still_an_alias(
+    test_grid,
+    random_part_stars,
+):
+    """Test a string parameter is looked up under the aliased name."""
+    # A string on the curve means "look this up under this name", so setting
+    # the aliased name on the model should behave like setting slope directly
+    explicit = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        PowerLaw(slope=-0.5),
+    )
+    aliased = _attenuated_lnu(
+        random_part_stars,
+        test_grid,
+        PowerLaw(slope="slope_young"),
+        slope_young=-0.5,
+    )
+    assert np.allclose(aliased.value, explicit.value), (
+        "An aliased slope should be looked up under the aliased name"
+    )
+
+
+def test_generator_param_on_model_overrides_generator(
+    test_grid,
+    random_part_stars,
+):
+    """Test a parameter on the model overrides a generator value.
+
+    This is the mirror of the transformer tests above, locking both sides of
+    the EmissionModel to the same rule.
+    """
+    incident = StellarEmissionModel(
+        label="incident",
+        grid=test_grid,
+        extract="incident",
+    )
+    attenuated = AttenuatedEmission(
+        label="attenuated",
+        dust_curve=PowerLaw(slope=-1.0),
+        apply_to=incident,
+        tau_v=0.5,
+        emitter="stellar",
+    )
+
+    def dust_lnu(curve_temperature, **model_params):
+        dust = DustEmission(
+            dust_emission_model=Greybody(
+                temperature=curve_temperature,
+                emissivity=1.5,
+            ),
+            emitter="stellar",
+            label="dust_emission",
+            dust_lum_intrinsic=incident,
+            dust_lum_attenuated=attenuated,
+            **model_params,
+        )
+        random_part_stars.clear_all_emissions()
+        return random_part_stars.get_spectra(dust).lnu
+
+    default = dust_lnu(30 * K)
+    explicit = dust_lnu(60 * K)
+    assert not np.allclose(default.value, explicit.value), (
+        "Changing the greybody temperature should change the emission"
+    )
+
+    overridden = dust_lnu(30 * K, temperature=60 * K)
+    assert np.allclose(overridden.value, explicit.value), (
+        "A temperature set on the EmissionModel should override the "
+        "generator value"
+    )


### PR DESCRIPTION
Transformers and generators disagreed about who wins when a parameter is set on both the `EmissionModel` and the object itself. Generators let the model win, as documented; attenuation laws silently ignored it, because `_check_required_params` stripped any concretely valued parameter out of `_required_params`, so `get_param`'s priority order never got a chance to run.

Unlike #1193 this did manifest in incorrectness: a model-level `slope`, `cent_lam`, `ampl` or `gamma` was accepted, stored in `fixed_parameters`, and then had no effect at all. Parameter variations over one of those expanded into correctly labelled variants that all computed identical physics.

Now every declared parameter stays required, and the constructor value acts as the last fallback via `obj=self`, exactly as generators already did. String aliases and the missing-parameter validation are unchanged, and the `None` sentinel is no longer needed to opt a parameter into being resolvable.

Closes #1195.

## Issue Type
<!-- delete options below as required -->
- Bug
- Document
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Attenuation settings now use values from the attached emission model or emitter when available, overriding default curve settings.
  - Concrete attenuation parameters remain available as fallbacks when no matching model or emitter value is provided.
  - Parameters set to `None` still require an explicit override.
  - Unit-bearing values and string aliases continue to work correctly when supplied by the emission model.

- **Documentation**
  - Updated attenuation documentation to explain parameter precedence and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->