### PR TITLE
Fixing PacmanEmission `dust_curve` propagation when escape fraction is also passed

### DIFF
--- a/src/synthesizer/emission_models/stellar/pacman_model.py
+++ b/src/synthesizer/emission_models/stellar/pacman_model.py
@@ -324,6 +324,7 @@ class PacmanEmissionWithEscapedNoDust(StellarEmissionModel):
         self,
         grid,
         tau_v="tau_v",
+        dust_curve=PowerLaw(),
         fesc="fesc",
         fesc_ly_alpha="fesc_ly_alpha",
         label=None,
@@ -336,6 +337,9 @@ class PacmanEmissionWithEscapedNoDust(StellarEmissionModel):
                 The grid object.
             tau_v (float):
                 The V-band optical depth.
+            dust_curve (synthesizer.emission_models.Transformer):
+                The assumed dust curve. Defaults to `PowerLaw`, with
+                default parameters.
             fesc (float):
                 The escape fraction.
             fesc_ly_alpha (float):
@@ -405,7 +409,7 @@ class PacmanEmissionWithEscapedNoDust(StellarEmissionModel):
         )
         attenuated = AttenuatedEmission(
             label="attenuated",
-            dust_curve=PowerLaw(),
+            dust_curve=dust_curve,
             apply_to=reprocessed,
             emitter="stellar",
             tau_v=tau_v,
@@ -679,6 +683,7 @@ class PacmanEmission:
                 return PacmanEmissionWithEscapedNoDust(
                     grid=grid,
                     tau_v=tau_v,
+                    dust_curve=dust_curve,
                     fesc=fesc,
                     fesc_ly_alpha=fesc_ly_alpha,
                     label=label,

--- a/src/synthesizer/emission_models/stellar/pacman_model.py
+++ b/src/synthesizer/emission_models/stellar/pacman_model.py
@@ -324,10 +324,10 @@ class PacmanEmissionWithEscapedNoDust(StellarEmissionModel):
         self,
         grid,
         tau_v="tau_v",
-        dust_curve=PowerLaw(),
         fesc="fesc",
         fesc_ly_alpha="fesc_ly_alpha",
         label=None,
+        dust_curve=PowerLaw(),
         **kwargs,
     ):
         """Initialize the PacmanEmissionWithEscapeNoDust model.
@@ -337,9 +337,6 @@ class PacmanEmissionWithEscapedNoDust(StellarEmissionModel):
                 The grid object.
             tau_v (float):
                 The V-band optical depth.
-            dust_curve (synthesizer.emission_models.Transformer):
-                The assumed dust curve. Defaults to `PowerLaw`, with
-                default parameters.
             fesc (float):
                 The escape fraction.
             fesc_ly_alpha (float):
@@ -347,6 +344,9 @@ class PacmanEmissionWithEscapedNoDust(StellarEmissionModel):
             label (str):
                 The label for the total emission model. If `None` this will
                 be set to "emergent".
+            dust_curve (synthesizer.emission_models.Transformer):
+                The assumed dust curve. Defaults to `PowerLaw`, with
+                default parameters.
             **kwargs:
                 Additional keyword arguments to pass to the models.
         """

--- a/tests/test_premade_emodels.py
+++ b/tests/test_premade_emodels.py
@@ -19,15 +19,25 @@ from synthesizer.emission_models.utils import get_param
 class TestPacmanEmission:
     """Test suite for PacmanEmission."""
 
-    def test_init(self, test_grid):
+    @pytest.mark.parametrize(
+        ("fesc", "with_dust_emission"),
+        ((0.0, False), (0.1, False), (0.0, True), (0.1, True)),
+    )
+    def test_init(self, test_grid, fesc, with_dust_emission):
         """Test the initialization of the PacmanEmission object."""
         # Define the emission model
         dust_curve = Calzetti2000()
+        dust_emission = (
+            Greybody(temperature=20 * K, emissivity=2)
+            if with_dust_emission
+            else None
+        )
         model = PacmanEmission(
             test_grid,
             tau_v=0.33,
             dust_curve=dust_curve,
-            fesc=0.1,
+            dust_emission=dust_emission,
+            fesc=fesc,
             fesc_ly_alpha=0.5,
         )
 

--- a/tests/test_premade_emodels.py
+++ b/tests/test_premade_emodels.py
@@ -22,15 +22,16 @@ class TestPacmanEmission:
     def test_init(self, test_grid):
         """Test the initialization of the PacmanEmission object."""
         # Define the emission model
+        dust_curve = Calzetti2000()
         model = PacmanEmission(
             test_grid,
             tau_v=0.33,
-            dust_curve=PowerLaw(slope=-1),
+            dust_curve=dust_curve,
             fesc=0.1,
             fesc_ly_alpha=0.5,
         )
 
-        assert model["attenuated"].dust_curve.slope == -1
+        assert model["attenuated"].dust_curve is dust_curve
         assert model["attenuated"].fixed_parameters["tau_v"] == 0.33
 
     def test_missing_optical_depth(self, test_grid, random_part_stars):


### PR DESCRIPTION
Closes #1194 by forwarding the user-provided `dust_curve` through `PacmanEmission` when an escape fraction is set without a dust emission model, instead of silently using the default PowerLaw. 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Pacman emission model parameter handling so positional escape-fraction values continue to be interpreted correctly.
  - Preserved the default power-law dust attenuation behavior.
  - Improved coverage for combinations of escape fractions and dust emission settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->